### PR TITLE
W2-1: fix inverted _calculate_confidence formula (closes W1-4-CARRY-1)

### DIFF
--- a/.dfg/agents/W2-1-belief-coefficient-formula-fix.md
+++ b/.dfg/agents/W2-1-belief-coefficient-formula-fix.md
@@ -1,0 +1,48 @@
+---
+id: W2-1
+role: bug-fixer
+name: Fix inverted _calculate_confidence formula; un-skip test
+purpose: "1-line fix at belief_coefficient.py:142 + un-skip test_calculate_confidence. Closes W1-4-CARRY-1."
+wave: W2
+unit: W2-1
+depends_on: []
+blocks: []
+governance_tier: VT2
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/algorithms/belief_coefficient.py  # line 142 — inverted formula
+    - python_refactor/tests/test_belief_coefficient.py  # the test currently skipped with W1-4-CARRY-1 marker
+output_contract:
+  files:
+    - python_refactor/src/algorithms/belief_coefficient.py
+    - python_refactor/tests/test_belief_coefficient.py
+  branch_name: feat/w2-1-belief-formula-fix
+  acceptance: >
+    Line 142 of belief_coefficient.py reads `tip_confidence = abs(tip - 0.5) * 2`
+    (removes the inverting `1.0 -` prefix). The docstring intent
+    ("higher when TIP is closer to 0 or 1") now matches the formula.
+    test_calculate_confidence is un-skipped (decorator removed,
+    W1-4-CARRY-1 marker comment removed). All 12 existing belief
+    tests + 2 W1-4 tests + the un-skipped test PASS (88 → 91 in
+    `.venv-w1`).
+dispatch_instructions: |
+  Two edits, both small:
+  1. belief_coefficient.py:142 — change
+     `tip_confidence = 1.0 - abs(tip - 0.5) * 2`
+     to
+     `tip_confidence = abs(tip - 0.5) * 2`
+  2. test_belief_coefficient.py — remove the @unittest.skip decorator
+     + the W1-4-CARRY-1 comment block.
+
+  Run pytest on test_belief_coefficient.py + a sample of dependent
+  tests to confirm 91/91 PASS.
+---
+
+# W2-1 — Fix inverted _calculate_confidence formula
+
+Closes W1-4-CARRY-1. The formula was always wrong; the test that
+caught it was always right; no-one knew because the test never ran
+until W1-4 fixed the test file's imports.

--- a/.dfg/retrospectives/W2/W2-1.md
+++ b/.dfg/retrospectives/W2/W2-1.md
@@ -1,0 +1,34 @@
+---
+unit: W2-1
+wave: W2
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  1-line bug fix, 1-decorator removal. 20/20 belief tests pass in
+  `.venv-w1`. Closes W1-4-CARRY-1 cleanly.
+what_didnt: |
+  None at this unit's level.
+what_to_change: |
+  Nothing additional; the W1-4 retro's "queue this as follow-up"
+  worked as designed.
+new_carries: |
+  None.
+scars_carried_forward: |
+  All other W1 carries unchanged; W2-2 and W2-4 close W1-3-CARRY-1/2 +
+  the packaging gap next.
+---
+
+# W2-1 — Fix inverted _calculate_confidence formula
+
+Closes W1-4-CARRY-1.
+
+## What changed
+
+- `belief_coefficient.py:142` — removed inverting `1.0 -` prefix; formula
+  now matches docstring intent ("higher when TIP is closer to 0 or 1").
+- `test_belief_coefficient.py` — removed `@unittest.skip` + the W1-4-CARRY-1
+  marker block. `test_calculate_confidence` now runs and passes.
+
+## Verification
+
+- 20/20 tests pass in `.venv-w1` (including the previously-skipped one).

--- a/python_refactor/src/algorithms/belief_coefficient.py
+++ b/python_refactor/src/algorithms/belief_coefficient.py
@@ -138,8 +138,12 @@ class BeliefCoefficientCalculator:
         # 1. TIP is closer to 0 or 1 (less uncertainty)
         # 2. Entropy is lower (less uncertainty)
         
-        # TIP-based confidence: higher when TIP is closer to 0 or 1
-        tip_confidence = 1.0 - abs(tip - 0.5) * 2
+        # TIP-based confidence: higher when TIP is closer to 0 or 1.
+        # W2-1 fix: was `1.0 - abs(tip - 0.5) * 2` which is INVERTED
+        # vs the docstring (returned 1.0 at tip=0.5, 0.0 at tip=0/1 —
+        # the opposite of the intent). Surfaced by test_calculate_confidence
+        # once W1-4 fixed the test file's imports. Closes W1-4-CARRY-1.
+        tip_confidence = abs(tip - 0.5) * 2
         
         # Entropy-based confidence: higher when entropy is lower
         entropy_confidence = 1.0 - entropy

--- a/python_refactor/tests/test_belief_coefficient.py
+++ b/python_refactor/tests/test_belief_coefficient.py
@@ -82,18 +82,6 @@ class TestBeliefCoefficientCalculator(unittest.TestCase):
         self.assertAlmostEqual(entropy_negative, 0.0, places=5)
         self.assertAlmostEqual(entropy_above_1, 0.0, places=5)
         
-    @unittest.skip(
-        "W1-4-CARRY: Pre-existing bug surfaced when this file's imports "
-        "started collecting cleanly. _calculate_confidence at "
-        "belief_coefficient.py:142 has `1.0 - abs(tip - 0.5) * 2` — the "
-        "leading `1.0 -` inverts the intent (the docstring says "
-        "'higher when TIP is closer to 0 or 1' but the formula returns "
-        "1.0 at tip=0.5 and 0.0 at tip=0/1). The test's assertions are "
-        "CORRECT; the implementation is wrong. Fix is one line in "
-        "belief_coefficient.py:142, scoped as a follow-up unit "
-        "(belief_coefficient.py is NOT in W1-4's output_contract per "
-        "directive #1)."
-    )
     def test_calculate_confidence(self):
         """Test confidence calculation."""
         # Test with TIP = 0.5 (maximum uncertainty)


### PR DESCRIPTION
1-line fix at `belief_coefficient.py:142`: removes inverting `1.0 -` prefix so formula matches docstring intent. Un-skips `test_calculate_confidence`. **20/20** belief tests pass in `.venv-w1`.