### PR TITLE
W2-2: import-style sweep (closes W1-3-CARRY-1/2; tests collected jump 50→156)

### DIFF
--- a/.dfg/agents/W2-2-import-style-sweep.md
+++ b/.dfg/agents/W2-2-import-style-sweep.md
@@ -1,0 +1,53 @@
+---
+id: W2-2
+role: bug-fixer
+name: Test-file + thesis_aligned_experiment import-style sweep
+purpose: "Fix 5 test files + 1 source file using broken `from algorithms.X` style. Closes W1-3-CARRY-1/2."
+wave: W2
+unit: W2-2
+depends_on: []
+blocks: []
+governance_tier: VT2
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/tests/test_multi_horizon_anticipatory.py
+    - python_refactor/tests/test_enhanced_n_step_prediction.py
+    - python_refactor/tests/test_correspondence_integration.py
+    - python_refactor/tests/test_sliding_window_dirichlet.py
+    - python_refactor/tests/test_correspondence_mapping.py
+    - python_refactor/src/experiments/thesis_aligned_experiment.py
+output_contract:
+  files:
+    - python_refactor/tests/test_multi_horizon_anticipatory.py
+    - python_refactor/tests/test_enhanced_n_step_prediction.py
+    - python_refactor/tests/test_correspondence_integration.py
+    - python_refactor/tests/test_sliding_window_dirichlet.py
+    - python_refactor/tests/test_correspondence_mapping.py
+    - python_refactor/src/experiments/thesis_aligned_experiment.py
+  branch_name: feat/w2-2-import-style-sweep
+  acceptance: >
+    Every test file uses `from src.algorithms.X` (W1-2/W1-3/W1-4 pattern);
+    thesis_aligned_experiment.py uses `from ..algorithms.X` (relative
+    within src/experiments/). `grep "from algorithms\\." python_refactor/`
+    returns 0 hits in any *.py file after the unit. All previously-
+    collecting tests continue to pass; previously-broken collect-error
+    tests either collect cleanly OR surface a different pre-existing
+    issue (documented as inherited carry).
+dispatch_instructions: |
+  Mechanical sweep. For each file:
+   - tests/*.py: `from algorithms.X` → `from src.algorithms.X`;
+     drop the `sys.path.insert(...)` shim if present.
+   - src/experiments/thesis_aligned_experiment.py: `from algorithms.X`
+     → `from ..algorithms.X` (matches the relative-import convention
+     used elsewhere in src/).
+  Verify in `.venv-w1` with PYTHONPATH=. that all 6 files at least
+  COLLECT cleanly; surface any newly-visible per-test failures as
+  inherited carries (those are W2-2's surface, not regressions).
+---
+
+# W2-2 — Test-file + thesis_aligned_experiment import-style sweep
+
+Closes W1-3-CARRY-1 (5 test files) + W1-3-CARRY-2 (thesis_aligned_experiment).

--- a/.dfg/retrospectives/W2/W2-2.md
+++ b/.dfg/retrospectives/W2/W2-2.md
@@ -1,0 +1,67 @@
+---
+unit: W2-2
+wave: W2
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Mechanical sweep across 6 files closed all remaining
+  `from algorithms.X` imports. Test collection in `.venv-w1` jumped
+  from ~50 to **156 tests collected** across 10 test files. 153 pass.
+  Massive surface gain for low effort.
+what_didnt: |
+  3 newly-visible test FAILURES surfaced (NOT introduced by W2-2):
+    1. test_multi_horizon_anticipatory::test_calculate_multi_horizon_lambda_rates
+       (AssertionError: 1 != 0 — likely off-by-one in horizon iteration)
+    2. test_enhanced_n_step_prediction::test_enhanced_prediction_bounds_validation
+       (ValueError: No prediction available for horizon 2 — setup issue)
+    3. test_correspondence_integration::test_correspondence_with_anticipatory_learning
+       (AssertionError: -0.068 not >= 0.0 — negative value where positive expected)
+  All three are the same dead-code-coming-alive pattern that W1-3
+  surfaced (SlidingWindowDirichlet kwarg) and W1-4 surfaced
+  (belief_coefficient formula). The tests were always there; nobody
+  knew they were broken because the imports never resolved. Now they
+  do, and 3 bugs ring out clearly.
+
+  Per W2-2 contract: "previously-broken collect-error tests either
+  collect cleanly OR surface a different pre-existing issue
+  (documented as inherited carry)." Honest scars below.
+what_to_change: |
+  Queue 3 small follow-up units (or one combined housekeeping unit)
+  to triage each of the 3 newly-visible failures. Each is likely
+  ≤ 5 lines of fix (or test adjustment) once root-caused.
+new_carries: |
+  - W2-2-CARRY-1: test_multi_horizon_anticipatory::test_calculate_multi_horizon_lambda_rates
+    — assertion `1 != 0`. Probably an off-by-one in the lambda-rates
+    list length (H=2 should give 1 rate, code probably gives 0).
+  - W2-2-CARRY-2: test_enhanced_n_step_prediction::test_enhanced_prediction_bounds_validation
+    — "No prediction available for horizon 2". EnhancedNStepPredictor
+    likely needs setup that the test doesn't provide.
+  - W2-2-CARRY-3: test_correspondence_integration::test_correspondence_with_anticipatory_learning
+    — negative value where positive expected. Likely a similarity-
+    metric sign-flip or off-by-one.
+scars_carried_forward: |
+  W1-1-CARRY-2 (pre-pr contract-first SKIP on master) recurred for
+  the 6th time. Per directive #5 unchanged: upstream-feedback only,
+  not modifying dfg-harness, not writing another canon entry.
+
+  W1-3-CARRY-3 (MultiHorizon's inherited learn_population uses
+  parent's single-horizon path) unchanged.
+
+  W1-4-CARRY-2 (TIP _calculate_tip_simple magic numbers) unchanged.
+---
+
+# W2-2 — Test-file + thesis_aligned_experiment import-style sweep
+
+Closes W1-3-CARRY-1 (5 test files) + W1-3-CARRY-2 (thesis_aligned_experiment).
+
+## Net effect
+
+| Before W2-2 | After W2-2 |
+|---|---|
+| ~50 tests collected in .venv-w1 | **156** tests collected |
+| Unknown number of latent failures hidden by ImportError | **3 newly-visible failures** (W2-2-CARRY-1/2/3) |
+| `from algorithms.X` lines in src/ + tests/ | 0 lines (only tombstone comments remain) |
+
+The 3 newly-visible failures are pre-existing bugs — same dead-code-
+coming-alive pattern as W1-3 / W1-4. Documented as carries; each
+≤ 5-line fix when triaged.

--- a/python_refactor/src/experiments/thesis_aligned_experiment.py
+++ b/python_refactor/src/experiments/thesis_aligned_experiment.py
@@ -11,10 +11,15 @@ from typing import Dict, Any, List, Tuple
 import logging
 from datetime import datetime
 
-from config.experiment_config import get_experiment_config, ExperimentConfig
-from algorithms.sms_emoa import SMSEMOA
-from algorithms.anticipatory_learning import TIPIntegratedAnticipatoryLearning
-from algorithms.correspondence_mapping import CorrespondenceMapping
+# W2-2: relative imports (was `from algorithms.X import Y` which only
+# worked under a `sys.path.insert(..., src)` hack and was one of the
+# pre-W1-3 collection errors). thesis_aligned_experiment lives in
+# src/experiments/, so the parent-package relative `..algorithms` /
+# `..config` resolves correctly when imported as part of `src`.
+from ..config.experiment_config import get_experiment_config, ExperimentConfig
+from ..algorithms.sms_emoa import SMSEMOA
+from ..algorithms.anticipatory_learning import TIPIntegratedAnticipatoryLearning
+from ..algorithms.correspondence_mapping import CorrespondenceMapping
 
 logger = logging.getLogger(__name__)
 

--- a/python_refactor/tests/test_correspondence_integration.py
+++ b/python_refactor/tests/test_correspondence_integration.py
@@ -7,13 +7,9 @@ learning algorithm.
 
 import unittest
 import numpy as np
-import sys
-import os
 
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from algorithms.anticipatory_learning import TIPIntegratedAnticipatoryLearning
+# W2-2 import-style fix: use canonical `from src.algorithms.X` (W1-2/W1-3/W1-4 pattern).
+from src.algorithms.anticipatory_learning import TIPIntegratedAnticipatoryLearning
 
 
 class TestCorrespondenceIntegration(unittest.TestCase):

--- a/python_refactor/tests/test_correspondence_mapping.py
+++ b/python_refactor/tests/test_correspondence_mapping.py
@@ -7,13 +7,9 @@ solutions across time periods.
 
 import unittest
 import numpy as np
-import sys
-import os
 
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from algorithms.correspondence_mapping import CorrespondenceMapping
+# W2-2 import-style fix: use canonical `from src.algorithms.X` (W1-2/W1-3/W1-4 pattern).
+from src.algorithms.correspondence_mapping import CorrespondenceMapping
 
 
 class TestCorrespondenceMapping(unittest.TestCase):

--- a/python_refactor/tests/test_enhanced_n_step_prediction.py
+++ b/python_refactor/tests/test_enhanced_n_step_prediction.py
@@ -7,13 +7,9 @@ belief coefficient usage, and conditional expected hypervolume calculation.
 
 import unittest
 import numpy as np
-import sys
-import os
 
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from algorithms.enhanced_n_step_prediction import (
+# W2-2 import-style fix: use canonical `from src.algorithms.X` (W1-2/W1-3/W1-4 pattern).
+from src.algorithms.enhanced_n_step_prediction import (
     EnhancedNStepPredictor, EnhancedPredictionResult,
     create_enhanced_n_step_predictor
 )

--- a/python_refactor/tests/test_multi_horizon_anticipatory.py
+++ b/python_refactor/tests/test_multi_horizon_anticipatory.py
@@ -7,13 +7,9 @@ Equation 6.10 and multi-horizon prediction capabilities.
 
 import unittest
 import numpy as np
-import sys
-import os
 
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from algorithms.multi_horizon_anticipatory import (
+# W2-2 import-style fix: use canonical `from src.algorithms.X` (W1-2/W1-3/W1-4 pattern).
+from src.algorithms.multi_horizon_anticipatory import (
     MultiHorizonAnticipatoryLearning, MultiHorizonPrediction,
     create_multi_horizon_anticipatory_learning
 )

--- a/python_refactor/tests/test_sliding_window_dirichlet.py
+++ b/python_refactor/tests/test_sliding_window_dirichlet.py
@@ -6,13 +6,9 @@ Tests the implementation of Equations 6.24-6.27 and related functionality.
 
 import unittest
 import numpy as np
-import sys
-import os
 
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from algorithms.sliding_window_dirichlet import SlidingWindowDirichlet
+# W2-2 import-style fix: use canonical `from src.algorithms.X` (W1-2/W1-3/W1-4 pattern).
+from src.algorithms.sliding_window_dirichlet import SlidingWindowDirichlet
 
 
 class TestSlidingWindowDirichlet(unittest.TestCase):


### PR DESCRIPTION
Mechanical sweep of 5 test files + thesis_aligned_experiment.py from broken `from algorithms.X` style to canonical `from src.algorithms.X` (or `from ..algorithms.X` for in-src).

**Result in `.venv-w1`:** test collection jumps from ~50 to **156 tests** (153 PASS / 3 newly-visible pre-existing failures documented as W2-2-CARRY-1/2/3, same dead-code-coming-alive pattern as W1-3/W1-4).