### PR TITLE
W9-4: smoke-test re-run + dedup hotfix (closes 2 carries)

### DIFF
--- a/.dfg/agents/W9-4-smoke-test-end-to-end-rerun.md
+++ b/.dfg/agents/W9-4-smoke-test-end-to-end-rerun.md
@@ -1,0 +1,47 @@
+---
+id: W9-4
+role: verifier
+name: Re-run W8-1 smoke-test end-to-end (closes W7-1-CARRY-1)
+purpose: "After W9-1 + W9-2 land, re-runs the W8-1 smoke-test on master. Closes W7-1-CARRY-1 + W8-1-CARRY-2."
+wave: W9
+unit: W9-4
+depends_on: [W9-1, W9-2]
+blocks: []
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/experiments/validation_matrix.py
+    - python_refactor/src/experiments/experiment_manager.py
+    - python_refactor/src/experiments/data_loader.py
+output_contract:
+  files:
+    - .dfg/retrospectives/W9/W9-4.md
+  branch_name: feat/w9-4-smoke-test-end-to-end-rerun
+  acceptance: >
+    `python -m experiments.validation_matrix --scenario S0 --window paper
+    --seed 1 --output /tmp/w9-smoke` exits 0 without --dry-run.
+    /tmp/w9-smoke/manifest.json shows status=ok. /tmp/w9-smoke/metrics.csv
+    has >= 1 metric row. Retro documents closure of W7-1-CARRY-1 +
+    W8-1-CARRY-2 OR honestly reports new src/ cascade bugs as new
+    carries (no laundering).
+dispatch_instructions: |
+  Verification-only unit. Re-runs the W8-1 smoke-test command. If
+  it now passes end-to-end, retro reports closure of W7-1-CARRY-1
+  and W8-1-CARRY-2. If new src/ bugs surface (real-data quirks that
+  the W9-2 synthetic-fixture tests missed), they become new carries
+  — sub-papercut #15 (synthesized fixtures must match real substrate)
+  pattern.
+
+  What NOT to do:
+    - Don't fabricate a passing manifest.
+    - Don't extend scope to fix arbitrary bugs unless they're a
+      direct W9-1/W9-2 regression.
+---
+
+# W9-4 — Re-run smoke-test end-to-end
+
+Verifies W9-1 + W9-2 fix the cascade. Closes W7-1-CARRY-1 if the
+real-run smoke-test now passes.

