### PR TITLE
W5-2: covariance threading per paper Eq 15 (closes W4-2-CARRY-1)

### DIFF
--- a/.dfg/agents/W5-2-multihorizon-covariance-threading.md
+++ b/.dfg/agents/W5-2-multihorizon-covariance-threading.md
@@ -1,0 +1,59 @@
+---
+id: W5-2
+role: bug-fixer
+name: Thread covariance updates (paper Eq 15) through MultiHorizon.learn_population
+purpose: "Closes W4-2-CARRY-1. Extends mean-only Eq 14 to full Gaussian convex combo: Σ_combined = (1 - Σλ)^2 * Σ_t + Σ λ_h^2 * Σ_{t+h}."
+wave: W5
+unit: W5-2
+depends_on: []
+blocks: []
+governance_tier: VT2
+sized: M
+hardening_max_cycles: 2
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/algorithms/multi_horizon_anticipatory.py
+    - python_refactor/tests/test_multi_horizon_anticipatory.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/multi_horizon_anticipatory.py
+    - python_refactor/tests/test_multi_horizon_anticipatory.py
+  branch_name: feat/w5-2-multihorizon-covariance-threading
+  acceptance: >
+    learn_population threads covariance: when solution.P.kalman_state is
+    not None, computes anticipatory covariance per paper Eq (15)
+    generalized to multi-horizon: Σ_combined = w_0^2 · Σ_t + Σ w_h^2 · Σ_{t+h}
+    where w_0 = (1 - Σλ) and w_h = λ_h. Writes back to
+    solution.P.kalman_state.P[:2, :2]. Degrades gracefully when
+    kalman_state is None (skip covariance update). New test asserts
+    covariance is updated AND remains positive-semidefinite. All
+    existing 25 multi_horizon tests continue to PASS.
+dispatch_instructions: |
+  ## What this contract does NOT authorise
+
+  - Touching anticipatory_learning.py.
+  - Modifying apply_anticipatory_learning_rule (it stays mean-only;
+    covariance threading is wrapped around it in learn_population).
+
+  ## Implementation
+
+  1. Extend learn_population to compute Σ_combined when kalman_state
+     is present:
+       - Build current_cov from solution.P.kalman_state.P[:2, :2]
+       - For each h, get predicted_cov from
+         predicted_solution.P.kalman_state.P[:2, :2] if predicted
+         _solution.P.kalman_state exists, else fall back to current_cov
+       - Compute: Σ_combined = (1-Σλ)^2 · current_cov + Σ λ_h^2 · predicted_cov_h
+       - Write back to solution.P.kalman_state.P[:2, :2]
+  2. New test test_w5_2_covariance_threaded_through_learn_population:
+       - Build a MockSolution WITH kalman_state (P matrix is PSD)
+       - Run learn_population
+       - Assert solution.P.kalman_state.P[:2, :2] eigenvalues all >= 0
+         (positive-semidefinite preserved)
+       - Assert covariance changed (non-trivial update)
+---
+
+# W5-2 — Covariance threading per paper Eq (15)
+
+Closes W4-2-CARRY-1.

