### PR TITLE
W9-2: data_loader pivot + multi-CSV glob

### DIFF
--- a/.dfg/agents/W9-2-data-loader-pivot-and-glob.md
+++ b/.dfg/agents/W9-2-data-loader-pivot-and-glob.md
@@ -1,0 +1,51 @@
+---
+id: W9-2
+role: code-fixer
+name: Fix data_loader pivot KeyError + add multi-CSV glob support
+purpose: "Closes W8-1-CARRY-1 + W8-1-CARRY-2 (partial). Bugs 2+3 converge on the same pivot site in src/data_loader.py: glob-expand asset_files, tag rows with asset_id, pivot on asset_id."
+wave: W9
+unit: W9-2
+depends_on: []
+blocks: [W9-4]
+governance_tier: VT1
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/experiments/data_loader.py
+output_contract:
+  files:
+    - python_refactor/src/experiments/data_loader.py
+    - python_refactor/tests/test_experiments_data_loader.py
+  branch_name: feat/w9-2-data-loader-pivot-and-glob
+  acceptance: >
+    load_asset_data: each asset_files entry is glob-expanded (via
+    pathlib.Path or glob.glob); each loaded row tagged with asset_id;
+    pivot uses columns='asset_id'. No KeyError(None). Paper-window
+    multi-CSV path loads ≥ 90 assets. FTSE single-CSV path still works
+    (backward compat). ≥ 2 regression tests.
+dispatch_instructions: |
+  Two bugs converge:
+   - Bug 2: pivot(columns=None) → KeyError(None). Need columns=<col>.
+   - Bug 3: asset_files entries are literal paths, not globs. Paper-
+     window data is 98 per-asset CSVs.
+
+  Fix shape:
+   1. For each entry in asset_files, if it has glob chars (* ? [),
+      Path(entry).parent.glob(Path(entry).name) → list of paths.
+      Otherwise treat as literal.
+   2. For each loaded CSV, set asset_id = Path(file).stem.
+   3. Keep ['Date', 'asset_id', 'Return'] in the appended frame.
+   4. After concat: pivot(index='Date', columns='asset_id', values='Return').
+   5. If `assets` filter is non-empty, restrict columns to that list.
+
+  What NOT to do:
+    - Don't refactor load_market_data (different code path).
+    - Don't add caching, async, or progress bars.
+    - Don't change the function signature.
+---
+
+# W9-2 — data_loader pivot + glob fix
+
+Bugs 2 and 3 converge. ~15 LOC change in load_asset_data + tests.

--- a/.dfg/retrospectives/W9/W9-2.md
+++ b/.dfg/retrospectives/W9/W9-2.md
@@ -1,0 +1,80 @@
+---
+unit: W9-2
+wave: W9
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Bugs 2 + 3 converged on the same pivot site in load_asset_data,
+  exactly as the W9-2 contract predicted. ~25 LOC total: glob
+  expansion for wildcard entries (paper-window data shipped as 98
+  per-asset CSVs at legacy-cpp/executable/data/ftse-original/table*.csv),
+  per-row asset_id tagging, and pivot(columns='asset_id').
+
+  5/5 tests PASS in 0.85s:
+   - test_two_assets_pivot_to_two_columns — pivot shape + pct_change values
+   - test_glob_pattern_expands_to_all_matching_csvs — wildcard expansion
+   - test_literal_path_still_works_backward_compat — single-CSV FTSE path
+   - test_assets_filter_restricts_columns — order-preserving filter
+   - test_real_paper_window_glob_loads_many_assets — closes W8-1-CARRY-1
+     against the actual 98-CSV paper dataset (loaded ≥ 90 assets)
+
+  The `assets` filter logic was tightened: pre-W9-2 it overwrote
+  columns by position (`returns_df.columns = assets[:len(returns_df.columns)]`),
+  which silently relabeled assets in lexicographic-pivot order regardless
+  of which CSV they came from. Post-W9-2 it filters by name match,
+  preserving the requested order — strict semantic match for the
+  config-supplied `assets` list.
+what_broke: |
+  Nothing in the unit; tests green on first run.
+what_youd_change: |
+  pct_change leaves a NaN at row 0 which then gets fillna(0). For a
+  metric like Return that should be NaN-not-zero on the first
+  observation, this conflates "no return" with "first day". Doesn't
+  affect strategy decisions (the first day is always the seed point)
+  but a future caller relying on row-0 semantics should know. Filed
+  loosely as a watch-out, not a carry.
+
+  load_market_data has the same pre-W9-2 shape risk (pivot-time bug
+  could be lurking) but was out of scope per dispatch_instructions
+  "Don't refactor load_market_data" — file separate unit if/when
+  market data is exercised end-to-end.
+assumption_to_challenge: |
+  Assumed: glob expansion on the supplied entry string is sufficient.
+  CHALLENGE: if a future config uses brace-expansion ({A,B}) or
+  recursive globs (**), Path.glob handles those differently than
+  shell expansion. The current scope (basic * ? [) covers all known
+  call sites; broader globs are a follow-up.
+
+  Closes:
+   - W8-1-CARRY-1 (paper-window per-asset CSV loader) — real-dataset
+     test PASSES.
+   - W8-1-CARRY-2 (data_loader half) — pivot KeyError(None) eliminated.
+   - W8-1-CARRY-2 (other half, experiment_manager bool DataFrame) — W9-1.
+
+  Remaining open carries:
+   - W7-1-CARRY-1 (closes in W9-4 via smoke-test).
+   - W8-CARRY-3 (analytics builders for C/E/F/G/H — future wave).
+   - W9-3-CARRY-1, W9-3-CARRY-2 (W7-1..W6-x retro backfill + plan.yaml
+     path correction).
+---
+
+# W9-2 — data_loader pivot + multi-CSV glob fix
+
+## What changed
+
+- `python_refactor/src/experiments/data_loader.py` — load_asset_data: ~25 LOC delta
+  - Glob-expand entries with wildcard chars before reading
+  - Tag each row with asset_id derived from filename stem
+  - Pivot on columns='asset_id' (was columns=None → KeyError)
+  - `assets` filter now restricts by name, not by position
+- `python_refactor/tests/test_experiments_data_loader.py` (NEW, 5 tests)
+
+## Verification
+
+- 5/5 regression tests PASS in 0.85s
+- Real paper-window dataset loads ≥ 90 assets (W8-1-CARRY-1 closure receipt)
+
+## Closes
+
+- W8-1-CARRY-1 (paper-window per-asset CSV loader)
+- W8-1-CARRY-2 (data_loader half — pivot fixed; experiment_manager half closed by W9-1)

--- a/python_refactor/src/experiments/data_loader.py
+++ b/python_refactor/src/experiments/data_loader.py
@@ -32,47 +32,72 @@ class DataLoader:
         """
         if not asset_files:
             return pd.DataFrame()
-        
+
+        # W9-2: glob-expand entries containing wildcard chars.
+        # The paper-window data ships as 98 per-asset CSVs at
+        # legacy-cpp/executable/data/ftse-original/table*.csv;
+        # before W9-2 the loader treated 'table*.csv' as a literal
+        # filename and silently loaded nothing.
+        from pathlib import Path
+        expanded: list[str] = []
+        for entry in asset_files:
+            p = Path(entry)
+            if any(ch in p.name for ch in "*?["):
+                matches = sorted(p.parent.glob(p.name))
+                expanded.extend(str(m) for m in matches)
+            else:
+                expanded.append(entry)
+
         # Load and combine all asset data
         all_data = []
-        
-        for file_path in asset_files:
+
+        for file_path in expanded:
             try:
                 # Load CSV file
                 df = pd.read_csv(file_path)
-                
+
                 # Convert date column
                 df['Date'] = pd.to_datetime(df['Date'])
-                
+
                 # Filter by date range if specified
                 if date_range:
                     start_date = pd.to_datetime(date_range.get('start', df['Date'].min()))
                     end_date = pd.to_datetime(date_range.get('end', df['Date'].max()))
                     df = df[(df['Date'] >= start_date) & (df['Date'] <= end_date)]
-                
+
                 # Calculate returns
                 df['Return'] = df['Close'].pct_change()
-                
+
+                # W9-2: tag each row with an asset_id derived from the
+                # filename stem; required for the post-concat pivot below
+                # (pre-W9-2 columns=None → KeyError(None) at pivot time).
+                df['asset_id'] = Path(file_path).stem
+
                 # Add to combined data
-                all_data.append(df[['Date', 'Return']])
-                
+                all_data.append(df[['Date', 'asset_id', 'Return']])
+
             except Exception as e:
                 print(f"Warning: Could not load {file_path}: {str(e)}")
                 continue
-        
+
         if not all_data:
             return pd.DataFrame()
-        
+
         # Combine all data
         combined_df = pd.concat(all_data, ignore_index=True)
-        
-        # Pivot to get assets as columns
-        returns_df = combined_df.pivot(index='Date', columns=None, values='Return')
-        
-        # Rename columns to asset names
-        if assets and len(assets) <= len(returns_df.columns):
-            returns_df.columns = assets[:len(returns_df.columns)]
-        
+
+        # W9-2: pivot on asset_id (the tag added above). Pre-W9-2 this
+        # was pivot(columns=None) → KeyError(None) in modern pandas.
+        returns_df = combined_df.pivot(index='Date', columns='asset_id', values='Return')
+
+        # Apply the `assets` filter when supplied: keep only those columns
+        # that match (and preserve the requested order). When `assets` is
+        # empty / None, return all loaded asset columns.
+        if assets:
+            kept = [a for a in assets if a in returns_df.columns]
+            if kept:
+                returns_df = returns_df[kept]
+
         return returns_df.fillna(0)
     
     def load_market_data(self, market_files: List[str], date_range: Dict[str, str]) -> pd.DataFrame:

--- a/python_refactor/tests/test_experiments_data_loader.py
+++ b/python_refactor/tests/test_experiments_data_loader.py
@@ -1,0 +1,121 @@
+"""
+W9-2 regression tests for data_loader.load_asset_data.
+
+Pins:
+  Bug 2: `pivot(columns=None)` → KeyError(None) — fix uses
+         columns='asset_id' (tag added per row).
+  Bug 3: literal-path-only entries — fix glob-expands entries
+         containing wildcard chars.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+
+from src.experiments.data_loader import DataLoader
+
+
+def _write_csv(path: Path, dates: list[str], closes: list[float]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({"Date": dates, "Close": closes}).to_csv(path, index=False)
+
+
+class TestPivotFix(unittest.TestCase):
+    """W9-2 bug 2 — pivot must use columns='asset_id', not None."""
+
+    def test_two_assets_pivot_to_two_columns(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            _write_csv(tmpdir / "AAPL.csv", ["2020-01-02", "2020-01-03", "2020-01-06"], [100.0, 102.0, 101.0])
+            _write_csv(tmpdir / "GOOG.csv", ["2020-01-02", "2020-01-03", "2020-01-06"], [1500.0, 1510.0, 1495.0])
+
+            loader = DataLoader()
+            df = loader.load_asset_data(
+                [str(tmpdir / "AAPL.csv"), str(tmpdir / "GOOG.csv")],
+                date_range={},
+                assets=[],
+            )
+            # Two columns, one per asset, named by file stem.
+            self.assertEqual(sorted(df.columns.tolist()), ["AAPL", "GOOG"])
+            self.assertEqual(len(df), 3)
+            # pct_change of [100, 102, 101] → [NaN, 0.02, -0.0098...] → first NaN filled to 0
+            self.assertAlmostEqual(df["AAPL"].iloc[1], 0.02, places=4)
+
+
+class TestGlobExpansion(unittest.TestCase):
+    """W9-2 bug 3 — wildcard entries glob-expand."""
+
+    def test_glob_pattern_expands_to_all_matching_csvs(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            for name in ["table_001.csv", "table_002.csv", "table_003.csv"]:
+                _write_csv(tmpdir / name, ["2020-01-02", "2020-01-03"], [10.0, 11.0])
+            # Also an unrelated csv that should NOT match.
+            _write_csv(tmpdir / "other.csv", ["2020-01-02", "2020-01-03"], [99.0, 100.0])
+
+            loader = DataLoader()
+            df = loader.load_asset_data(
+                [str(tmpdir / "table_*.csv")],
+                date_range={},
+                assets=[],
+            )
+            self.assertEqual(sorted(df.columns.tolist()),
+                              ["table_001", "table_002", "table_003"])
+
+    def test_literal_path_still_works_backward_compat(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            _write_csv(tmpdir / "FTSE_updated.csv",
+                        ["2020-01-02", "2020-01-03", "2020-01-06"],
+                        [7000.0, 7050.0, 6995.0])
+            loader = DataLoader()
+            df = loader.load_asset_data(
+                [str(tmpdir / "FTSE_updated.csv")],
+                date_range={},
+                assets=[],
+            )
+            self.assertEqual(df.columns.tolist(), ["FTSE_updated"])
+            self.assertEqual(len(df), 3)
+
+
+class TestAssetsFilter(unittest.TestCase):
+    """`assets` arg restricts and orders the returned columns."""
+
+    def test_assets_filter_restricts_columns(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            for name in ["AAPL.csv", "GOOG.csv", "MSFT.csv"]:
+                _write_csv(tmpdir / name, ["2020-01-02", "2020-01-03"], [100.0, 101.0])
+            loader = DataLoader()
+            df = loader.load_asset_data(
+                [str(tmpdir / f) for f in ["AAPL.csv", "GOOG.csv", "MSFT.csv"]],
+                date_range={},
+                assets=["MSFT", "AAPL"],
+            )
+            # Order preserved; GOOG dropped.
+            self.assertEqual(df.columns.tolist(), ["MSFT", "AAPL"])
+
+
+class TestPaperWindowLoad(unittest.TestCase):
+    """W8-1-CARRY-1 closure check: paper-window per-asset CSVs load."""
+
+    def test_real_paper_window_glob_loads_many_assets(self):
+        # Skip if the dataset isn't present (CI without legacy-cpp/).
+        data_dir = Path(__file__).parents[2] / "legacy-cpp" / "executable" / "data" / "ftse-original"
+        if not data_dir.exists():
+            self.skipTest(f"paper-window dataset not present at {data_dir}")
+        loader = DataLoader()
+        df = loader.load_asset_data(
+            [str(data_dir / "table*.csv")],
+            date_range={},
+            assets=[],
+        )
+        # Paper-window: 98 per-asset CSVs (W8-1-CARRY-1 spec).
+        self.assertGreaterEqual(len(df.columns), 90,
+                                  f"Expected >=90 paper-window assets, got {len(df.columns)}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Bugs 2 + 3 from W8-1-CARRY-2 converge on the same pivot site
- Glob-expand wildcard entries; tag rows with asset_id; pivot on `columns='asset_id'`
- Real paper-window dataset (98 per-asset CSVs) loads ≥ 90 assets
- 5/5 regression tests PASS in 0.85s

## Closes

- W8-1-CARRY-1 (paper-window per-asset CSV loader)
- W8-1-CARRY-2 (data_loader half — experiment_manager half closed by W9-1)

## Test plan

- [x] `test_two_assets_pivot_to_two_columns` — pivot shape correct
- [x] `test_glob_pattern_expands_to_all_matching_csvs` — wildcard expansion works
- [x] `test_literal_path_still_works_backward_compat` — FTSE single-CSV path preserved
- [x] `test_assets_filter_restricts_columns` — order-preserving name filter
- [x] `test_real_paper_window_glob_loads_many_assets` — real dataset ≥ 90 assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)