--- a/.dfg/retrospectives/W9/W9-4.md
+++ b/.dfg/retrospectives/W9/W9-4.md
@@ -1,0 +1,115 @@
+---
+unit: W9-4
+wave: W9
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  The W9-1 + W9-2 fixes close the original src/ cascade. The
+  smoke-test now reaches the algorithm + portfolio-evaluation
+  stages and completes:
+
+  - ExperimentManager._load_experiment_data — no more bool(DataFrame)
+    ValueError. Logs num_assets=1.
+  - DataLoader.load_asset_data — no more pivot KeyError(None). The
+    FTSE-updated CSV pivots cleanly after the W9-4 hotfix.
+  - sms_emoa runs 30 generations, completes in 0.7s.
+  - PortfolioEvaluator emits final_value=1.4955 (= 49.55% total return
+    over the paper-window — directionally plausible vs paper Table I
+    ~12% for HDM; S0 is the unleveraged baseline so a different absolute
+    is expected but the order of magnitude is right).
+
+  Smoke-test exits 0; manifest.json reports status=ok. Acceptance
+  criteria 1 + 2 MET.
+
+  W9-2 hotfix (in this same PR): real FTSE-updated CSV has 12 duplicate
+  date rows (year-end summaries). W9-2's synthetic fixtures didn't
+  surface this; the smoke-test did. 1-line `drop_duplicates(subset=
+  ['Date','asset_id'], keep='last')` before the pivot. Plus 2 new
+  regression tests using real-data + synthetic-with-dupes (sub-papercut
+  #15 receipt: "synthesized fixtures must match real substrate").
+what_broke: |
+  Acceptance criterion #3 NOT MET: metrics.csv has 0 metric rows
+  (only the header). The smoke-test orchestration succeeded but
+  the metric-serialization step in validation_matrix.py:266-269
+  filters with `isinstance(value, (int, float))` against a nested
+  dict (`final_metrics` is `{"algorithm": {...}, "portfolio": {...},
+  "summary": {...}, ...}`). Every top-level value is a dict, so 0
+  rows get written.
+
+  This is a 3rd dead-code-coming-alive instance in the chain
+  (W8-1 surfaced 2; this surfaces a 3rd). Each smoke-test re-run
+  reveals one layer deeper. Per directive #4 (no scope creep
+  without replan) the fix is W9-CARRY-3, not W9-4 inline.
+
+  Scope creep was already paid once for the dedup hotfix; paying
+  it a second time for metric-flattening would compound. Stop.
+what_youd_change: |
+  Add a validation_matrix metric-flattening pass: walk
+  `final_metrics` recursively, emit `<category>.<metric>` rows
+  (e.g. `portfolio.final_value`, `summary.total_return`). ~10 LOC.
+  W10 candidate as W10-1.
+
+  Better: the metric-output schema should be a CONTRACT between
+  ExperimentManager and validation_matrix — written down in
+  ANALYTICS-PLAN.md §7 (Tables A spec) as a stable column list, so
+  ExperimentManager evolution can't silently change what
+  aggregate_validation.py / report.py expect.
+assumption_to_challenge: |
+  Assumed: a "smoke-test" passing means the whole chain works.
+  CHALLENGE: in this codebase a smoke-test passes when no Python
+  exception is raised, but the substrate downstream (aggregate_
+  validation.py → report.py) only works if metrics.csv is populated.
+  "Exit 0" is necessary but not sufficient. The W9-4 acceptance
+  criteria already encode this (criteria 1+2+3 all required); the
+  third criterion's failure is what catches the gap.
+
+  Closes (partial):
+  - W7-1-CARRY-1 — PARTIAL. Real-run smoke-test now reaches algorithm
+    completion (was blocked at bool(DataFrame) before W9-1). Full
+    closure pending metric-flattening (W9-CARRY-3).
+  - W8-1-CARRY-1 — CLOSED. paper-window data loader works (W9-2);
+    FTSE-updated single-CSV path works (W9-2 + W9-4 hotfix dedup).
+  - W8-1-CARRY-2 — CLOSED. Both halves fixed (W9-1 experiment_manager
+    + W9-2 data_loader pivot).
+
+  New carries:
+  - W9-CARRY-3: validation_matrix.py metric-flattening pass. The
+    smoke-test orchestration succeeds (status=ok) but final_metrics
+    is a nested dict and the row-writer filters out all non-scalars
+    → 0 metric rows. ~10 LOC fix. W10 candidate.
+
+  Pattern receipt: dead-code-coming-alive instance #7 across the
+  wave chain. The 6 prior were caught by W8-1 (3 bugs) + W9-4
+  (dedup) + this (metric flattening). Each smoke-test depth-pass
+  surfaces one more layer.
+---
+
+# W9-4 — Smoke-test end-to-end (closes W7-1-CARRY-1 partial)
+
+## What changed
+
+- Re-ran W8-1 smoke-test on master + W9-1/W9-2 merged: now reaches
+  algorithm + portfolio completion (was blocked at bool(DataFrame)).
+- `python_refactor/src/experiments/data_loader.py` — W9-4 hotfix:
+  drop_duplicates before pivot (real FTSE-updated CSV has 12 dup
+  year-end rows; W9-2 synthetic fixtures missed this).
+- `python_refactor/tests/test_experiments_data_loader.py` — 2 new
+  tests covering the dedup behavior (synthetic + real CSV).
+
+## Verification
+
+- 7/7 data_loader regression tests PASS (was 5; +2 W9-4)
+- `python -m experiments.validation_matrix --scenario S0 --window paper --seed 1 --output /tmp/w9-smoke` → exit 0, status=ok
+- final_value=1.4955 (order-of-magnitude plausible vs paper Table I)
+- metrics.csv has only the header (0 metric rows) — see W9-CARRY-3
+
+## Closes
+
+- W8-1-CARRY-1 (paper-window per-asset CSV loader works)
+- W8-1-CARRY-2 (both halves of the src/ cascade fixed)
+- W7-1-CARRY-1 PARTIAL (orchestration reaches completion; metric
+  flattening pending W9-CARRY-3)
+
+## Carries forward
+
+- W9-CARRY-3: validation_matrix metric-flattening pass (W10 candidate)

--- a/python_refactor/src/experiments/data_loader.py
+++ b/python_refactor/src/experiments/data_loader.py
@@ -86,6 +86,15 @@ class DataLoader:
         # Combine all data
         combined_df = pd.concat(all_data, ignore_index=True)
 
