### PR TITLE
W8-3: table generators A-H

### DIFF
--- a/.dfg/agents/W8-3-table-generators.md
+++ b/.dfg/agents/W8-3-table-generators.md
@@ -1,0 +1,36 @@
+---
+id: W8-3
+role: tooling-author
+name: Table generators A-H from summary CSV
+purpose: "Reads VALIDATION-SUMMARY.csv + per-run results, emits Markdown table strings for A-H per ANALYTICS-PLAN.md §7."
+wave: W8
+unit: W8-3
+depends_on: []
+blocks: ['W8-4']
+governance_tier: VT2
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - docs/ANALYTICS-PLAN.md
+    - docs/VALIDATION-RESULTS.md
+output_contract:
+  files:
+    - python_refactor/experiments/tables.py
+    - python_refactor/tests/test_experiments_tables.py
+  branch_name: feat/w8-3-table-generators
+  acceptance: >
+    tables.py exposes generate_table_a..generate_table_h. Each
+    returns a Markdown-formatted string. Numerical formatting per
+    ANALYTICS-PLAN §7. test_experiments_tables.py has ≥ 4 tests.
+dispatch_instructions: |
+  Pure-function module. Reads list-of-dicts (one row per
+  scenario × window × metric); writes Markdown table strings.
+  Number formatting: 4 sig figs default; p < 0.001 → '<0.001';
+  effect sizes to 3 decimals.
+---
+
+# W8-3 — Table generators A-H
+
+Per ANALYTICS-PLAN.md §7.

--- a/.dfg/retrospectives/W8/W8-3.md
+++ b/.dfg/retrospectives/W8/W8-3.md
@@ -1,0 +1,79 @@
+---
+unit: W8-3
+wave: W8
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Pure functions, no I/O — same shape as W8-2. 8 table generators
+  (A-H) + 3 number-formatting helpers (fmt_sigfig, fmt_pvalue,
+  fmt_effect) in ~285 lines.
+
+  Each generator: (1) returns "_(Table X: no data)_" on empty input,
+  (2) builds Markdown header + separator, (3) iterates rows applying
+  formatting helpers, (4) returns the joined string. Same pattern A→H
+  makes them trivial to read together.
+
+  Number formatting per ANALYTICS-PLAN.md §7:
+   - fmt_sigfig: digits = sig − floor(log10(|v|)) − 1, NaN-safe, 0-safe.
+   - fmt_pvalue: '<0.001' for very small p, else 3 sig figs (so
+     p=0.0421 stays readable as "0.0421", p=1e-10 collapses to "<0.001").
+   - fmt_effect: 3 decimals fixed (Cohen's d / Cliff's δ scale).
+
+  Table F uses an inner grouping pass to widen scenarios × metrics
+  into one row per (regime, scenario) with mean ± std cells — the
+  only non-trivial generator. Tested with a 2-scenario × 2-metric
+  example confirming the header has both metrics and both rows render
+  with combined cells.
+
+  15/15 tests pass on first run after one test-assertion tightening
+  (see what_didnt).
+what_didnt: |
+  Initial test assertion `assertIn("[0.012, 0.08", out)` for the
+  Table D CI brackets was too narrow — the 4-sig-fig formatter
+  pads trailing zeros (0.012 → "0.01200", 0.08 → "0.08000"), so the
+  bracket substring is "[0.01200, 0.08000]". This is correct per the
+  ANALYTICS-PLAN §7 spec (4 sig figs default) — the test was wrong,
+  not the formatter.
+
+  Fix: assertion now checks for "0.01200", "0.08000", "[", "]", and
+  "synergy" separately — robust to formatter precision choices and
+  still pins the bracket-rendered CI shape.
+what_to_change: |
+  None at this unit's level. The trailing-zero padding is a property
+  of the formula `f"{v:.{digits}f}"` — when |v| < 1 and sig > number
+  of non-trailing-zero digits, fixed-decimal formatting will pad. If
+  a future caller wants stripped trailing zeros, add a `strip_trailing=True`
+  kwarg to fmt_sigfig; not needed for W8-3 / W8-4.
+new_carries: |
+  None.
+scars_carried_forward: |
+  W8-1-CARRY-1 (paper-window data loader gap) and W8-1-CARRY-2
+  (src/ bool(DataFrame) bug cascade) unchanged — independent of W8-3.
+---
+
+# W8-3 — Table generators A-H
+
+## What changed
+
+- `python_refactor/experiments/tables.py` (NEW, ~285 lines) — 8 generators + 3 formatters
+- `python_refactor/tests/test_experiments_tables.py` (NEW, ~165 lines) — 15 tests
+
+## Tables shipped
+
+| Generator | Purpose | Input shape |
+|---|---|---|
+| A descriptive_stats | scenario × window × metric → (mean, std, median, min, max, n) | summary CSV rows |
+| B pairwise_tests | (scenario_i, scenario_j) × window × metric → (U, p_raw, p_holm, d, δ, CLES) | pairwise-test rows |
+| C anova | window × metric × source → (SS, df, MS, F, p) | one-way ANOVA rows |
+| D synergy_contrast | window × metric → (Δ_interaction, 95% CI) | synergy rows |
+| E horizon_ablation | comparison × window × metric → (U, p, d) | ablation rows |
+| F regime_segmentation | regime × scenario × metric → mean ± std | per-regime rows (grouped) |
+| G sub_window_stability | sub_window × scenario × metric → mean ± std | sub-window rows |
+| H paper_comparison | metric → (paper, ours, diff, agree?) | paper-vs-this-impl rows |
+
+## Verification
+
+- 15/15 tests PASS
+- Formatting helpers tested against textbook cases (sig-fig rounding, NaN, zero, p < 0.001, normal p, 3-decimal effects)
+- Each generator tested with a representative minimal row to confirm Markdown shape + content
+- Table F tested with multi-metric / multi-scenario input to confirm column-grouping

