### PR TITLE
W2-4: pyproject.toml + ruff fix on 3 legacy files (closes packaging gap)

### DIFF
--- a/.dfg/agents/W2-4-packaging-and-ruff.md
+++ b/.dfg/agents/W2-4-packaging-and-ruff.md
@@ -1,0 +1,56 @@
+---
+id: W2-4
+role: tooling-author
+name: pyproject.toml + ruff fix on 3 legacy files
+purpose: "Add packaging substrate (pyproject.toml) + close 11 F401 ruff errors in 3 legacy files. Closes packaging gap."
+wave: W2
+unit: W2-4
+depends_on: []
+blocks: []
+governance_tier: VT2
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/requirements.txt  # 5 runtime + 2 dev deps to lift into pyproject
+    - python_refactor/data_analysis.py  # legacy F401 errors
+    - python_refactor/ftse_data_downloader.py
+    - python_refactor/ftse_data_downloader_v2.py
+output_contract:
+  files:
+    - pyproject.toml
+    - python_refactor/data_analysis.py
+    - python_refactor/ftse_data_downloader.py
+    - python_refactor/ftse_data_downloader_v2.py
+  branch_name: feat/w2-4-packaging-and-ruff
+  acceptance: >
+    pyproject.toml at repo root declares the project metadata
+    (name=learning-to-anticipate-flexible-choices, dynamic-version
+    OK, runtime deps from requirements.txt). Ruff F401 count drops
+    by 11 across the 3 legacy files (verified via
+    `ruff check --select F401 python_refactor/data_analysis.py
+    python_refactor/ftse_data_downloader*.py` returning 0 errors).
+    No file outside output_contract is touched.
+dispatch_instructions: |
+  1. Author pyproject.toml at repo root with PEP 621 metadata:
+     - name = "learning-to-anticipate-flexible-choices"
+     - version = "0.1.0"
+     - description = "Python implementation of Azevedo & Von Zuben (2015) anticipatory MCDM"
+     - readme = "README.md"
+     - requires-python = ">=3.10"
+     - dependencies from requirements.txt (numpy, pandas, scipy, matplotlib, scikit-learn)
+     - optional-dependencies.dev = pytest + pytest-cov + ruff
+     - tool.ruff.lint section with sensible defaults
+     - Reference docs/paper.pdf in URLs section
+  2. Apply `ruff check --select F401 --fix python_refactor/data_analysis.py python_refactor/ftse_data_downloader*.py` to close F401 errors in scope.
+  3. Verify scope: only the 3 legacy files + pyproject.toml are modified.
+---
+
+# W2-4 — pyproject.toml + ruff fix on 3 legacy files
+
+Adds the packaging substrate the audit flagged as missing + closes
+the 11 F401 errors in legacy files (data_analysis, ftse_data_downloader
+v1+v2). File-disjoint from W2-1 / W2-2 / W2-3.
+
+Does NOT add uv.lock — locked installs are a separate concern.

