### PR TITLE
W8-1: validation_matrix smoke-test (HONEST SCAR: src/ cascade)

### DIFF
--- a/.dfg/agents/W8-1-validation-matrix-smoke-test.md
+++ b/.dfg/agents/W8-1-validation-matrix-smoke-test.md
@@ -1,0 +1,38 @@
+---
+id: W8-1
+role: bug-fixer
+name: Smoke-test validation_matrix real-run path
+purpose: "Closes W7-1-CARRY-1 partial. End-to-end real-run + integration fixes in validation_matrix.py."
+wave: W8
+unit: W8-1
+depends_on: []
+blocks: []
+governance_tier: VT2
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/experiments/validation_matrix.py
+    - python_refactor/src/experiments/experiment_manager.py
+    - python_refactor/run_experiments.py
+output_contract:
+  files:
+    - python_refactor/experiments/validation_matrix.py
+  branch_name: feat/w8-1-validation-matrix-smoke-test
+  acceptance: >
+    Scaffold's real-run path verified callable up to data-loading layer.
+    Pre-existing src/ integration bugs surfaced are filed as carries
+    for a future wave — NOT fixed in W8-1 (scope-discipline per
+    directive #4).
+dispatch_instructions: |
+  Run `python -m experiments.validation_matrix --scenario S0
+  --window paper --seed 1 --output /tmp/w8-smoke-S0/`. Fix any
+  integration bugs INSIDE validation_matrix.py. Surface any
+  src/-side bugs as honest carries — do NOT scope-creep into
+  src/ fixes without replan.
+---
+
+# W8-1 — Smoke-test validation_matrix real-run
+
+Closes W7-1-CARRY-1 partial.

--- a/.dfg/retrospectives/W8/W8-1.md
+++ b/.dfg/retrospectives/W8/W8-1.md
@@ -1,0 +1,99 @@
+---
+unit: W8-1
+wave: W8
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Scaffold (validation_matrix.py) is verified callable end-to-end up
+  to the data-loading layer:
+    - Config construction OK
+    - ExperimentManager constructor invocation FIXED in W8-1
+      (was wrong kwarg `experiment_dir=`; corrected to suite-config dict
+      pattern matching run_experiments.py)
+    - Data-path glob handling clarified: data_loader takes literal
+      paths, not globs. Updated WINDOWS to use FTSE-updated CSV for
+      both windows (paper-window data loader is W8-1-CARRY-1).
+
+  These are 2 real integration fixes in the scaffold (in-scope).
+what_didnt: |
+  PRE-EXISTING SRC/ BUGS CASCADE.
+
+  After fixing the data path, smoke-test surfaced a `KeyError: None`
+  in pandas `pivot()` deeper in the data_loader / experiment_manager
+  chain — another pre-existing bug latent in code that was never
+  exercised end-to-end before W8-1.
+
+  Plus the earlier `bool(DataFrame)` ambiguity at
+  experiment_manager.py:190 surfaced before this one.
+
+  My W8-1 scope is validation_matrix.py only. Fixing the src/
+  integration chain bugs would dwarf the original scope and risk
+  scope-creep without replan. Per directive #4 (paired plan-mutation
+  + replan accept) the correct move is to file the src/ bugs as
+  carries and let a focused investigation wave (W9 candidate) take
+  them in proper scope.
+
+  The acceptance criterion "smoke-test exits 0 without --dry-run"
+  is NOT met. The acceptance criterion "manifest.json shows
+  status=ok" is NOT met. Honest scar — not laundered.
+
+  Partial success: the scaffold's reachability is verified — config
+  builds, ExperimentManager constructs, data_loader is called. The
+  failure is inside the chain, not in the scaffold.
+what_to_change: |
+  W9 should be a focused "data-loader integration fixup" wave that
+  investigates + fixes the src/ bugs cascading from the smoke-test.
+  Expected size: M-L (1-3 units). After W9 lands, re-run W8-1's
+  smoke-test as part of W9's gate to verify the cascade is closed.
+
+  Alternative: scope W9 narrowly to "smoke-test passes for S0/paper"
+  and defer per-scenario fixes to W9+ units.
+new_carries: |
+  - W8-1-CARRY-1: paper-window data path (98 per-asset CSVs at
+    legacy-cpp/executable/data/ftse-original/) needs a custom loader
+    extension. The data_loader treats asset_files as literal paths,
+    not globs. Smoke-test temporarily uses the FTSE-updated CSV
+    for both windows.
+  - W8-1-CARRY-2: pre-existing src/ integration bugs surfaced by
+    end-to-end smoke-test:
+      * experiment_manager.py:190 — `bool(DataFrame)` ambiguity
+      * data_loader → pandas.pivot() KeyError(None) cascade
+      * possibly more deeper in the chain
+    None of these were exercised before W8-1's smoke-test attempt.
+    Dead-code-coming-alive pattern, 6th instance across the wave
+    chain. Investigation + fix needs a dedicated W9 unit.
+scars_carried_forward: |
+  W7-1-CARRY-1 is PARTIALLY closed — the scaffold IS callable + reaches
+  data-loading. Full end-to-end success blocked on W8-1-CARRY-2's
+  src/ fixes.
+
+  W6-2-CARRY-1 (CSV-parens shell-grep) unchanged.
+---
+
+# W8-1 — Smoke-test validation_matrix real-run
+
+## What changed
+
+- `validation_matrix.py`: 2 in-scope fixes:
+  1. ExperimentManager invocation pattern (suite-config dict, not
+     `experiment_dir=` kwarg)
+  2. WINDOWS uses FTSE-updated single-CSV for both windows
+     (paper-window loader is a carry)
+
+## Verification (HONEST SCAR)
+
+- Scaffold callability VERIFIED up to data-loading layer.
+- End-to-end smoke-test acceptance criterion **NOT MET** —
+  blocked by pre-existing src/ integration bugs (W8-1-CARRY-2).
+- The scaffold itself is sound. The chain it invokes has latent bugs.
+
+## Closes
+
+- W7-1-CARRY-1 **partially** (scaffold reachability proven; full
+  end-to-end deferred to W9).
+
+## Forwards
+
+- W8-1-CARRY-1: paper-window data loader extension.
+- W8-1-CARRY-2: src/ integration bug cascade (3+ bugs surfaced,
+  more likely beneath).

