### PR TITLE
W8-4: report orchestrator

### DIFF
--- a/.dfg/agents/W8-4-report-orchestrator.md
+++ b/.dfg/agents/W8-4-report-orchestrator.md
@@ -1,0 +1,67 @@
+---
+id: W8-4
+role: tooling-author
+name: Report orchestrator (CSVs → populated VALIDATION-RESULTS.md)
+purpose: "Composes stats + tables; reads summary CSV + per-run metric files; emits a populated copy of VALIDATION-RESULTS.md with 🚧 markers replaced where data exists, preserved where it doesn't."
+wave: W8
+unit: W8-4
+depends_on: ['W8-2', 'W8-3']
+blocks: []
+governance_tier: VT2
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - docs/ANALYTICS-PLAN.md
+    - docs/VALIDATION-RESULTS.md
+    - python_refactor/experiments/stats.py
+    - python_refactor/experiments/tables.py
+    - python_refactor/experiments/aggregate_validation.py
+output_contract:
+  files:
+    - python_refactor/experiments/report.py
+    - python_refactor/tests/test_experiments_report.py
+  branch_name: feat/w8-4-report-orchestrator
+  acceptance: >
+    report.py exposes a CLI accepting --summary, --runs, --template,
+    --output. Reads VALIDATION-SUMMARY.csv + per-run files; computes
+    Tables A-H using experiments.stats + experiments.tables; emits a
+    copy of the template with 🚧 markers replaced where data exists,
+    preserved where it doesn't (graceful incompleteness). Embeds
+    reproducibility receipt block per ANALYTICS-PLAN.md §8 (git SHA,
+    uv lock hash, generated timestamp, n_runs, seeds, command). At
+    least 4 tests covering: end-to-end render with synthetic summary,
+    graceful 🚧-preservation when data is partial, receipt-block
+    population, table substitution.
+dispatch_instructions: |
+  Pure-orchestration layer — no new analytics. Imports from
+  experiments.stats + experiments.tables. Reads the W8-3 table
+  output strings and substitutes them into the template by section
+  header. Receipt block uses subprocess to capture git SHA + hashlib
+  to fingerprint uv.lock.
+---
+
+# W8-4 — Report orchestrator
+
+Composes stats + tables into a populated `VALIDATION-RESULTS.md`.
+
+## Substitution strategy
+
+For each Table A–H section in `VALIDATION-RESULTS.md`:
+1. Locate the section header (e.g. `## 2. Descriptive statistics (Table A)`).
+2. Filter summary rows by the section's expected (scenario, window, metric) tuples.
+3. Call the matching `generate_table_*` from `experiments.tables`.
+4. Replace the placeholder table-of-🚧 in the template with the generated string.
+
+If no rows exist for a section, leave the placeholder intact.
+
+## Receipt block
+
+Populates section §0:
+- `git_sha`: first 8 chars of `git rev-parse HEAD`
+- `uv_lock`: first 16 chars of `sha256(uv.lock)`
+- `generated`: ISO-8601 UTC timestamp
+- `n_runs`: total run count from summary
+- `seeds`: deduplicated seed list from summary
+- `command`: literal CLI string for reproducibility

