### PR TITLE
W3-4: TIP magic numbers to named constants (closes W1-4-CARRY-2)

### DIFF
--- a/.dfg/agents/W3-4-tip-magic-numbers.md
+++ b/.dfg/agents/W3-4-tip-magic-numbers.md
@@ -1,0 +1,46 @@
+---
+id: W3-4
+role: bug-fixer
+name: Replace TIP _calculate_tip_simple magic numbers with named constants
+purpose: "Closes W1-4-CARRY-2. Replaces inline 0.5 / 0.3 magic numbers with documented module-level constants flagged as heuristic placeholders."
+wave: W3
+unit: W3-4
+depends_on: []
+blocks: ['W3-5']
+governance_tier: VT2
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/algorithms/temporal_incomparability_probability.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/temporal_incomparability_probability.py
+    - python_refactor/tests/test_temporal_incomparability_probability.py
+  branch_name: feat/w3-4-tip-magic-numbers
+  acceptance: >
+    `_calculate_tip_simple` uses two named module-level constants
+    `_TIP_FALLBACK_MAX_ROI_DIFF` + `_TIP_FALLBACK_MAX_RISK_DIFF` (or
+    similar) instead of inline `0.5` and `0.3`. Constants are
+    documented with a comment naming them as HEURISTIC placeholders
+    (not paper-grounded). All existing 19 TIP tests + 7 W1-4 tests
+    continue to pass in .venv-w1.
+dispatch_instructions: |
+  1. Add module-level constants near the top of
+     temporal_incomparability_probability.py:
+       # W3-4 / W1-4-CARRY-2: heuristic placeholders for the simple-
+       # fallback TIP path (when KF covariance is unavailable). NOT
+       # paper-grounded; chosen to span the typical FTSE-100 range
+       # observed during development. Replace with empirically-fitted
+       # values when a real calibration unit lands.
+       _TIP_FALLBACK_MAX_ROI_DIFF: float = 0.5
+       _TIP_FALLBACK_MAX_RISK_DIFF: float = 0.3
+  2. In _calculate_tip_simple, replace the inline 0.5 and 0.3 with
+     the new constants.
+  3. No test additions required — the constants behave identically.
+---
+
+# W3-4 — TIP magic numbers → named constants
+
+Closes W1-4-CARRY-2.

--- a/.dfg/retrospectives/W3/W3-4.md
+++ b/.dfg/retrospectives/W3/W3-4.md
@@ -1,0 +1,25 @@
+---
+unit: W3-4
+wave: W3
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  2 magic numbers → 2 named module constants with a clear "heuristic
+  placeholder" comment. 23/23 TIP tests pass. test_temporal_
+  incomparability_probability.py was in W3-4 output_contract but
+  needed no changes (constants behave identically).
+what_didnt: |
+  None.
+what_to_change: |
+  When a real calibration unit eventually fits these constants
+  empirically (e.g. from the FTSE-updated dataset), the constants
+  already have clear names so the new values land in one place.
+new_carries: |
+  None.
+scars_carried_forward: |
+  All other W3 carries unchanged.
+---
+
+# W3-4 — TIP magic numbers → named constants
+
+Closes W1-4-CARRY-2.

--- a/python_refactor/src/algorithms/temporal_incomparability_probability.py
+++ b/python_refactor/src/algorithms/temporal_incomparability_probability.py
@@ -13,6 +13,16 @@ from typing import Tuple, Optional
 from scipy.stats import norm
 import logging
 
+# ---------------------------------------------------------------------------
+# W3-4 (closes W1-4-CARRY-2): heuristic placeholders for the
+# `_calculate_tip_simple` fallback path (used when KF covariance is
+# unavailable). These constants are NOT paper-grounded — they were chosen
+# during development to span the typical FTSE-100 ROI/risk range. Replace
+# with empirically-fitted values when a calibration unit lands.
+# ---------------------------------------------------------------------------
+_TIP_FALLBACK_MAX_ROI_DIFF: float = 0.5
+_TIP_FALLBACK_MAX_RISK_DIFF: float = 0.3
+
 logger = logging.getLogger(__name__)
 
 
@@ -200,12 +210,15 @@ class TemporalIncomparabilityCalculator:
             roi_distance = abs(current_roi - predicted_roi)
             risk_distance = abs(current_risk - predicted_risk)
             
-            # Normalize distances (assuming typical ranges)
-            max_roi_diff = 0.5  # Maximum expected ROI difference
-            max_risk_diff = 0.3  # Maximum expected risk difference
-            
-            normalized_roi_distance = min(roi_distance / max_roi_diff, 1.0)
-            normalized_risk_distance = min(risk_distance / max_risk_diff, 1.0)
+            # W3-4: named module constants (see top of file) replace the
+            # pre-W3-4 inline magic numbers. Flagged as heuristic
+            # placeholders; not paper-grounded.
+            normalized_roi_distance = min(
+                roi_distance / _TIP_FALLBACK_MAX_ROI_DIFF, 1.0,
+            )
+            normalized_risk_distance = min(
+                risk_distance / _TIP_FALLBACK_MAX_RISK_DIFF, 1.0,
+            )
             
             # TIP is higher when objectives are more similar (closer)
             tip = 0.5 * (1.0 - normalized_roi_distance + 1.0 - normalized_risk_distance)


### PR DESCRIPTION
Two magic numbers in _calculate_tip_simple promoted to named module constants with heuristic-placeholder comment. 23/23 TIP tests pass.