### PR TITLE
W9-1: fix bool(DataFrame) at experiment_manager.py:190

### DIFF
--- a/.dfg/agents/W9-1-experiment-manager-bool-dataframe-fix.md
+++ b/.dfg/agents/W9-1-experiment-manager-bool-dataframe-fix.md
@@ -1,0 +1,40 @@
+---
+id: W9-1
+role: code-fixer
+name: Fix bool(DataFrame) ambiguity at experiment_manager.py:190
+purpose: "Closes W8-1-CARRY-2 partial. `if asset_data:` on a DataFrame raises ValueError; replace with explicit emptiness check."
+wave: W9
+unit: W9-1
+depends_on: []
+blocks: [W9-4]
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/experiments/experiment_manager.py
+output_contract:
+  files:
+    - python_refactor/src/experiments/experiment_manager.py
+    - python_refactor/tests/test_experiments_experiment_manager.py
+  branch_name: feat/w9-1-experiment-manager-bool-dataframe-fix
+  acceptance: >
+    Line 190 no longer triggers ValueError. num_assets log field
+    reports the column count for an asset DataFrame; 0 when None or empty.
+    >= 1 regression test that exercises the path without raising.
+dispatch_instructions: |
+  Surgical fix: line 190 changes from
+    'num_assets': len(asset_data) if asset_data else 0
+  to
+    'num_assets': 0 if asset_data is None or asset_data.empty else len(asset_data.columns)
+
+  What NOT to do:
+    - Don't refactor the surrounding _load_experiment_data method.
+    - Don't add type hints unrelated to the fix.
+    - Don't touch data_loader.py (that's W9-2).
+---
+
+# W9-1 — bool(DataFrame) fix
+
+One-line fix at experiment_manager.py:190 + regression test.

--- a/.dfg/retrospectives/W9/W9-1.md
+++ b/.dfg/retrospectives/W9/W9-1.md
@@ -1,0 +1,60 @@
+---
+unit: W9-1
+wave: W9
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Surgical 6-line fix at experiment_manager.py:189-200. Replaces
+  `len(asset_data) if asset_data else 0` with explicit
+  `None or .empty` guard and uses `len(asset_data.columns)` to count
+  assets (one per column post-pivot — the semantically correct count
+  for a "num_assets" log field).
+
+  3 regression tests cover the path: non-empty DataFrame (2 columns →
+  num_assets=2), empty DataFrame (0), None (0). All PASS in 0.72s.
+
+  Used unittest.mock to inject a stub data_loader so the test
+  exercises only the line-190 site without dragging in the rest of
+  the data pipeline (which W9-2 is fixing).
+what_broke: |
+  Nothing. Smallest possible unit; the fix is mechanical and the
+  pre-existing test suite still passes.
+what_youd_change: |
+  Could have batched in lint-pass cleanups of similar bool(DataFrame)
+  patterns elsewhere in the file, but per dispatch_instructions
+  "Don't refactor the surrounding method" — kept scope minimal.
+  If `grep -n 'if.*data_frame:' src/` surfaces more, file as a
+  separate cleanup unit.
+assumption_to_challenge: |
+  Assumed: `num_assets` should report the column count (one column
+  per asset post-pivot). CHALLENGE: pre-W9-2 the pivot is broken,
+  so `asset_data` may NOT have one-column-per-asset shape until
+  W9-2 lands. After W9-2, this assumption holds; pre-W9-2 the
+  smoke-test still crashes downstream in data_loader so the log
+  message never fires.
+
+  This partially closes W8-1-CARRY-2 (the bool(DataFrame) sub-bug).
+  W9-2 closes the pivot sub-bug. W9-4 verifies the cascade is
+  resolved by re-running W8-1's smoke-test end-to-end.
+
+  Scars carried forward:
+  - W7-1-CARRY-1 still open (closes in W9-4).
+  - W8-1-CARRY-1, W8-1-CARRY-2 (other half) still open (close in W9-2).
+  - W8-CARRY-3 still open.
+---
+
+# W9-1 — bool(DataFrame) fix at experiment_manager.py:190
+
+## What changed
+
+- `python_refactor/src/experiments/experiment_manager.py` (modified): 6-line surgical fix at lines 189-200
+- `python_refactor/tests/test_experiments_experiment_manager.py` (NEW, 3 tests)
+
+## Verification
+
+- 3/3 regression tests PASS in 0.72s
+- Pre-existing test suite unaffected (line touched the bool truthiness check only)
+
+## Closes (partial)
+
+- W8-1-CARRY-2 — the experiment_manager.py:190 half of the src/ cascade