--- a/.dfg/retrospectives/W2/W2-4.md
+++ b/.dfg/retrospectives/W2/W2-4.md
@@ -1,0 +1,54 @@
+---
+unit: W2-4
+wave: W2
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  pyproject.toml landed in one file with PEP 621 metadata + ruff
+  config + pytest config. Runtime deps lifted directly from
+  requirements.txt (no version drift). `ruff check --select F401
+  --fix` closed all 11 F401 errors in the 3 legacy files in one
+  command — left those files with cleaner imports and the ruff F401
+  surface trimmed accordingly.
+what_didnt: |
+  pre-pr's ruff still reports ~144 F401 errors across src/ files —
+  W2-4 deliberately scoped to the 3 legacy files only (file-disjoint
+  from W2-1/W2-2/W2-3). The remaining 144 are pre-existing in src/
+  files and require a wider sweep that's NOT in W2 scope. Queued
+  for a future cleanup unit.
+
+  No uv.lock added. The contract explicitly deferred locked installs
+  to a separate concern. `pip install -e .` works today but isn't
+  reproducible across environments without a lockfile.
+what_to_change: |
+  Future "ruff cleanup wide" unit can do `ruff check --fix python_refactor/`
+  in one command. Or add ruff to make ci so each subsequent unit
+  is forced to keep its own files clean.
+
+  Future "lockfile add" unit: `uv lock` + commit. ~5 lines.
+new_carries: |
+  - W2-4-CARRY-1: ~144 F401 errors remain in src/ files (out of W2-4
+    scope). Wider ruff sweep unit queued.
+  - W2-4-CARRY-2: no uv.lock yet (out of W2-4 scope per contract).
+    Lockfile unit queued.
+scars_carried_forward: |
+  All prior W2 carries unchanged at this unit's level.
+---
+
+# W2-4 — pyproject.toml + ruff fix on 3 legacy files
+
+Closes the packaging gap; partial close of the broader ruff F401 surface.
+
+## What changed
+
+| File | Change |
+|---|---|
+| `pyproject.toml` (NEW) | PEP 621 metadata, runtime deps from requirements.txt, dev deps (pytest, ruff), ruff lint config, pytest config |
+| `python_refactor/data_analysis.py` | ruff F401 fixes (auto) |
+| `python_refactor/ftse_data_downloader.py` | ruff F401 fixes (auto) |
+| `python_refactor/ftse_data_downloader_v2.py` | ruff F401 fixes (auto) |
+
+## Verification
+
+- `ruff check --select F401` on the 3 legacy files: 0 errors (was 11).
+- Substrate gates: validate / index --verify / substrate check / make ci OK.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,84 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "learning-to-anticipate-flexible-choices"
+version = "0.1.0"
+description = "Python implementation of Azevedo & Von Zuben (2015) — Anticipatory MCDM under Uncertainty (IEEE TCYB)."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Carlos R. B. Azevedo", email = "renatoaz@gmail.com" },
+]
+keywords = [
+    "anticipatory-learning",
+    "multi-objective-optimization",
+    "kalman-filter",
+    "dirichlet-dynamical",
+    "portfolio-optimization",
+    "mcdm",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Mathematics",
+]
+
+# Runtime dependencies lifted from python_refactor/requirements.txt
+# (numpy/pandas/scipy/matplotlib/scikit-learn). Versions match the
+# constraints there; W2-4 doesn't introduce uv.lock — locked installs
+# are a separate concern.
+dependencies = [
+    "numpy>=1.21.0",
+    "pandas>=1.3.0",
+    "scipy>=1.7.0",
+    "matplotlib>=3.4.0",
+    "scikit-learn>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6.0.0",
+    "pytest-cov>=2.12.0",
+    "ruff>=0.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/crbazevedo/learning-to-anticipate-flexible-choices"
+Paper = "https://doi.org/10.1109/TCYB.2015.2415732"
+
+[tool.hatch.build.targets.wheel]
+# The Python sources live at python_refactor/src/. Future units will
+# consolidate this layout; W2-4 ships the minimal pyproject without
+# rearranging the tree.
+packages = ["python_refactor/src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+extend-exclude = [
+    "legacy-cpp",  # frozen C++ tree; not Python
+]
+
+[tool.ruff.lint]
+# Default ruleset + explicit F401 (unused imports) since pre-W2-4
+# legacy files carried 11 F401 errors closed in this unit.
+select = ["F", "E", "W", "I"]
+ignore = [
+    "E501",  # line-too-long: legacy files have long lines; future
+              # cleanup unit can re-enable.
+]
+
+[tool.pytest.ini_options]
+testpaths = ["python_refactor/tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/python_refactor/data_analysis.py
+++ b/python_refactor/data_analysis.py
@@ -8,13 +8,10 @@ downloading updated data.
 """
 
 import pandas as pd
-import numpy as np
 import os
 import glob
 from datetime import datetime
-import matplotlib.pyplot as plt
-import seaborn as sns
-from typing import Dict, List, Tuple
+from typing import Dict, List
 import warnings
 warnings.filterwarnings('ignore')
 

--- a/python_refactor/ftse_data_downloader.py
+++ b/python_refactor/ftse_data_downloader.py
@@ -12,8 +12,8 @@ import pandas as pd
 import numpy as np
 import os
 import time
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from datetime import datetime
+from typing import Dict, Optional
 import warnings
 warnings.filterwarnings('ignore')
 

--- a/python_refactor/ftse_data_downloader_v2.py
+++ b/python_refactor/ftse_data_downloader_v2.py
@@ -12,9 +12,8 @@ This script provides multiple approaches to get FTSE data:
 import pandas as pd
 import numpy as np
 import os
-import time
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Dict
 import warnings
 warnings.filterwarnings('ignore')
 


### PR DESCRIPTION
Adds packaging substrate (pyproject.toml at repo root, PEP 621) + closes 11 F401 errors in 3 legacy files via `ruff check --fix`.

**Two new carries** (out of W2-4 scope per contract): W2-4-CARRY-1 (~144 remaining F401 in src/) + W2-4-CARRY-2 (no uv.lock yet). Both queued for future wider-sweep units.