--- a/python_refactor/experiments/validation_matrix.py
+++ b/python_refactor/experiments/validation_matrix.py
@@ -95,12 +95,19 @@ SCENARIOS: dict[str, dict[str, Any]] = {
     },
 }
 
+# W8-1 (closes W7-1-CARRY-1 partial): the paper-window's original FTSE
+# data is 98 per-asset CSVs at legacy-cpp/executable/data/ftse-original/
+# table\\ (*).csv — the underlying data_loader doesn't accept glob patterns
+# in its asset_files list (treats each entry as a literal filename).
+# Filed as W8-1-CARRY-1; for now both windows use the FTSE-updated
+# single-CSV path so the scaffold's smoke-test gets past data loading.
+# A future paper-window-loader unit (W9 candidate) will close the gap.
 WINDOWS: dict[str, dict[str, str]] = {
     "paper": {
-        "asset_files_glob": "../legacy-cpp/executable/data/ftse-original/table (*).csv",
-        "date_start": "2006-11-20",
-        "date_end": "2012-12-31",
-        "notes": "Direct paper-comparison window (paper §V-A).",
+        "asset_files_glob": "data/ftse-updated/FTSE_100_20121121_20241231.csv",
+        "date_start": "2012-11-21",  # W8-1-CARRY-1: paper-window data needs loader extension
+        "date_end": "2024-12-31",
+        "notes": "Paper-window data loader is a W8-1-CARRY-1; smoke-test temporarily uses the FTSE-updated CSV here.",
     },
     "extended": {
         "asset_files_glob": "data/ftse-updated/FTSE_100_20121121_20241231.csv",
@@ -231,7 +238,17 @@ def run_one(scenario_id: str, window_id: str, seed: int,
         return 2
 
     logging.basicConfig(level=logging.INFO)
-    manager = ExperimentManager(experiment_dir=str(output_dir))
+    # ExperimentManager takes a top-level "suite" config (name, description,
+    # version, timestamp) at init time, NOT a per-experiment config. The
+    # per-experiment config is passed to run_experiment() below. W8-1 fix:
+    # initial scaffold used `experiment_dir=...` kwarg which doesn't exist.
+    suite_config = {
+        "experiment_name": f"validation_matrix_{scenario_id}",
+        "description": f"W8 validation run: {SCENARIOS[scenario_id]['name']}",
+        "version": "W8-1",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    manager = ExperimentManager(suite_config)
 
     try:
         results = manager.run_experiment(config)


### PR DESCRIPTION
2 in-scope fixes to validation_matrix.py. Smoke-test reaches data-loading layer then surfaces pre-existing src/ bugs. Carries filed for W9; scope-discipline per directive #4 prevented chasing them in W8-1.