--- a/.dfg/retrospectives/W8/W8-4.md
+++ b/.dfg/retrospectives/W8/W8-4.md
@@ -1,0 +1,87 @@
+---
+unit: W8-4
+wave: W8
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Pure-orchestration layer composes W8-2 stats + W8-3 tables into a
+  populated VALIDATION-RESULTS.md. ~330 lines of code, 9/9 tests pass,
+  0.9s for the full W8 analytics test suite (40 tests across stats +
+  tables + report).
+
+  Substitution strategy: regex-locate each Table A-H section header,
+  find the first Markdown table block under it, replace contiguous
+  pipe-prefixed lines with the generated string. Sections without
+  data keep their 🚧 placeholders → graceful incompleteness, which
+  is what the contract demanded.
+
+  Builders convert raw summary CSV + per-run buckets into the
+  row-dicts that the W8-3 generators expect. build_table_b_rows
+  runs Mann-Whitney + Cohen's d + Cliff's δ + CLES over all scenario
+  pairs, then Holm-Bonferroni across the family at the end (matches
+  ANALYTICS-PLAN.md §3.1 family-wise control).
+
+  build_table_d_rows implements the synergy contrast Δ_interaction
+  = (S2 − S0) − 2*(S1 − S0) = S2 − 2*S1 + S0, with 10k-bootstrap
+  CI. Verified with a clean signal: S0=1.00, S1=1.05, S2=1.20 →
+  Δ=0.10, CI positive → "synergy".
+
+  Receipt block per ANALYTICS-PLAN §8: git SHA (8 char), uv.lock
+  sha256 fingerprint (16 char), ISO-8601 UTC timestamp, n_runs from
+  summary, seed list (collapsed to [first, ..., last] (N seeds)
+  when > 4), reproducibility command echoed verbatim.
+
+  CLI roundtrip test writes a synthetic summary + 2-run results tree
+  + template to a tempdir, runs main(), reads back the output, and
+  confirms the receipt populates and Table A renders.
+what_didnt: |
+  Tables C/E/F/G/H not wired: ANOVA over Multi-Horizon levels
+  (C), per-horizon ablation (E), regime segmentation (F), sub-window
+  stability (G), and paper-comparison (H) all need per-run inputs
+  the W7-1 scaffold doesn't yet emit (regime tags, sub-window splits,
+  paper-Table-I values). The generators are ready (W8-3); the
+  builders are stubs that return [] → the template keeps its 🚧
+  markers for those sections. Filed as W8-CARRY-3 (analytics-builder
+  completion) — not blocking wave-close because the orchestrator's
+  contract is "graceful incompleteness."
+
+  Bootstrap CI in build_table_d_rows uses independent resampling
+  per scenario, not paired-by-seed. If seeds align across scenarios
+  (which W7-1 does enforce), a paired bootstrap would be tighter.
+  Filed as part of W8-CARRY-3.
+what_to_change: |
+  None at this unit's level. The orchestrator's contract is to wire
+  what's wireable and leave the rest gracefully unfilled. C/E/F/G/H
+  are W8-CARRY-3 deliverables for the next wave.
+new_carries: |
+  - W8-CARRY-3: complete builders for Tables C, E, F, G, H once
+    W7-1 emits the inputs they need (per-horizon ablation, regime
+    tags, sub-window splits, paper-Table-I gold values). Includes
+    paired-by-seed bootstrap upgrade for Table D.
+scars_carried_forward: |
+  W8-1-CARRY-1 (paper-window data loader) and W8-1-CARRY-2 (src/
+  bool(DataFrame) cascade) unchanged — independent of W8-4.
+---
+
+# W8-4 — Report orchestrator
+
+## What changed
+
+- `python_refactor/experiments/report.py` (NEW, ~330 lines)
+  - Summary CSV + per-run-tree readers
+  - Builders for Tables A, B, D (C/E/F/G/H stubbed → 🚧 preserved)
+  - Receipt block per ANALYTICS-PLAN §8
+  - Template-substitution engine
+  - CLI: `--summary --runs --template --output [--repo-root]`
+- `python_refactor/tests/test_experiments_report.py` (NEW, ~165 lines, 9 tests)
+
+## Verification
+
+- 9/9 unit tests PASS
+- 40/40 PASS across full W8 analytics suite (stats + tables + report) in 0.9s
+- CLI roundtrip with synthetic 2-run tree → populated output with
+  receipt + Table A
+
+## Carries
+
+- W8-CARRY-3 (new): Tables C/E/F/G/H builders + paired-by-seed bootstrap for D

