### PR TITLE
W6-2: flip repo visibility to PUBLIC

### DIFF
--- a/.dfg/agents/W6-2-visibility-public-flip.md
+++ b/.dfg/agents/W6-2-visibility-public-flip.md
@@ -1,0 +1,42 @@
+---
+id: W6-2
+role: tooling-author
+name: Flip repo visibility to public
+purpose: "One-way door. `gh repo edit --visibility public`. Depends on W6-1 (README must already be public-ready)."
+wave: W6
+unit: W6-2
+depends_on: ['W6-1']
+blocks: []
+governance_tier: VT3
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - README.md
+output_contract:
+  files:
+    - .dfg/checkpoints/W6-2-visibility-receipt.md
+  branch_name: feat/w6-2-visibility-public-flip
+  acceptance: >
+    `gh repo view --json visibility` returns PUBLIC. Receipt at
+    .dfg/checkpoints/W6-2-visibility-receipt.md records the timestamp
+    + the gh command output.
+dispatch_instructions: |
+  ## VT3 ceremony
+
+  This is a one-way door. Pre-conditions verified by W6-1 merge:
+    - README.md is publication-quality (no stub, no TODOs)
+    - No secrets in tracked files (verify via `git ls-files | xargs grep -l "ELEVENLABS\|API_KEY\|SECRET"` returns nothing)
+    - Repo is private at execution time (otherwise no-op)
+
+  Execute:
+    gh repo edit crbazevedo/learning-to-anticipate-flexible-choices \
+        --visibility public
+
+  Write receipt + verify.
+---
+
+# W6-2 — Flip repo visibility to public
+
+VT3 one-way door. Operator-approved 2026-05-17.

--- a/.dfg/checkpoints/W6-2-visibility-receipt.md
+++ b/.dfg/checkpoints/W6-2-visibility-receipt.md
@@ -1,0 +1,41 @@
+# W6-2 visibility-flip receipt
+
+**Unit:** W6-2 — Flip repo visibility to public
+**Operator-approved:** 2026-05-17 (per session directive "make it public")
+**Executed:** 2026-05-17
+
+## Pre-conditions verified
+
+- W6-1 README is publication-quality (PR #33 merged 2026-05-17)
+- W6-3 validation plan committed (PR #34 merged 2026-05-17)
+- Secret scan clean: `git ls-files -z | xargs -0 grep -lE "ELEVENLABS|API_KEY|SECRET"` returned only this contract file (which contains the token names as scan targets, not actual secrets)
+
+## Command executed
+
+```
+gh repo edit crbazevedo/learning-to-anticipate-flexible-choices \
+    --visibility public \
+    --accept-visibility-change-consequences
+```
+
+## Pre-flip state
+
+```json
+{"visibility":"PRIVATE","isArchived":false,"url":"https://github.com/crbazevedo/learning-to-anticipate-flexible-choices"}
+```
+
+## Post-flip state (verified via `gh repo view`)
+
+```json
+{"visibility":"PUBLIC","url":"https://github.com/crbazevedo/learning-to-anticipate-flexible-choices"}
+```
+
+## Verification
+
+`gh repo view --json visibility` returns `PUBLIC`.
+
+The repo is now publicly accessible at:
+**https://github.com/crbazevedo/learning-to-anticipate-flexible-choices**
+
+This is a **one-way door** (VT3). Re-privatising is possible but
+requires manual `gh repo edit --visibility private`.

--- a/.dfg/retrospectives/W6/W6-2.md
+++ b/.dfg/retrospectives/W6/W6-2.md
@@ -1,0 +1,46 @@
+---
+unit: W6-2
+wave: W6
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Single gh command. Pre-conditions verified (W6-1 README live;
+  W6-3 plan committed; secret scan clean). One-way door executed
+  per operator directive 2026-05-17. Receipt at
+  .dfg/checkpoints/W6-2-visibility-receipt.md records exact command,
+  pre/post visibility state, verification output, and pre-condition
+  checks. Repo is now public at
+  https://github.com/crbazevedo/learning-to-anticipate-flexible-choices.
+what_didnt: |
+  Initial secret scan with `git ls-files | xargs grep` failed because
+  unquoted FTSE-original CSV filenames have parens (e.g. `table (0).csv`)
+  that the shell mis-parses. The null-delimited form
+  `git ls-files -z | xargs -0 grep` fixed it. Any future shell command
+  that touches legacy-cpp/ must use null-delimiting.
+what_to_change: |
+  Document the null-delimited shell pattern (or rename the FTSE-original
+  CSVs in a future cleanup unit — they're in legacy-cpp/ so blast radius
+  is minimal).
+new_carries: |
+  - W6-2-CARRY-1: FTSE-original CSV filenames contain `(N)` which breaks
+    naive shell expansion. Trivia-tier. Document or rename in a future
+    cleanup wave.
+scars_carried_forward: |
+  None.
+---
+
+# W6-2 — Flip repo visibility to PUBLIC
+
+Operator-approved VT3 one-way door executed.
+
+## What changed
+
+- Visibility: PRIVATE → PUBLIC via `gh repo edit`.
+- Receipt: `.dfg/checkpoints/W6-2-visibility-receipt.md` records command + verification.
+
+## Verification
+
+`gh repo view --json visibility` returns `{"visibility":"PUBLIC"}`.
+
+Repo is now publicly accessible at:
+**https://github.com/crbazevedo/learning-to-anticipate-flexible-choices**


### PR DESCRIPTION
VT3 one-way door. gh repo edit --visibility public executed per operator directive 2026-05-17. Receipt at .dfg/checkpoints/W6-2-visibility-receipt.md.