+        # W9-4 hotfix to W9-2: real data has duplicate (Date, asset_id)
+        # tuples (e.g. FTSE_100_20121121_20241231.csv has 2 rows for each
+        # year-end day — a regular EOD plus a consolidated-summary entry).
+        # Synthetic test fixtures didn't surface this; smoke-test did.
+        # Keep last observation per (Date, asset_id) — consolidated summary
+        # if present, otherwise the only row.
+        # Sub-papercut #15 receipt: "synthesized fixtures must match real substrate."
+        combined_df = combined_df.drop_duplicates(subset=['Date', 'asset_id'], keep='last')
+
         # W9-2: pivot on asset_id (the tag added above). Pre-W9-2 this
         # was pivot(columns=None) → KeyError(None) in modern pandas.
         returns_df = combined_df.pivot(index='Date', columns='asset_id', values='Return')

--- a/python_refactor/tests/test_experiments_data_loader.py
+++ b/python_refactor/tests/test_experiments_data_loader.py
@@ -98,6 +98,42 @@ class TestAssetsFilter(unittest.TestCase):
             self.assertEqual(df.columns.tolist(), ["MSFT", "AAPL"])
 
 
+class TestRealDataDuplicates(unittest.TestCase):
+    """W9-4 hotfix to W9-2: real CSVs have duplicate (Date, asset_id)
+    tuples (year-end summary rows). Synthetic fixtures missed this;
+    smoke-test surfaced it. Pin the dedup behavior."""
+
+    def test_duplicate_dates_in_single_csv_dont_break_pivot(self):
+        with TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            # CSV has 2 rows for 2020-12-31 (year-end summary + EOD).
+            _write_csv(tmpdir / "INDEX.csv",
+                        ["2020-01-02", "2020-12-31", "2020-12-31"],
+                        [100.0, 110.0, 110.5])
+            loader = DataLoader()
+            df = loader.load_asset_data(
+                [str(tmpdir / "INDEX.csv")],
+                date_range={},
+                assets=[],
+            )
+            # Pivot succeeds; one row per unique date.
+            self.assertEqual(len(df), 2)
+            # 'keep=last' preserves the consolidated-summary value.
+            self.assertAlmostEqual(df["INDEX"].loc[pd.Timestamp("2020-12-31")],
+                                     (110.5 - 110.0) / 110.0, places=4)
+
+    def test_real_ftse_updated_csv_loads(self):
+        repo_root = Path(__file__).parents[2]
+        ftse_csv = repo_root / "python_refactor" / "data" / "ftse-updated" / "FTSE_100_20121121_20241231.csv"
+        if not ftse_csv.exists():
+            self.skipTest(f"FTSE-updated CSV not present at {ftse_csv}")
+        loader = DataLoader()
+        df = loader.load_asset_data([str(ftse_csv)], date_range={}, assets=[])
+        # Smoke: shape sane, no duplicates leaked past pivot.
+        self.assertGreater(len(df), 1000)
+        self.assertEqual(len(df.index), len(df.index.unique()))
+
+
 class TestPaperWindowLoad(unittest.TestCase):
     """W8-1-CARRY-1 closure check: paper-window per-asset CSVs load."""
 


### PR DESCRIPTION
## Summary

- W8-1 smoke-test now runs end-to-end on master: sms_emoa completes, portfolio final_value=1.4955, manifest.json status=ok
- W9-2 hotfix: real FTSE-updated CSV has 12 duplicate year-end rows (synthetic fixtures missed it); 1-line dedup + 2 regression tests
- Pattern receipt: dead-code-coming-alive instance #7, sub-papercut #15 receipt

## Closes

- ✅ W8-1-CARRY-1 (paper-window per-asset CSV loader works)
- ✅ W8-1-CARRY-2 (src/ cascade — both halves fixed via W9-1 + W9-2)
- 🟡 W7-1-CARRY-1 PARTIAL (orchestration green; metric-flattening pending W9-CARRY-3)

## New carry

- W9-CARRY-3: validation_matrix metric-flattening (`final_metrics` is nested dict; row-writer filters out non-scalars → 0 rows in metrics.csv). ~10 LOC fix for W10.

## Test plan

- [x] 7/7 data_loader tests PASS (was 5; +2 W9-4 dedup tests)
- [x] Smoke-test exit 0, status=ok
- [x] Real FTSE-updated CSV loads without ValueError
- [ ] metrics.csv populated (NOT met — W9-CARRY-3)

## Honest verdict

PASS-WITH-CARRY: 2 of 3 acceptance criteria fully met; #3 surfaces a new layer in the cascade that's filed as W9-CARRY-3, not laundered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)