--- a/.dfg/retrospectives/W5/W5-2.md
+++ b/.dfg/retrospectives/W5/W5-2.md
@@ -1,0 +1,56 @@
+---
+unit: W5-2
+wave: W5
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  ~25-line extension to MultiHorizon.learn_population threads
+  paper Eq (15) covariance through the convex combo:
+    Σ_combined = w_0² · Σ_t + Σ w_h² · Σ_{t+h}
+  with w_0 = (1 − Σλ). Writes back to solution.P.kalman_state.P[:2, :2].
+  Graceful degradation when kalman_state is None on either current
+  or any predicted-horizon solution. 3 new regression tests pin:
+    * covariance is actually updated (not left unchanged)
+    * Σ_combined remains positive-semidefinite (eigenvalues ≥ 0)
+    * kalman_state=None doesn't crash (degrades to mean-only path)
+  28/28 multi_horizon tests PASS. 162/162 in curated W1-5 test set.
+what_didnt: |
+  Pre-existing dead-code bug surfaced (same dead-code-coming-alive
+  pattern that's recurred in every wave): `_generate_predicted_solution`
+  at line 250 had `Q=kalman_state.Q` — but KalmanParams doesn't
+  carry a Q (process-noise) attribute. The path was dead because no
+  test had constructed a KF-bearing solution to drive it. My W5-2
+  test was the first to do so → AttributeError. Fixed in same unit
+  by dropping the Q kwarg (no behavioural change — n_step_prediction
+  doesn't use Q in its forward predict either).
+
+  Test-mock setup needed real `create_kalman_params` rather than
+  SimpleNamespace because `_generate_predicted_solution` invokes
+  the full n-step KF predictor which needs F + H + R. Two iterations
+  to find this — but the SimpleNamespace pattern is cleaner for
+  pure data-shape testing; here we need the KF surface to fire.
+what_to_change: |
+  Future tests that construct KF-bearing solutions should use
+  `create_kalman_params` from the start (or the documented constructor)
+  rather than SimpleNamespace; saves the second iteration.
+new_carries: |
+  None — both W4-2-CARRY-1 and the dead-Q-kwarg bug closed in this unit.
+scars_carried_forward: |
+  None — W5 closes all known carries.
+---
+
+# W5-2 — Covariance threading per paper Eq (15)
+
+Closes W4-2-CARRY-1.
+
+## What changed
+
+- `multi_horizon_anticipatory.py`:
+  - `learn_population` extended (~25 lines) with Eq (15) covariance threading
+  - `_generate_predicted_solution`: drop pre-existing `Q=kalman_state.Q` kwarg (KalmanParams has no Q field)
+- `test_multi_horizon_anticipatory.py`: NEW `TestW5_2_CovarianceThreading` class (3 tests)
+
+## Verification
+
+- 28/28 multi_horizon tests PASS
+- 162/162 curated W1-5 test set PASS

--- a/python_refactor/src/algorithms/multi_horizon_anticipatory.py
+++ b/python_refactor/src/algorithms/multi_horizon_anticipatory.py
@@ -241,14 +241,21 @@ class MultiHorizonAnticipatoryLearning(TIPIntegratedAnticipatoryLearning):
                 predicted_solution.P.ROI = predicted_state[0]
                 predicted_solution.P.risk = predicted_state[1]
                 
-                # Update Kalman state
+                # Update Kalman state.
+                # W5-2: drop the pre-existing `Q=kalman_state.Q` kwarg —
+                # KalmanParams doesn't carry a Q (process-noise) field
+                # (verified against src/algorithms/kalman_filter.py:32-56),
+                # so the reference was always a latent AttributeError waiting
+                # for the dead `_generate_predicted_solution` path to wake up.
+                # Surfaced by W5-2 covariance-threading tests (the first
+                # tests to actually construct a KF-bearing solution and
+                # drive this path).
                 predicted_solution.P.kalman_state = KalmanParams(
                     x=predicted_state,
                     P=step_prediction['covariance'],
                     F=kalman_state.F,
                     H=kalman_state.H,
-                    Q=kalman_state.Q,
-                    R=kalman_state.R
+                    R=kalman_state.R,
                 )
         else:
             # Fallback: simple linear prediction
@@ -510,6 +517,20 @@ class MultiHorizonAnticipatoryLearning(TIPIntegratedAnticipatoryLearning):
         (paper Eq 15) — only mean vectors. A deeper integration unit
         would close that gap.
 
+        W5-2 (closes W4-2-CARRY-1): the mean-only restriction is
+        LIFTED. When `solution.P.kalman_state` is present, the
+        anticipatory covariance is computed per paper Eq (15)
+        generalized to the multi-horizon convex combo:
+
+            Σ_combined = w_0² · Σ_t + Σ_{h=1}^{H-1} w_h² · Σ_{t+h}
+
+        where w_0 = (1 - Σλ) and w_h = λ_{t+h}. The result is
+        positive-semidefinite (sum of weighted PSD matrices with
+        non-negative weights). Written back to
+        `solution.P.kalman_state.P[:2, :2]` (the [ROI, risk] block
+        per paper Eq 11). Degrades to mean-only when kalman_state
+        is None or lacks the predicted-side covariance.
+
         Args:
             population: list of Solution objects to update in-place
             current_time: current time step
@@ -533,8 +554,10 @@ class MultiHorizonAnticipatoryLearning(TIPIntegratedAnticipatoryLearning):
                 continue
 
             # For each future horizon h=1..H-1, build the predicted
-            # [ROI, risk] state from the existing predictor surface.
+            # [ROI, risk] state + (W5-2) covariance from the existing
+            # predictor surface.
             predicted_states = []
+            predicted_covs = []  # W5-2: per-horizon [ROI, risk] cov blocks
             for h_idx, _ in enumerate(lambda_rates):
                 h = h_idx + 1  # horizons are 1-indexed in the API
                 predicted_solution = self._generate_predicted_solution(
@@ -544,17 +567,43 @@ class MultiHorizonAnticipatoryLearning(TIPIntegratedAnticipatoryLearning):
                     predicted_solution.P.ROI,
                     predicted_solution.P.risk,
                 ]))