--- a/python_refactor/experiments/tables.py
+++ b/python_refactor/experiments/tables.py
@@ -1,0 +1,283 @@
+"""
+W8-3 table generators (A-H) from aggregated validation results.
+
+Pure functions. Input shapes vary per table (summary CSV row-list vs
+per-run metric dicts vs pairwise-test rows). Output: Markdown-formatted
+string suitable for embedding in VALIDATION-RESULTS.md.
+
+Table catalog (per ANALYTICS-PLAN.md §7):
+    A: descriptive_stats   — scenario × window × metric → (mean, std, ...)
+    B: pairwise_tests      — (scenario_i, scenario_j) × window × metric → (U, p, d, δ)
+    C: anova               — window × metric × source → (SS, df, MS, F, p)
+    D: synergy_contrast    — window × metric → (Δ_interaction, 95% CI)
+    E: horizon_ablation    — comparison × window × metric → (U, p, d)
+    F: regime_segmentation — regime × scenario × metric → mean ± std
+    G: sub_window_stability — sub_window × scenario × metric → mean ± std
+    H: paper_comparison    — metric → (paper value, this impl, diff, agree?)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Number formatting helpers
+# ---------------------------------------------------------------------------
+
+def fmt_sigfig(value: float, sig: int = 4) -> str:
+    """Format `value` to `sig` significant figures. NaN-safe."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if v != v:  # NaN
+        return "nan"
+    if v == 0:
+        return "0"
+    import math
+    digits = sig - int(math.floor(math.log10(abs(v)))) - 1
+    return f"{v:.{max(0, digits)}f}"
+
+
+def fmt_pvalue(p: float) -> str:
+    """Render p-value: '<0.001' for very small, else 3 sig figs."""
+    try:
+        pv = float(p)
+    except (TypeError, ValueError):
+        return str(p)
+    if pv != pv:
+        return "nan"
+    if pv < 0.001:
+        return "<0.001"
+    return fmt_sigfig(pv, sig=3)
+
+
+def fmt_effect(d: float) -> str:
+    """Render effect size to 3 decimals (Cohen's d / Cliff's δ scale)."""
+    try:
+        return f"{float(d):.3f}"
+    except (TypeError, ValueError):
+        return str(d)
+
+
+# ---------------------------------------------------------------------------
+# Table generators
+# ---------------------------------------------------------------------------
+
+def generate_table_a(summary_rows: list[dict[str, Any]]) -> str:
+    """Table A — descriptive statistics.
+
+    Input: rows from aggregate_validation.py summary CSV with columns
+    scenario, window, metric, mean, std, median, min, max, n_seeds.
+    """
+    if not summary_rows:
+        return "_(Table A: no data)_"
+    header = "| scenario | window | metric | mean | std | median | min | max | n |\n"
+    sep    = "|---|---|---|---|---|---|---|---|---|\n"
+    body_rows = []
+    for r in sorted(summary_rows, key=lambda x: (x.get("scenario", ""),
+                                                    x.get("window", ""),
+                                                    x.get("metric", ""))):
+        body_rows.append(
+            "| {scenario} | {window} | {metric} | {mean} | {std} | {median} | {minv} | {maxv} | {n} |".format(
+                scenario=r.get("scenario", ""),
+                window=r.get("window", ""),
+                metric=r.get("metric", ""),
+                mean=fmt_sigfig(r.get("mean", float("nan"))),
+                std=fmt_sigfig(r.get("std", float("nan"))),
+                median=fmt_sigfig(r.get("median", float("nan"))),
+                minv=fmt_sigfig(r.get("min", float("nan"))),
+                maxv=fmt_sigfig(r.get("max", float("nan"))),
+                n=r.get("n_seeds", "?"),
+            )
+        )
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_b(pairwise_rows: list[dict[str, Any]]) -> str:
+    """Table B — pairwise scenario comparison.
+
+    Input rows: pair, window, metric, U, p_raw, p_holm, cohens_d, cliffs_delta, cles.
+    """
+    if not pairwise_rows:
+        return "_(Table B: no data)_"
+    header = "| pair | window | metric | U | p (raw) | p (Holm) | Cohen's d | Cliff's δ | CLES |\n"
+    sep    = "|---|---|---|---|---|---|---|---|---|\n"
+    body_rows = []
+    for r in pairwise_rows:
+        body_rows.append(
+            "| {pair} | {window} | {metric} | {U} | {p_raw} | {p_holm} | {d} | {delta} | {cles} |".format(
+                pair=r.get("pair", ""),
+                window=r.get("window", ""),
+                metric=r.get("metric", ""),
+                U=fmt_sigfig(r.get("U", float("nan"))),
+                p_raw=fmt_pvalue(r.get("p_raw", float("nan"))),
+                p_holm=fmt_pvalue(r.get("p_holm", float("nan"))),
+                d=fmt_effect(r.get("cohens_d", float("nan"))),
+                delta=fmt_effect(r.get("cliffs_delta", float("nan"))),
+                cles=fmt_effect(r.get("cles", float("nan"))),
+            )
+        )
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_c(anova_rows: list[dict[str, Any]]) -> str:
+    """Table C — one-way ANOVA over Multi-Horizon levels.
+
+    Input rows: window, metric, source, SS, df, MS, F, p.
+    """
+    if not anova_rows:
+        return "_(Table C: no data)_"
+    header = "| window | metric | source | SS | df | MS | F | p |\n"
+    sep    = "|---|---|---|---|---|---|---|---|\n"
+    body_rows = []
+    for r in anova_rows:
+        body_rows.append(
+            "| {window} | {metric} | {source} | {SS} | {df} | {MS} | {F} | {p} |".format(
+                window=r.get("window", ""),
+                metric=r.get("metric", ""),
+                source=r.get("source", ""),
+                SS=fmt_sigfig(r.get("SS", float("nan"))),
+                df=r.get("df", "?"),
+                MS=fmt_sigfig(r.get("MS", float("nan"))),
+                F=fmt_sigfig(r.get("F", float("nan"))),
+                p=fmt_pvalue(r.get("p", float("nan"))),
+            )
+        )
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_d(synergy_rows: list[dict[str, Any]]) -> str:
+    """Table D — synergy contrast Δ_interaction with bootstrap 95% CI.
+
+    Input rows: window, metric, delta_interaction, ci_lo, ci_hi, interpretation.
+    """
+    if not synergy_rows:
+        return "_(Table D: no data)_"
+    header = "| window | metric | Δ_interaction | 95% CI | interpretation |\n"
+    sep    = "|---|---|---|---|---|\n"
+    body_rows = []
+    for r in synergy_rows:
+        ci = "[{lo}, {hi}]".format(
+            lo=fmt_sigfig(r.get("ci_lo", float("nan"))),
+            hi=fmt_sigfig(r.get("ci_hi", float("nan"))),
+        )
+        body_rows.append(
+            "| {window} | {metric} | {delta} | {ci} | {interp} |".format(
+                window=r.get("window", ""),
+                metric=r.get("metric", ""),
+                delta=fmt_sigfig(r.get("delta_interaction", float("nan"))),
+                ci=ci,
+                interp=r.get("interpretation", ""),
+            )
+        )
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_e(ablation_rows: list[dict[str, Any]]) -> str:
+    """Table E — per-horizon ablation.
+
+    Input rows: comparison, window, metric, U, p, cohens_d, interpretation.
+    """
+    if not ablation_rows:
+        return "_(Table E: no data)_"
+    header = "| comparison | window | metric | U | p | Cohen's d | interpretation |\n"
+    sep    = "|---|---|---|---|---|---|---|\n"
+    body_rows = []
+    for r in ablation_rows:
+        body_rows.append(
+            "| {cmp} | {window} | {metric} | {U} | {p} | {d} | {interp} |".format(
+                cmp=r.get("comparison", ""),
+                window=r.get("window", ""),
+                metric=r.get("metric", ""),
+                U=fmt_sigfig(r.get("U", float("nan"))),
+                p=fmt_pvalue(r.get("p", float("nan"))),
+                d=fmt_effect(r.get("cohens_d", float("nan"))),
+                interp=r.get("interpretation", ""),
+            )
+        )
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_f(regime_rows: list[dict[str, Any]]) -> str:
+    """Table F — volatility regime segmentation.
+
+    Input rows: regime, scenario, metric, mean, std.
+    """
+    if not regime_rows:
+        return "_(Table F: no data)_"
+    # Group metrics into columns for compact rendering.
+    metrics_seen: list[str] = []
+    for r in regime_rows:
+        m = r.get("metric")
+        if m and m not in metrics_seen:
+            metrics_seen.append(m)
+    metric_cols = " | ".join(f"{m} (mean ± std)" for m in metrics_seen)
+    header = f"| regime | scenario | {metric_cols} |\n"
+    sep_cells = ["---"] * (2 + len(metrics_seen))
+    sep = "| " + " | ".join(sep_cells) + " |\n"
+
+    # Build per-(regime, scenario) row.
+    grouped: dict[tuple[str, str], dict[str, tuple[float, float]]] = {}
+    for r in regime_rows:
+        key = (r.get("regime", ""), r.get("scenario", ""))
+        grouped.setdefault(key, {})[r.get("metric", "")] = (
+            r.get("mean", float("nan")), r.get("std", float("nan")),
+        )
+
+    body_rows = []
+    for (regime, scenario), metric_map in sorted(grouped.items()):
+        cells = []
+        for m in metrics_seen:
+            mean, std = metric_map.get(m, (float("nan"), float("nan")))
+            cells.append(f"{fmt_sigfig(mean)} ± {fmt_sigfig(std)}")
+        body_rows.append(f"| {regime} | {scenario} | " + " | ".join(cells) + " |")
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_g(sub_window_rows: list[dict[str, Any]]) -> str:
+    """Table G — sub-window stability.
+
+    Input rows: sub_window, scenario, metric, mean, std.
+    """
+    if not sub_window_rows:
+        return "_(Table G: no data)_"
+    header = "| sub-window | scenario | metric | mean | std |\n"
+    sep    = "|---|---|---|---|---|\n"
+    body_rows = []
+    for r in sub_window_rows:
+        body_rows.append(
+            "| {sw} | {scenario} | {metric} | {mean} | {std} |".format(
+                sw=r.get("sub_window", ""),
+                scenario=r.get("scenario", ""),
+                metric=r.get("metric", ""),
+                mean=fmt_sigfig(r.get("mean", float("nan"))),
+                std=fmt_sigfig(r.get("std", float("nan"))),
+            )
+        )
+    return header + sep + "\n".join(body_rows)
+
+
+def generate_table_h(paper_rows: list[dict[str, Any]]) -> str:
+    """Table H — paper comparison.
+
+    Input rows: metric, paper_value, our_value, abs_diff, rel_diff, agree.
+    """
+    if not paper_rows:
+        return "_(Table H: no data)_"
+    header = "| metric | paper value | this impl (S2, paper-window) | abs diff | rel diff | agree? |\n"
+    sep    = "|---|---|---|---|---|---|\n"
+    body_rows = []
+    for r in paper_rows:
+        body_rows.append(
+            "| {metric} | {paper} | {ours} | {abs_d} | {rel_d} | {agree} |".format(
+                metric=r.get("metric", ""),
+                paper=fmt_sigfig(r.get("paper_value", float("nan"))),
+                ours=fmt_sigfig(r.get("our_value", float("nan"))),
+                abs_d=fmt_sigfig(r.get("abs_diff", float("nan"))),
+                rel_d=fmt_sigfig(r.get("rel_diff", float("nan"))),
+                agree=r.get("agree", "?"),
+            )
+        )
+    return header + sep + "\n".join(body_rows)

