### PR TITLE
W3-3: correspondence test non-determinism fix (closes W2-2-CARRY-3)

### DIFF
--- a/.dfg/agents/W3-3-correspondence-integration-bug.md
+++ b/.dfg/agents/W3-3-correspondence-integration-bug.md
@@ -1,0 +1,47 @@
+---
+id: W3-3
+role: bug-fixer
+name: Fix correspondence_with_anticipatory_learning test non-determinism
+purpose: "Closes W2-2-CARRY-3 from test side. Algorithm bug (anticipatory_learning.py:328 doesn't clamp negative rates) filed as W3-3-CARRY."
+wave: W3
+unit: W3-3
+depends_on: []
+blocks: ['W3-5']
+governance_tier: VT2
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/tests/test_correspondence_integration.py
+    - python_refactor/src/algorithms/correspondence_mapping.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/correspondence_mapping.py
+    - python_refactor/tests/test_correspondence_integration.py
+  branch_name: feat/w3-3-correspondence-integration-bug
+  acceptance: >
+    test_correspondence_with_anticipatory_learning PASSES deterministically
+    in .venv-w1. Test mock uses bounded prediction_error within
+    [min_error, max_error]. Real algorithm bug at anticipatory_learning.py
+    (negative rates when prediction_error > max_error; no output clamp on
+    _compute_traditional_learning_rate) documented as W3-3-CARRY for a
+    follow-up unit that touches anticipatory_learning.py.
+dispatch_instructions: |
+  Root cause: MockSolution's prediction_error = np.random.random() * 0.1
+  is in [0, 0.1] but test sets min_error=0.01, max_error=0.05. ~50% of
+  runs have prediction_error > max_error → accuracy_factor goes negative
+  → traditional_rate < 0 → combined_rate < 0 → assertion fails.
+
+  Real algorithm bug: `_compute_traditional_learning_rate` should clamp
+  its output to [rate_lwb=0, rate_upb=0.5] per the C++ comment intent
+  but doesn't. NOT FIXED in W3-3 (anticipatory_learning.py NOT in scope).
+
+  W3-3 fix: seed RNG + bound the mock's prediction_error explicitly.
+  Or simpler: set prediction_error = 0.03 (mid-bounds) deterministically.
+---
+
+# W3-3 — Fix correspondence_with_anticipatory_learning non-determinism
+
+Closes W2-2-CARRY-3 from the test side. Files an honest carry for the
+real algorithm bug.

--- a/.dfg/retrospectives/W3/W3-3.md
+++ b/.dfg/retrospectives/W3/W3-3.md
@@ -1,0 +1,38 @@
+---
+unit: W3-3
+wave: W3
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Triage trace was quick: MockSolution.prediction_error was random in
+  [0, 0.1] but test bounds were [0.01, 0.05]. ~50% of runs had
+  prediction_error > max_error → accuracy_factor negative → traditional_
+  rate negative → combined_rate negative → assertion failed.
+  Pinned to 0.03. 9/9 correspondence tests pass deterministically.
+what_didnt: |
+  The real bug is in anticipatory_learning.py:328 — _compute_traditional_
+  learning_rate doesn't clamp its output to [rate_lwb=0, rate_upb=0.5]
+  per the C++ comment intent. Test catches it; W3-3 scope excludes
+  anticipatory_learning.py so we work around in the test mock instead
+  of fixing the algorithm. Filed as W3-3-CARRY-1 for a 1-line clamp
+  fix in a follow-up unit.
+what_to_change: |
+  Schedule a follow-up unit (call it W4-N or W3-followup) that:
+    (a) adds an output clamp at anticipatory_learning.py:328 — the
+        rate should be `max(rate_lwb, min(rate_upb, anticipation_rate))`
+    (b) verifies the W3-3 mock can revert to random prediction_error
+        without test flakiness
+  ~5 minutes of work.
+new_carries: |
+  - W3-3-CARRY-1: _compute_traditional_learning_rate in
+    anticipatory_learning.py doesn't clamp its output to
+    [rate_lwb=0, rate_upb=0.5]. Negative rates possible when
+    prediction_error > max_error. Real algorithm bug; 1-line fix
+    queued for follow-up.
+scars_carried_forward: |
+  All other W3 carries unchanged at this unit's level.
+---
+
+# W3-3 — Fix correspondence test non-determinism
+
+Closes W2-2-CARRY-3 (test side); files W3-3-CARRY-1 (algorithm side).

--- a/python_refactor/tests/test_correspondence_integration.py
+++ b/python_refactor/tests/test_correspondence_integration.py
@@ -58,7 +58,14 @@ class TestCorrespondenceIntegration(unittest.TestCase):
                 self.rank_risk = 0
                 self.alpha = np.random.random()
                 self.anticipation = False
-                self.prediction_error = np.random.random() * 0.1
+                # W3-3: was `np.random.random() * 0.1` — random in [0, 0.1]
+                # which often exceeds the test's max_error=0.05, driving
+                # accuracy_factor negative in _compute_traditional_learning_rate
+                # → traditional_rate < 0 → test assertion fails ~50% of runs.
+                # Pinned to 0.03 (mid-bounds) for deterministic test inputs.
+                # The real algorithm bug (no output clamp on the rate) is
+                # filed as W3-3-CARRY for a follow-up unit.
+                self.prediction_error = 0.03
         
         return MockSolution(roi, risk, weights)
     


### PR DESCRIPTION
Test mock fix + W3-3-CARRY-1 filed for real algorithm bug in anticipatory_learning.py (not in W3-3 output_contract). 9/9 correspondence tests pass deterministically.