--- a/python_refactor/experiments/report.py
+++ b/python_refactor/experiments/report.py
@@ -1,0 +1,390 @@
+"""
+W8-4 report orchestrator.
+
+Composes the W8 analytics layer (stats helpers + table generators)
+into a populated VALIDATION-RESULTS.md.
+
+Reads:
+    - VALIDATION-SUMMARY.csv  (from aggregate_validation.py)
+    - results/                (per-run metrics.csv + manifest.json tree)
+    - docs/VALIDATION-RESULTS.md  (template with 🚧 placeholders)
+
+Writes:
+    - docs/VALIDATION-RESULTS.populated.md
+
+Substitution strategy:
+    For each Table A-H section in the template, locate the section
+    header, build the corresponding data rows from the summary CSV /
+    pairwise tests / per-run files, call generate_table_X from
+    experiments.tables, and replace the placeholder table body with
+    the generated string. Sections with no data keep their 🚧
+    placeholders (graceful incompleteness).
+
+Receipt block per ANALYTICS-PLAN.md §8 populates section §0 with
+git SHA + uv.lock fingerprint + generated timestamp + n_runs +
+seed list + reproducibility command.
+
+CLI:
+    python -m experiments.report \\
+        --summary docs/VALIDATION-SUMMARY.csv \\
+        --runs results/ \\
+        --template docs/VALIDATION-RESULTS.md \\
+        --output docs/VALIDATION-RESULTS.populated.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as _dt
+import hashlib
+import itertools
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from experiments import stats, tables
+
+
+# ---------------------------------------------------------------------------
+# Summary CSV reader
+# ---------------------------------------------------------------------------
+
+def read_summary(summary_path: Path) -> list[dict[str, Any]]:
+    """Read VALIDATION-SUMMARY.csv emitted by aggregate_validation.py.
+
+    Returns a list of row-dicts with numeric fields coerced to float
+    where possible.
+    """
+    rows: list[dict[str, Any]] = []
+    if not summary_path.exists():
+        return rows
+    with summary_path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            for k in ("mean", "std", "median", "min", "max"):
+                if k in row and row[k] != "":
+                    try:
+                        row[k] = float(row[k])
+                    except (TypeError, ValueError):
+                        pass
+            if "n_seeds" in row and row["n_seeds"] != "":
+                try:
+                    row["n_seeds"] = int(row["n_seeds"])
+                except (TypeError, ValueError):
+                    pass
+            rows.append(row)
+    return rows
+
+
+def read_run_values(runs_root: Path) -> dict[tuple[str, str, str], list[tuple[int, float]]]:
+    """Walk runs_root and collect per-(scenario, window, metric) → [(seed, value)].
+
+    Mirrors aggregate_validation.collect_metrics but keeps per-seed values
+    needed for pairwise tests / synergy contrast / bootstrap CI.
+    """
+    bucket: dict[tuple[str, str, str], list[tuple[int, float]]] = {}
+    if not runs_root.exists():
+        return bucket
+    for run_dir in sorted(runs_root.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        manifest_path = run_dir / "manifest.json"
+        metrics_path = run_dir / "metrics.csv"
+        if not manifest_path.exists() or not metrics_path.exists():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if manifest.get("status") != "ok":
+            continue
+        with metrics_path.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                key = (row.get("scenario", ""), row.get("window", ""), row.get("metric", ""))
+                try:
+                    value = float(row.get("value", "nan"))
+                    seed = int(row.get("seed", "0"))
+                except (TypeError, ValueError):
+                    continue
+                bucket.setdefault(key, []).append((seed, value))
+    return bucket
+
+
+# ---------------------------------------------------------------------------
+# Builders — turn summary + per-run buckets into the row-dicts that the
+# Table A-H generators expect.
+# ---------------------------------------------------------------------------
+
+def build_table_a_rows(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Table A — pass through summary CSV rows verbatim."""
+    return list(summary)
+
+
+def build_table_b_rows(per_run: dict[tuple[str, str, str], list[tuple[int, float]]],
+                        scenario_pairs: list[tuple[str, str]] | None = None,
+                        windows: list[str] | None = None,
+                        metrics: list[str] | None = None) -> list[dict[str, Any]]:
+    """Table B — pairwise Mann-Whitney U + effect sizes.
+
+    Iterates all (pair, window, metric) combinations present in `per_run`.
+    Applies Holm-Bonferroni correction across the family at the end.
+    """
+    if scenario_pairs is None:
+        scenarios = sorted({s for (s, _, _) in per_run.keys()})
+        scenario_pairs = list(itertools.combinations(scenarios, 2))
+    if windows is None:
+        windows = sorted({w for (_, w, _) in per_run.keys()})
+    if metrics is None:
+        metrics = sorted({m for (_, _, m) in per_run.keys()})
+
+    raw: list[dict[str, Any]] = []
+    p_values: list[float] = []
+    for (s_i, s_j), window, metric in itertools.product(scenario_pairs, windows, metrics):
+        x = [v for (_, v) in per_run.get((s_i, window, metric), [])]
+        y = [v for (_, v) in per_run.get((s_j, window, metric), [])]
+        if len(x) < 2 or len(y) < 2:
+            continue
+        U, p_raw = stats.mann_whitney_u(x, y)
+        d = stats.cohens_d(x, y)
+        delta = stats.cliffs_delta(x, y)
+        # CLES = P(X > Y) — same definition as U / (n_x * n_y).
+        cles = float(U) / (len(x) * len(y))
+        raw.append({
+            "pair": f"{s_i} vs {s_j}", "window": window, "metric": metric,
+            "U": U, "p_raw": p_raw, "p_holm": p_raw,  # filled below
+            "cohens_d": d, "cliffs_delta": delta, "cles": cles,
+        })
+        p_values.append(p_raw)
+
+    if p_values:
+        adjusted = stats.holm_bonferroni(p_values)
+        for row, p_adj in zip(raw, adjusted):
+            row["p_holm"] = p_adj
+    return raw
+
+
+def build_table_d_rows(per_run: dict[tuple[str, str, str], list[tuple[int, float]]],
+                        windows: list[str] | None = None,
+                        metrics: list[str] | None = None,
+                        n_bootstrap: int = 10_000) -> list[dict[str, Any]]:
+    """Table D — synergy contrast Δ_interaction = (S2 − S0) − (S1 − S0).
+
+    Hardcodes the S0/S1/S2 triplet from ANALYTICS-PLAN.md §4.2; if any of
+    the three is missing for a given (window, metric), the row is skipped.
+    """
+    if windows is None:
+        windows = sorted({w for (_, w, _) in per_run.keys()})
+    if metrics is None:
+        metrics = sorted({m for (_, _, m) in per_run.keys()})
+
+    rows: list[dict[str, Any]] = []
+    for window, metric in itertools.product(windows, metrics):
+        s0_vals = [v for (_, v) in per_run.get(("S0", window, metric), [])]
+        s1_vals = [v for (_, v) in per_run.get(("S1", window, metric), [])]
+        s2_vals = [v for (_, v) in per_run.get(("S2", window, metric), [])]
+        if not (s0_vals and s1_vals and s2_vals):
+            continue
+        delta = (sum(s2_vals) / len(s2_vals)) - 2 * (sum(s1_vals) / len(s1_vals)) + (sum(s0_vals) / len(s0_vals))
+        # Bootstrap CI on the contrast — resample each scenario's seed pool
+        # independently. Cheap version: pool deltas at scenario means via
+        # bootstrap_ci on a fabricated delta-sample (1 value); replaced
+        # by per-pair seed pairing if seeds align in a later iteration.
+        import numpy as np
+        rng = np.random.default_rng(0)
+        n = min(len(s0_vals), len(s1_vals), len(s2_vals))
+        deltas = np.empty(n_bootstrap)
+        s0_arr = np.asarray(s0_vals)
+        s1_arr = np.asarray(s1_vals)
+        s2_arr = np.asarray(s2_vals)
+        for i in range(n_bootstrap):
+            i0 = rng.integers(0, len(s0_arr), n)
+            i1 = rng.integers(0, len(s1_arr), n)
+            i2 = rng.integers(0, len(s2_arr), n)
+            deltas[i] = s2_arr[i2].mean() - 2 * s1_arr[i1].mean() + s0_arr[i0].mean()
+        ci_lo, ci_hi = float(np.percentile(deltas, 2.5)), float(np.percentile(deltas, 97.5))
+        if ci_lo > 0:
+            interp = "synergy"
+        elif ci_hi < 0:
+            interp = "sub-additive"
+        else:
+            interp = "additive (CI spans 0)"
+        rows.append({
+            "window": window, "metric": metric,
+            "delta_interaction": delta, "ci_lo": ci_lo, "ci_hi": ci_hi,
+            "interpretation": interp,
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Receipt block
+# ---------------------------------------------------------------------------
+
+def _git_sha(repo_root: Path) -> str:
+    try:
+        out = subprocess.check_output(["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+                                       stderr=subprocess.DEVNULL).decode().strip()
+        return out[:8]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _uv_lock_sha(repo_root: Path) -> str:
+    lock = repo_root / "uv.lock"
+    if not lock.exists():
+        # Try python_refactor/uv.lock as fallback (per W6-1).
+        lock = repo_root / "python_refactor" / "uv.lock"
+    if not lock.exists():
+        return "unknown"
+    return hashlib.sha256(lock.read_bytes()).hexdigest()[:16]
+
+
+def build_receipt_block(summary: list[dict[str, Any]],
+                         repo_root: Path,
+                         command: str | None = None,
+                         now: _dt.datetime | None = None) -> str:
+    """Build the §0 reproducibility-receipt block per ANALYTICS-PLAN §8."""
+    if now is None:
+        now = _dt.datetime.now(_dt.timezone.utc)
+    seeds: set[int] = set()
+    for r in summary:
+        for s in str(r.get("seeds_used", "")).split(","):
+            s = s.strip()
+            if s.isdigit():
+                seeds.add(int(s))
+    n_runs = sum(int(r.get("n_seeds", 0) or 0) for r in summary)
+    seeds_list = sorted(seeds)
+    seeds_str = (f"[{seeds_list[0]}, ..., {seeds_list[-1]}] ({len(seeds_list)} seeds)"
+                  if len(seeds_list) > 4 else str(seeds_list))
+    cmd = command or "python -m experiments.report --summary docs/VALIDATION-SUMMARY.csv --runs results/ --template docs/VALIDATION-RESULTS.md --output docs/VALIDATION-RESULTS.populated.md"
+    return (
+        "```\n"
+        f"git_sha:    {_git_sha(repo_root)}\n"
+        f"uv_lock:    sha256:{_uv_lock_sha(repo_root)}\n"
+        f"generated:  {now.strftime('%Y-%m-%dT%H:%M:%SZ')}\n"
+        f"n_runs:     {n_runs}\n"
+        f"seeds:      {seeds_str}\n"
+        f"command:    {cmd}\n"
+        "```"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Template substitution
+# ---------------------------------------------------------------------------
+
+# Each section is identified by its header. Mapping: header pattern → (builder, generator).
+_SECTION_MAP: list[tuple[str, str]] = [
+    (r"## 2\. Descriptive statistics \(Table A\)", "A"),
+    (r"### 3\.1 Pairwise scenario comparison \(Table B\)", "B"),
+    (r"### 4\.1 One-way ANOVA over Multi-Horizon levels \(Table C\)", "C"),
+    (r"### 4\.2 Synergy contrast \(Table D\)", "D"),
+    (r"### 4\.3 Per-horizon ablation \(Table E\)", "E"),
+    (r"### 5\.2 By volatility regime \(Table F \+ Figure F10\)", "F"),
+    (r"### 5\.3 By sub-window \(Table G\)", "G"),
+    (r"## 7\. Paper-comparison receipt \(Table H\)", "H"),
+]
+
+
+def _replace_table_block(template: str, section_pattern: str, new_table: str) -> str:
+    """Replace the Markdown-table block following `section_pattern`.
+
+    Locates the section header, then finds the first Markdown table
+    (line starting with `|`) below it, and replaces the contiguous
+    table block with `new_table`. If no header / no table found,
+    returns the template unchanged.
+    """
+    m = re.search(section_pattern, template)
+    if not m:
+        return template
+    # Find the first table line at or after the header.
+    rest = template[m.end():]
+    table_start_match = re.search(r"^\|", rest, re.MULTILINE)
+    if not table_start_match:
+        return template
+    abs_start = m.end() + table_start_match.start()
+    # Find the end of the table — first non-table line (blank or non-|).
+    lines = template[abs_start:].split("\n")
+    end_offset = 0
+    for line in lines:
+        if line.startswith("|") or line.strip() == "":
+            end_offset += len(line) + 1
+            if line.strip() == "" and end_offset > 1:
+                # blank line ends the table
+                end_offset -= 1
+                break
+        else:
+            break
+    # Trim the trailing blank line we may have consumed.
+    abs_end = abs_start + end_offset
+    return template[:abs_start] + new_table + "\n" + template[abs_end:]
+
+
+def populate(template: str,
+              summary: list[dict[str, Any]],
+              per_run: dict[tuple[str, str, str], list[tuple[int, float]]],
+              receipt: str) -> str:
+    """Populate the template, replacing placeholders where data exists."""
+    out = template
+
+    # Receipt block — replace section §0 fenced block.
+    receipt_pattern = re.compile(r"```\ngit_sha:.*?```", re.DOTALL)
+    if receipt_pattern.search(out):
+        out = receipt_pattern.sub(receipt, out)
+
+    # Table generators keyed by letter.
+    gen_map = {
+        "A": (tables.generate_table_a, build_table_a_rows(summary)),
+        "B": (tables.generate_table_b, build_table_b_rows(per_run)),
+        # C, E, F, G, H require per-run extras (ANOVA / ablation / regimes /
+        # sub-windows / paper comparison) that aren't yet emitted by the
+        # W7-1 scaffold — leave 🚧 markers intact (graceful incompleteness).
+        "D": (tables.generate_table_d, build_table_d_rows(per_run)),
+    }
+
+    for pattern, letter in _SECTION_MAP:
+        gen, rows = gen_map.get(letter, (None, []))
+        if gen is None or not rows:
+            continue
+        rendered = gen(rows)
+        out = _replace_table_block(out, pattern, rendered)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="W8-4 validation-results report orchestrator.")
+    parser.add_argument("--summary", type=Path, required=True,
+                          help="VALIDATION-SUMMARY.csv path")
+    parser.add_argument("--runs", type=Path, required=True,
+                          help="results/ tree root (per-seed manifests + metrics)")
+    parser.add_argument("--template", type=Path, required=True,
+                          help="VALIDATION-RESULTS.md template path")
+    parser.add_argument("--output", type=Path, required=True,
+                          help="populated output file path")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(),
+                          help="repo root for git SHA + uv.lock fingerprint")
+    args = parser.parse_args(argv)
+
+    summary = read_summary(args.summary)
+    per_run = read_run_values(args.runs)
+    template = args.template.read_text()
+    receipt = build_receipt_block(summary, args.repo_root)
+    populated = populate(template, summary, per_run, receipt)
+    args.output.write_text(populated)
+    print(f"[report] wrote {args.output} ({len(populated)} bytes, "
+          f"{len(summary)} summary rows, {sum(len(v) for v in per_run.values())} per-run values)",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/python_refactor/tests/test_experiments_report.py
+++ b/python_refactor/tests/test_experiments_report.py
@@ -1,0 +1,225 @@
+"""
+W8-4 tests for the report orchestrator.
+
+Synthetic-fixture tests: build a minimal summary CSV + per-run tree
++ template, run `populate`, and assert that placeholders are
+replaced where data exists and preserved where it doesn't.
+"""
+
+import csv
+import datetime as _dt
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from experiments import report
+
+
+def _write_summary(path: Path, rows: list[dict]) -> None:
+    fieldnames = ["scenario", "window", "metric", "n_seeds", "seeds_used",
+                  "mean", "std", "median", "min", "max"]
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def _write_run(run_root: Path, scenario: str, window: str, seed: int,
+                metrics: dict[str, float]) -> None:
+    run_dir = run_root / f"{scenario}_{window}_seed{seed}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "manifest.json").write_text(json.dumps({"status": "ok"}))
+    with (run_dir / "metrics.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["scenario", "window", "seed", "metric", "value"])
+        for metric, val in metrics.items():
+            w.writerow([scenario, window, seed, metric, val])
+
+
+# ---------------------------------------------------------------------------
+# Receipt block
+# ---------------------------------------------------------------------------
+
+class TestReceiptBlock(unittest.TestCase):
+    def test_receipt_block_populates_all_fields(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            summary = [
+                {"scenario": "S0", "window": "paper", "metric": "final_wealth",
+                  "n_seeds": 3, "seeds_used": "1,2,3", "mean": 1.0, "std": 0.0,
+                  "median": 1.0, "min": 1.0, "max": 1.0},
+                {"scenario": "S2", "window": "paper", "metric": "final_wealth",
+                  "n_seeds": 3, "seeds_used": "1,2,3", "mean": 1.1, "std": 0.01,
+                  "median": 1.1, "min": 1.0, "max": 1.2},
+            ]
+            now = _dt.datetime(2026, 5, 17, 3, 45, 0, tzinfo=_dt.timezone.utc)
+            block = report.build_receipt_block(summary, tmpdir, command="X", now=now)
+            self.assertIn("git_sha:", block)
+            self.assertIn("uv_lock:", block)
+            self.assertIn("2026-05-17T03:45:00Z", block)
+            self.assertIn("n_runs:     6", block)  # 3 + 3
+            self.assertIn("[1, 2, 3]", block)
+            self.assertIn("X", block)  # command echoed
+
+    def test_receipt_block_handles_empty_summary(self):
+        with TemporaryDirectory() as tmp:
+            block = report.build_receipt_block([], Path(tmp))
+            self.assertIn("n_runs:     0", block)
+            self.assertIn("seeds:      []", block)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+class TestBuilders(unittest.TestCase):
+    def test_build_table_a_passes_summary_through(self):
+        summary = [{"scenario": "S0", "window": "paper", "metric": "final_wealth",
+                     "mean": 1.0, "std": 0.0, "n_seeds": 3}]
+        rows = report.build_table_a_rows(summary)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["scenario"], "S0")
+
+    def test_build_table_b_runs_pairwise_with_holm(self):
+        per_run = {
+            ("S0", "paper", "final_wealth"): [(s, 1.0 + 0.001 * s) for s in range(1, 11)],
+            ("S2", "paper", "final_wealth"): [(s, 1.1 + 0.001 * s) for s in range(1, 11)],
+        }
+        rows = report.build_table_b_rows(per_run)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["pair"], "S0 vs S2")
+        self.assertIn("p_raw", rows[0])
+        self.assertIn("p_holm", rows[0])
+        # Single test → Holm == raw
+        self.assertAlmostEqual(rows[0]["p_holm"], rows[0]["p_raw"], places=10)
+        # CLES ∈ [0,1]
+        self.assertGreaterEqual(rows[0]["cles"], 0.0)
+        self.assertLessEqual(rows[0]["cles"], 1.0)
+
+    def test_build_table_d_synergy_with_clean_signal(self):
+        # Construct data with positive synergy: S2 − 2*S1 + S0 > 0.
+        per_run = {
+            ("S0", "paper", "final_wealth"): [(s, 1.00) for s in range(1, 11)],
+            ("S1", "paper", "final_wealth"): [(s, 1.05) for s in range(1, 11)],
+            ("S2", "paper", "final_wealth"): [(s, 1.20) for s in range(1, 11)],
+        }
+        rows = report.build_table_d_rows(per_run, n_bootstrap=200)
+        self.assertEqual(len(rows), 1)
+        # Δ = 1.20 - 2*1.05 + 1.00 = 0.10 > 0 → synergy
+        self.assertAlmostEqual(rows[0]["delta_interaction"], 0.10, places=4)
+        self.assertEqual(rows[0]["interpretation"], "synergy")
+
+    def test_build_table_d_skips_when_triplet_missing(self):
+        per_run = {
+            ("S0", "paper", "final_wealth"): [(s, 1.0) for s in range(1, 5)],
+            # No S1, no S2.
+        }
+        rows = report.build_table_d_rows(per_run, n_bootstrap=100)
+        self.assertEqual(rows, [])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end populate
+# ---------------------------------------------------------------------------
+
+class TestPopulate(unittest.TestCase):
+    TEMPLATE = """# Validation results
+
+## 0. Reproducibility receipt
+
+```
+git_sha:    🚧
+uv_lock:    🚧
+generated:  🚧
+n_runs:     🚧
+seeds:      🚧
+command:    python -m experiments.report
+```
+
+## 2. Descriptive statistics (Table A)
+
+| scenario | window | metric | mean | std | median | IQR | n |
+|---|---|---|---|---|---|---|---|
+| S0 | paper | final_wealth | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
+| S2 | paper | final_wealth | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
+
+## 9. Honest scars
+
+🚧 nothing yet.
+"""
+
+    def test_populate_replaces_receipt_and_table_a(self):
+        summary = [
+            {"scenario": "S0", "window": "paper", "metric": "final_wealth",
+              "mean": 1.0, "std": 0.0, "median": 1.0, "min": 1.0, "max": 1.0,
+              "n_seeds": 3, "seeds_used": "1,2,3"},
+            {"scenario": "S2", "window": "paper", "metric": "final_wealth",
+              "mean": 1.12, "std": 0.05, "median": 1.10, "min": 1.05, "max": 1.20,
+              "n_seeds": 3, "seeds_used": "1,2,3"},
+        ]
+        receipt = report.build_receipt_block(summary, Path("."))
+        out = report.populate(self.TEMPLATE, summary, {}, receipt)
+
+        # Receipt populated — placeholders gone in §0.
+        self.assertNotIn("git_sha:    🚧", out)
+        self.assertIn("n_runs:     6", out)
+
+        # Table A populated — has S0 + S2 cells with concrete numbers.
+        self.assertIn("| S0 | paper | final_wealth", out)
+        self.assertIn("1.12", out)
+        # Table A header rendered by generator.
+        self.assertIn("| scenario | window | metric | mean | std | median | min | max | n |", out)
+
+        # Section §9 untouched (graceful incompleteness).
+        self.assertIn("🚧 nothing yet.", out)
+
+    def test_populate_preserves_template_when_no_data(self):
+        # Empty summary + empty per_run → template structure preserved, only
+        # the receipt block is touched.
+        receipt = report.build_receipt_block([], Path("."))
+        out = report.populate(self.TEMPLATE, [], {}, receipt)
+        # Table A placeholders intact.
+        self.assertIn("| S0 | paper | final_wealth | 🚧", out)
+        self.assertIn("| S2 | paper | final_wealth | 🚧", out)
+        # Receipt populated even when summary is empty.
+        self.assertNotIn("git_sha:    🚧", out)
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+class TestCLIRoundtrip(unittest.TestCase):
+    def test_main_reads_writes_end_to_end(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            # Build fixtures.
+            summary_path = tmpdir / "summary.csv"
+            _write_summary(summary_path, [
+                {"scenario": "S0", "window": "paper", "metric": "final_wealth",
+                  "n_seeds": 2, "seeds_used": "1,2", "mean": 1.00, "std": 0.01,
+                  "median": 1.00, "min": 0.99, "max": 1.01},
+            ])
+            runs_dir = tmpdir / "results"
+            _write_run(runs_dir, "S0", "paper", 1, {"final_wealth": 0.99})
+            _write_run(runs_dir, "S0", "paper", 2, {"final_wealth": 1.01})
+            template_path = tmpdir / "template.md"
+            template_path.write_text(TestPopulate.TEMPLATE)
+            output_path = tmpdir / "out.md"
+            rc = report.main([
+                "--summary", str(summary_path),
+                "--runs", str(runs_dir),
+                "--template", str(template_path),
+                "--output", str(output_path),
+                "--repo-root", str(tmpdir),
+            ])
+            self.assertEqual(rc, 0)
+            out = output_path.read_text()
+            self.assertIn("n_runs:     2", out)
+            self.assertIn("| S0 | paper | final_wealth", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Pure-orchestration layer composing W8-2 stats + W8-3 tables into a populated copy of `VALIDATION-RESULTS.md`
- Graceful incompleteness: cells with data get computed values; cells without keep their 🚧 markers
- Receipt block (§0) per `ANALYTICS-PLAN.md` §8 — git SHA + uv.lock fingerprint + n_runs + seeds + command

## Files

- `python_refactor/experiments/report.py` (NEW, ~330 lines)
- `python_refactor/tests/test_experiments_report.py` (NEW, ~165 lines, 9 tests)
- `.dfg/retrospectives/W8/W8-4.md` (NEW, ADR-004 retro)

## Tables wired

| Table | Status | Notes |
|---|---|---|
| A descriptive | ✓ | from summary CSV |
| B pairwise | ✓ | Mann-Whitney + Cohen's d + Cliff's δ + CLES + Holm-Bonferroni |
| C ANOVA | stub | needs per-horizon ablation inputs (W8-CARRY-3) |
| D synergy | ✓ | 10k-bootstrap CI on Δ = S2 − 2*S1 + S0 |
| E ablation | stub | W8-CARRY-3 |
| F regimes | stub | needs regime tags (W8-CARRY-3) |
| G sub-window | stub | needs sub-window splits (W8-CARRY-3) |
| H paper | stub | needs paper-Table-I gold values (W8-CARRY-3) |

## CLI

```bash
python -m experiments.report \\
    --summary docs/VALIDATION-SUMMARY.csv \\
    --runs results/ \\
    --template docs/VALIDATION-RESULTS.md \\
    --output docs/VALIDATION-RESULTS.populated.md
```

## Test plan

- [x] 9/9 unit tests PASS
- [x] 40/40 PASS across W8 analytics (stats + tables + report) in 0.9s
- [x] CLI roundtrip with synthetic 2-run results tree → populated output

## Carries

- W8-CARRY-3 (new): C/E/F/G/H builders + paired-by-seed bootstrap for D

🤖 Generated with [Claude Code](https://claude.com/claude-code)