--- a/python_refactor/tests/test_experiments_tables.py
+++ b/python_refactor/tests/test_experiments_tables.py
@@ -1,0 +1,170 @@
+"""
+W8-3 tests for table generators A-H.
+
+Smoke + format tests. Each generator gets a minimal-input case + a
+multi-row case to verify Markdown shape + formatting helpers.
+"""
+
+import unittest
+
+from experiments.tables import (
+    fmt_effect,
+    fmt_pvalue,
+    fmt_sigfig,
+    generate_table_a,
+    generate_table_b,
+    generate_table_c,
+    generate_table_d,
+    generate_table_e,
+    generate_table_f,
+    generate_table_g,
+    generate_table_h,
+)
+
+
+class TestFormattingHelpers(unittest.TestCase):
+    """Number-format helpers per ANALYTICS-PLAN.md §7."""
+
+    def test_fmt_sigfig_four_sig_figs(self):
+        self.assertEqual(fmt_sigfig(0.123456, sig=4), "0.1235")
+        self.assertEqual(fmt_sigfig(123.456, sig=4), "123.5")
+        self.assertEqual(fmt_sigfig(1234567.0, sig=4), "1234567")  # large numbers handled
+
+    def test_fmt_sigfig_zero(self):
+        self.assertEqual(fmt_sigfig(0.0), "0")
+
+    def test_fmt_sigfig_nan(self):
+        self.assertEqual(fmt_sigfig(float("nan")), "nan")
+
+    def test_fmt_pvalue_small_renders_lt_001(self):
+        self.assertEqual(fmt_pvalue(0.0005), "<0.001")
+        self.assertEqual(fmt_pvalue(1e-10), "<0.001")
+
+    def test_fmt_pvalue_normal_three_sig_figs(self):
+        result = fmt_pvalue(0.0421)
+        # 3 sig figs of 0.0421 → "0.0421" (or "0.042" depending on rounding)
+        self.assertTrue(result.startswith("0.04"))
+
+    def test_fmt_effect_three_decimals(self):
+        self.assertEqual(fmt_effect(0.7654321), "0.765")
+        self.assertEqual(fmt_effect(-0.5), "-0.500")
+
+
+class TestTableA(unittest.TestCase):
+    def test_empty_input_returns_no_data_marker(self):
+        self.assertIn("no data", generate_table_a([]))
+
+    def test_single_row_renders_full_table(self):
+        rows = [{
+            "scenario": "S0", "window": "paper", "metric": "final_wealth",
+            "mean": 1.12, "std": 0.05, "median": 1.10,
+            "min": 1.00, "max": 1.25, "n_seeds": 30,
+        }]
+        out = generate_table_a(rows)
+        self.assertIn("S0", out)
+        self.assertIn("paper", out)
+        self.assertIn("final_wealth", out)
+        self.assertIn("30", out)  # n_seeds
+        # Markdown table shape
+        self.assertIn("| scenario |", out)
+        self.assertIn("|---|", out)
+
+
+class TestTableB(unittest.TestCase):
+    def test_pairwise_rendering_with_small_p_value(self):
+        rows = [{
+            "pair": "S0 vs S2", "window": "paper", "metric": "final_wealth",
+            "U": 150.0, "p_raw": 0.0001, "p_holm": 0.001,
+            "cohens_d": 0.85, "cliffs_delta": 0.62, "cles": 0.81,
+        }]
+        out = generate_table_b(rows)
+        self.assertIn("S0 vs S2", out)
+        self.assertIn("<0.001", out)  # tiny p formatted as '<0.001'
+        self.assertIn("0.850", out)   # Cohen's d at 3 decimals
+
+
+class TestTableC(unittest.TestCase):
+    def test_anova_row_with_residual(self):
+        rows = [
+            {"window": "paper", "metric": "final_wealth", "source": "Multi-Horizon",
+             "SS": 0.123, "df": 2, "MS": 0.0615, "F": 8.5, "p": 0.001},
+            {"window": "paper", "metric": "final_wealth", "source": "Residual",
+             "SS": 1.234, "df": 87, "MS": 0.0142, "F": float("nan"), "p": float("nan")},
+        ]
+        out = generate_table_c(rows)
+        self.assertIn("Multi-Horizon", out)
+        self.assertIn("Residual", out)
+        self.assertIn("8.5", out)  # F stat
+        self.assertEqual(out.count("\n"), 1 + 1 + 2 - 1)  # header + sep + 2 rows - last has no trailing \n
+
+
+class TestTableD(unittest.TestCase):
+    def test_synergy_with_ci_brackets(self):
+        rows = [{"window": "paper", "metric": "final_wealth",
+                  "delta_interaction": 0.045, "ci_lo": 0.012, "ci_hi": 0.080,
+                  "interpretation": "synergy"}]
+        out = generate_table_d(rows)
+        # 4-sig-fig formatter pads trailing zeros: 0.012 → "0.01200", 0.08 → "0.08000".
+        # Assert the bracket shape + numbers (not the exact substring) so the test
+        # is robust to formatter precision choices.
+        self.assertIn("0.01200", out)
+        self.assertIn("0.08000", out)
+        self.assertIn("[", out)
+        self.assertIn("]", out)
+        self.assertIn("synergy", out)
+
+
+class TestTableE(unittest.TestCase):
+    def test_horizon_ablation_basic(self):
+        rows = [{"comparison": "S2 (H=3) vs S3 (H=2)", "window": "paper",
+                  "metric": "final_wealth", "U": 220.0, "p": 0.02,
+                  "cohens_d": 0.35, "interpretation": "small effect favoring H=3"}]
+        out = generate_table_e(rows)
+        self.assertIn("S2 (H=3) vs S3 (H=2)", out)
+        self.assertIn("small effect", out)
+
+
+class TestTableF(unittest.TestCase):
+    def test_regime_table_groups_metrics_into_columns(self):
+        rows = [
+            {"regime": "low-vol", "scenario": "S0", "metric": "final_wealth",
+              "mean": 1.10, "std": 0.05},
+            {"regime": "low-vol", "scenario": "S0", "metric": "hypv",
+              "mean": 0.85, "std": 0.10},
+            {"regime": "low-vol", "scenario": "S2", "metric": "final_wealth",
+              "mean": 1.15, "std": 0.06},
+            {"regime": "low-vol", "scenario": "S2", "metric": "hypv",
+              "mean": 0.92, "std": 0.09},
+        ]
+        out = generate_table_f(rows)
+        # Header should have both metric columns
+        self.assertIn("final_wealth (mean ± std)", out)
+        self.assertIn("hypv (mean ± std)", out)
+        # Both scenarios present
+        self.assertIn("| low-vol | S0 |", out)
+        self.assertIn("| low-vol | S2 |", out)
+
+
+class TestTableG(unittest.TestCase):
+    def test_sub_window_stability_basic(self):
+        rows = [{"sub_window": "early", "scenario": "S0", "metric": "final_wealth",
+                  "mean": 1.05, "std": 0.03}]
+        out = generate_table_g(rows)
+        self.assertIn("early", out)
+        self.assertIn("S0", out)
+
+
+class TestTableH(unittest.TestCase):
+    def test_paper_comparison_basic(self):
+        rows = [{"metric": "Final wealth (HDM, FTSE)", "paper_value": 1.12,
+                  "our_value": 1.15, "abs_diff": 0.03, "rel_diff": 0.027,
+                  "agree": "agrees"}]
+        out = generate_table_h(rows)
+        self.assertIn("Final wealth (HDM, FTSE)", out)
+        self.assertIn("agrees", out)
+        self.assertIn("1.12", out)
+        self.assertIn("1.15", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 8 Markdown table generators (A-H) per `docs/ANALYTICS-PLAN.md` §7
- 3 number-formatting helpers (fmt_sigfig, fmt_pvalue, fmt_effect)
- 15/15 unit tests PASS

## Files

- `python_refactor/experiments/tables.py` (NEW, ~285 lines)
- `python_refactor/tests/test_experiments_tables.py` (NEW, ~165 lines)
- `.dfg/retrospectives/W8/W8-3.md` (NEW, ADR-004 retro)

## Tables shipped

| Generator | Purpose |
|---|---|
| A | scenario × window × metric → (mean, std, median, min, max, n) |
| B | (scenario_i, scenario_j) × window × metric → (U, p_raw, p_holm, d, δ, CLES) |
| C | window × metric × source → (SS, df, MS, F, p) |
| D | window × metric → (Δ_interaction, 95% CI) |
| E | comparison × window × metric → (U, p, d) |
| F | regime × scenario × metric → mean ± std (grouped into columns) |
| G | sub_window × scenario × metric → mean ± std |
| H | metric → (paper, ours, abs diff, rel diff, agree?) |

## Test plan

- [x] uv run python -m pytest tests/test_experiments_tables.py -v → 15/15 PASS
- [x] Formatting helpers tested against textbook cases
- [x] Each generator tested with a representative minimal row
- [x] Table F tested with multi-metric / multi-scenario input

🤖 Generated with [Claude Code](https://claude.com/claude-code)