+                # W5-2: pull the predicted [ROI, risk] covariance block
+                # if the predicted solution carries a kalman_state.
+                pred_kf = getattr(predicted_solution.P, 'kalman_state', None)
+                if pred_kf is not None and getattr(pred_kf, 'P', None) is not None:
+                    predicted_covs.append(np.array(pred_kf.P[:2, :2]))
+                else:
+                    predicted_covs.append(None)
 
-            # Paper Eq (14): the multi-horizon convex combination.
+            # Paper Eq (14): the multi-horizon convex combination on
+            # mean vectors.
             anticipatory_state = self.apply_anticipatory_learning_rule(
                 current_state, predicted_states, lambda_rates,
             )
 
-            # Write back the anticipated state. The solution's covariance
-            # update (paper Eq 15) is NOT threaded here — see honest scar
-            # in the docstring.
+            # Write back the anticipated MEAN.
             solution.P.ROI = float(anticipatory_state[0])
             solution.P.risk = float(anticipatory_state[1])
+
+            # W5-2: paper Eq (15) covariance threading. Only fires when
+            # the current solution AND every predicted-horizon solution
+            # carry a kalman_state with a P matrix; otherwise leaves the
+            # current covariance untouched (graceful degradation).
+            current_kf = getattr(solution.P, 'kalman_state', None)
+            if (current_kf is not None
+                    and getattr(current_kf, 'P', None) is not None
+                    and all(c is not None for c in predicted_covs)):
+                current_cov = np.array(current_kf.P[:2, :2])
+                w_0 = 1.0 - sum(lambda_rates)
+                # Σ_combined = w_0² · Σ_t + Σ w_h² · Σ_{t+h}
+                combined_cov = (w_0 ** 2) * current_cov
+                for w_h, cov_h in zip(lambda_rates, predicted_covs):
+                    combined_cov = combined_cov + (w_h ** 2) * cov_h
+                # Write back to the [ROI, risk] block of P, leaving the
+                # velocity block untouched (W4 scope; deeper integration
+                # would thread velocities too).
+                current_kf.P[:2, :2] = combined_cov
+
             solution.multi_horizon_applied = True
 
         # Mirror the parent's bookkeeping so historical-population

--- a/python_refactor/tests/test_multi_horizon_anticipatory.py
+++ b/python_refactor/tests/test_multi_horizon_anticipatory.py
@@ -535,5 +535,126 @@ class TestW4_2_LearnPopulationOverride(unittest.TestCase):
         )
 
 