--- a/python_refactor/src/experiments/experiment_manager.py
+++ b/python_refactor/src/experiments/experiment_manager.py
@@ -186,8 +186,16 @@ class ExperimentManager:
             'config': data_config
         }
         
+        # W9-1: explicit None/empty check — `if asset_data:` calls
+        # DataFrame.__bool__ which raises ValueError ("ambiguous").
+        # `num_assets` reports the column count (one column per asset
+        # after the data_loader pivot in W9-2).
+        if asset_data is None or asset_data.empty:
+            num_assets = 0
+        else:
+            num_assets = len(asset_data.columns)
         self.logger.log('data', 'INFO', 'Data loading completed', {
-            'num_assets': len(asset_data) if asset_data else 0,
+            'num_assets': num_assets,
             'data_period': data_config.get('date_range', {})
         })
         

--- a/python_refactor/tests/test_experiments_experiment_manager.py
+++ b/python_refactor/tests/test_experiments_experiment_manager.py
@@ -1,0 +1,76 @@
+"""
+W9-1 regression tests for experiment_manager.py.
+
+Pins the fix for `bool(DataFrame)` ambiguity at line 190 (was 189
+pre-W9-1): `if asset_data:` on a pandas.DataFrame raises ValueError.
+The W9-1 fix replaces with explicit `None or .empty` check and counts
+columns (one per asset) instead of rows.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from src.experiments.experiment_manager import ExperimentManager
+
+
+def _make_manager(tmp_path):
+    suite_config = {
+        "experiment_name": "W9-1-regression",
+        "description": "bool(DataFrame) fix",
+        "version": "W9-1",
+        "timestamp": "2026-05-17T00:00:00Z",
+        "output_directory": str(tmp_path),
+    }
+    return ExperimentManager(suite_config)
+
+
+class TestBoolDataFrameFix(unittest.TestCase):
+    """W9-1: line 190 must not raise ValueError on DataFrame input."""
+
+    def setUp(self):
+        # ExperimentManager constructs an output dir; use a per-test tempdir.
+        from tempfile import mkdtemp
+        from pathlib import Path
+        self.tmp = Path(mkdtemp(prefix="w9-1-"))
+        self.mgr = _make_manager(self.tmp)
+
+    def _load_with(self, asset_df):
+        """Helper: call _load_experiment_data with a mocked data_loader
+        whose load_asset_data returns `asset_df` and load_market_data
+        returns an empty DataFrame. Exercises the bool(DataFrame) site."""
+        self.mgr.data_loader = MagicMock()
+        self.mgr.data_loader.load_asset_data.return_value = asset_df
+        self.mgr.data_loader.load_market_data.return_value = pd.DataFrame()
+        self.mgr.logger = MagicMock()
+        cfg = {"data": {"asset_files": [], "date_range": {}, "assets": [],
+                          "market_files": []}}
+        # Just exercise the path that used to raise.
+        return self.mgr._load_experiment_data(cfg)
+
+    def test_non_empty_dataframe_does_not_raise(self):
+        df = pd.DataFrame({"AAPL": [1.0, 2.0], "GOOG": [3.0, 4.0]})
+        data = self._load_with(df)
+        # num_assets logged as column count (2 assets), not row count.
+        log_call = self.mgr.logger.log.call_args_list[-1]
+        log_payload = log_call[0][3]
+        self.assertEqual(log_payload["num_assets"], 2)
+        self.assertIs(data["assets"], df)
+
+    def test_empty_dataframe_logs_zero_assets(self):
+        df = pd.DataFrame()
+        self._load_with(df)
+        log_call = self.mgr.logger.log.call_args_list[-1]
+        log_payload = log_call[0][3]
+        self.assertEqual(log_payload["num_assets"], 0)
+
+    def test_none_logs_zero_assets(self):
+        self._load_with(None)
+        log_call = self.mgr.logger.log.call_args_list[-1]
+        log_payload = log_call[0][3]
+        self.assertEqual(log_payload["num_assets"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 6-line surgical fix at `experiment_manager.py:189-200` replacing DataFrame truthiness with explicit `None or .empty` check
- 3 regression tests pin the path (non-empty / empty / None)
- Partially closes W8-1-CARRY-2

## Test plan

- [x] 3/3 regression tests PASS
- [x] Test exercises the line-190 site with mocked data_loader (no upstream pipeline dependency — W9-2 is fixing that separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)