### PR TITLE
W4-1: clamp _compute_traditional_learning_rate (closes W3-3-CARRY-1)

### DIFF
--- a/.dfg/agents/W4-1-traditional-rate-output-clamp.md
+++ b/.dfg/agents/W4-1-traditional-rate-output-clamp.md
@@ -1,0 +1,47 @@
+---
+id: W4-1
+role: bug-fixer
+name: Clamp _compute_traditional_learning_rate output to [rate_lwb, rate_upb]
+purpose: "Closes W3-3-CARRY-1. 1-line clamp on the returned rate + revert W3-3's test-mock pinning."
+wave: W4
+unit: W4-1
+depends_on: []
+blocks: []
+governance_tier: VT2
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/algorithms/anticipatory_learning.py
+    - python_refactor/tests/test_correspondence_integration.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/anticipatory_learning.py
+    - python_refactor/tests/test_correspondence_integration.py
+  branch_name: feat/w4-1-traditional-rate-output-clamp
+  acceptance: >
+    _compute_traditional_learning_rate clamps the returned rate to
+    [rate_lwb=0, rate_upb=0.5] per the C++ comment intent. W3-3's
+    pinned test mock prediction_error reverted to random; test
+    PASSES under any random input because the clamp guarantees
+    valid rates.
+
+## What this contract does NOT authorise
+
+- Touching any file outside output_contract.
+- Adding new tests (the W3-3 test was the regression case; reverting
+  its pinning is the verification).
+
+dispatch_instructions: |
+  1. anticipatory_learning.py: in _compute_traditional_learning_rate,
+     change `return anticipation_rate` to
+     `return max(rate_lwb, min(rate_upb, anticipation_rate))`.
+  2. test_correspondence_integration.py: revert the W3-3 mock
+     prediction_error pin (back to `np.random.random() * 0.1`).
+  3. Run correspondence_integration tests in venv to confirm.
+---
+
+# W4-1 — clamp traditional rate
+
+Closes W3-3-CARRY-1.

--- a/.dfg/retrospectives/W4/W4-1.md
+++ b/.dfg/retrospectives/W4/W4-1.md
@@ -1,0 +1,37 @@
+---
+unit: W4-1
+wave: W4
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  1-line clamp at anticipatory_learning.py:330 closes W3-3-CARRY-1.
+  Reverted W3-3's test-mock pinning to random prediction_error; the
+  clamp guarantees rate in [0, 0.5] regardless of input. 122/122
+  tests pass in the curated W1-3 + W4 test set.
+what_didnt: |
+  Edit-race: the first clamp Edit reported "File has been modified
+  since read" (linter race after my initial Read). Re-read + re-Edit
+  succeeded. Worth noting that the harness's pre-commit linter can
+  race with Edit-tool atomicity; future units should Read immediately
+  before Edit if a linter is active.
+what_to_change: |
+  None at this unit's level.
+new_carries: |
+  None.
+scars_carried_forward: |
+  W3-5-CARRY-1 (test pollution) deferred to W5 — not touched in W4.
+  W1-3-CARRY-3 is W4-2's scope.
+---
+
+# W4-1 — clamp traditional learning rate
+
+Closes W3-3-CARRY-1.
+
+## What changed
+
+- `anticipatory_learning.py:330`: `return max(rate_lwb, min(rate_upb, anticipation_rate))` (was `return anticipation_rate`)
+- `test_correspondence_integration.py`: revert pinned `prediction_error=0.03` back to random `np.random.random() * 0.1`
+
+## Verification
+
+- 122/122 PASS across the curated W1-3 test set (was 121/122 before W4-1 because the W3-3 mock revert needed the W4-1 clamp to be safe; both edits required together).

--- a/python_refactor/src/algorithms/anticipatory_learning.py
+++ b/python_refactor/src/algorithms/anticipatory_learning.py
@@ -323,11 +323,14 @@ class AnticipatoryLearning:
             rate_lwb = 0.0
         
         # Anticipatory learning rate formula (exact C++ implementation)
-        anticipation_rate = (rate_lwb + 
-                           0.5 * uncertainty_factor * (rate_upb - rate_lwb) + 
+        anticipation_rate = (rate_lwb +
+                           0.5 * uncertainty_factor * (rate_upb - rate_lwb) +
                            0.5 * accuracy_factor * (rate_upb - rate_lwb))
-        
-        return anticipation_rate
+
+        # W4-1 (closes W3-3-CARRY-1): clamp output to [rate_lwb, rate_upb]
+        # per the C++ comment intent. Pre-W4-1 the rate could go negative
+        # when prediction_error > max_error (accuracy_factor < 0).
+        return max(rate_lwb, min(rate_upb, anticipation_rate))
 
 
 class TIPIntegratedAnticipatoryLearning(AnticipatoryLearning):

--- a/python_refactor/tests/test_correspondence_integration.py
+++ b/python_refactor/tests/test_correspondence_integration.py
@@ -58,14 +58,11 @@ class TestCorrespondenceIntegration(unittest.TestCase):
                 self.rank_risk = 0
                 self.alpha = np.random.random()
                 self.anticipation = False
-                # W3-3: was `np.random.random() * 0.1` — random in [0, 0.1]
-                # which often exceeds the test's max_error=0.05, driving
-                # accuracy_factor negative in _compute_traditional_learning_rate
-                # → traditional_rate < 0 → test assertion fails ~50% of runs.
-                # Pinned to 0.03 (mid-bounds) for deterministic test inputs.
-                # The real algorithm bug (no output clamp on the rate) is
-                # filed as W3-3-CARRY for a follow-up unit.
-                self.prediction_error = 0.03
+                # W4-1: W3-3 pinned this to 0.03 as a workaround for the
+                # missing output clamp in _compute_traditional_learning_rate.
+                # W4-1 fixed the clamp at source; the random value is safe
+                # again because the rate is now always in [rate_lwb, rate_upb].
+                self.prediction_error = np.random.random() * 0.1
         
         return MockSolution(roi, risk, weights)
     


### PR DESCRIPTION
1-line clamp at anticipatory_learning.py:330. Reverts W3-3 mock pinning. 122/122 PASS.