+class TestW5_2_CovarianceThreading(unittest.TestCase):
+    """W5-2 regression: MultiHorizonAnticipatoryLearning.learn_population
+    threads covariance updates per paper Eq (15) when kalman_state is
+    present on the current and predicted solutions.
+
+    Closes W4-2-CARRY-1.
+
+    Paper canon:
+        Σ_combined = w_0² · Σ_t + Σ_{h=1}^{H-1} w_h² · Σ_{t+h}
+
+    where w_0 = (1 - Σλ) and w_h = λ_{t+h}. Σ_combined is positive-
+    semidefinite by construction (sum of weighted PSD matrices with
+    non-negative weights).
+    """
+
+    def setUp(self):
+        np.random.seed(7)
+        self.learner = MultiHorizonAnticipatoryLearning(
+            max_horizon=3, monte_carlo_samples=50,
+        )
+
+    def _make_solution_with_kf(self, roi: float, risk: float,
+                                roi_var: float = 0.01, risk_var: float = 0.01,
+                                cov: float = 0.0):
+        """Build a Solution-shaped mock WITH a real KalmanParams whose
+        P[:2, :2] is the [ROI, risk] covariance. Uses create_kalman_params
+        helper so F + H + R are all properly populated (required by
+        the n-step predictor that `_generate_predicted_solution` calls).
+        """
+        from src.algorithms.kalman_filter import create_kalman_params
+
+        kalman_state = create_kalman_params(initial_roi=roi, initial_risk=risk)
+        # Override the [ROI, risk] covariance block to the test-specified
+        # values; leave velocity block at the create_kalman_params default.
+        kalman_state.P[0, 0] = roi_var
+        kalman_state.P[1, 1] = risk_var
+        kalman_state.P[0, 1] = cov
+        kalman_state.P[1, 0] = cov
+        kalman_state.P_next = kalman_state.P.copy()
+
+        class MockPortfolio:
+            def __init__(self, roi, risk, kf):
+                self.ROI = roi
+                self.risk = risk
+                self.num_assets = 3
+                self.investment = np.array([0.4, 0.3, 0.3])
+                self.cardinality = 3
+                self.kalman_state = kf
+
+        class MockSolution:
+            def __init__(self, roi, risk, kf):
+                self.P = MockPortfolio(roi, risk, kf)
+                self.alpha = 0.5
+                self.prediction_error = 0.02
+                self.anticipation = False
+
+        return MockSolution(roi, risk, kalman_state)
+
+    def test_covariance_updated_in_place_for_solution_with_kf(self):
+        """When solution has kalman_state, learn_population computes
+        the Eq (15) Σ_combined and writes it to P[:2, :2].
+        """
+        sol = self._make_solution_with_kf(roi=0.10, risk=0.05,
+                                            roi_var=0.005, risk_var=0.005)
+        original_cov = sol.P.kalman_state.P[:2, :2].copy()
+
+        self.learner.learn_population([sol], current_time=1)
+
+        new_cov = sol.P.kalman_state.P[:2, :2]
+        # Covariance should be a real 2x2 numpy array.
+        self.assertEqual(new_cov.shape, (2, 2))
+        self.assertTrue(np.all(np.isfinite(new_cov)))
+        # In the multi-horizon path with non-trivial λ, the combined
+        # covariance differs from the original (weighted sum, not a
+        # passthrough). Original was 0.005·I; combined typically smaller
+        # because each w² < 1 and Σ w² < 1 for the weighted sum.
+        self.assertFalse(np.allclose(new_cov, original_cov),
+                          "Covariance should be updated, not left unchanged")
+
+    def test_covariance_remains_positive_semidefinite(self):
+        """Σ_combined per paper Eq (15) is PSD by construction. Verify
+        eigenvalues all >= 0 (within numerical tolerance).
+        """
+        sol = self._make_solution_with_kf(roi=0.1, risk=0.05)
+        self.learner.learn_population([sol], current_time=1)
+
+        new_cov = sol.P.kalman_state.P[:2, :2]
+        eigenvalues = np.linalg.eigvalsh(new_cov)
+        # PSD: all eigenvalues >= 0 (small numerical slack)
+        for eig in eigenvalues:
+            self.assertGreaterEqual(eig, -1e-9,
+                                     f"Covariance must remain PSD; eig={eig:.2e}")
+
+    def test_kalman_state_none_does_not_break_learn_population(self):
+        """Graceful degradation: when current solution has no
+        kalman_state, the mean update still runs and the solution is
+        still tagged. No covariance update + no exception.
+        """
+        class MockPortfolio:
+            def __init__(self, roi, risk):
+                self.ROI = roi
+                self.risk = risk
+                self.num_assets = 3
+                self.investment = np.array([0.4, 0.3, 0.3])
+                self.cardinality = 3
+                self.kalman_state = None  # ← graceful-degradation case
+
+        class MockSolution:
+            def __init__(self, roi, risk):
+                self.P = MockPortfolio(roi, risk)
+                self.alpha = 0.5
+                self.prediction_error = 0.02
+                self.anticipation = False
+
+        sol = MockSolution(0.1, 0.05)
+
+        # Must NOT raise.
+        self.learner.learn_population([sol], current_time=1)
+        self.assertTrue(sol.multi_horizon_applied)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Paper Eq (15) covariance threading in MultiHorizon.learn_population. Also fixes pre-existing dead-code Q-kwarg bug. 28/28 multi_horizon + 162/162 W1-5 tests PASS.