### PR TITLE
W10-1: metric flatten + paper-window real-glob

### DIFF
--- a/.dfg/agents/W10-1-validation-matrix-tightening.md
+++ b/.dfg/agents/W10-1-validation-matrix-tightening.md
@@ -1,0 +1,61 @@
+---
+id: W10-1
+role: tooling-author
+name: Metric flatten + paper-window real-glob switch
+purpose: "Closes W9-CARRY-3 (metrics.csv has 0 rows because final_metrics is nested dict and writer filters scalars) + W8-1-CARRY-1 fully (switches WINDOWS paper to legacy-cpp/.../table*.csv real 98-CSV glob)."
+wave: W10
+unit: W10-1
+depends_on: []
+blocks: [W10-2, W10-3, W10-4, W10-5]
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/experiments/validation_matrix.py
+    - python_refactor/experiments/aggregate_validation.py
+output_contract:
+  files:
+    - python_refactor/experiments/validation_matrix.py
+    - python_refactor/tests/test_experiments_validation_matrix.py
+  branch_name: feat/w10-1-validation-matrix-tightening
+  acceptance: >
+    validation_matrix.py: final_metrics recursed into '<category>.<metric>'
+    rows in metrics.csv. WINDOWS['paper']['asset_files_glob'] points to
+    legacy-cpp/executable/data/ftse-original/table*.csv. ≥ 2 regression
+    tests (flatten round-trip + WINDOWS paper-window loads ≥ 90 assets).
+    S0/paper/seed=1 smoke-test → metrics.csv has ≥ 5 metric rows.
+dispatch_instructions: |
+  Two surgical edits in one file:
+
+  1) Replace the metric-writer loop at line ~266-269 with a recursive
+     flatten:
+       def _flatten(d: dict, prefix: str = "") -> Iterator[tuple[str, float]]:
+           for k, v in d.items():
+               key = f"{prefix}.{k}" if prefix else k
+               if isinstance(v, dict):
+                   yield from _flatten(v, key)
+               elif isinstance(v, (int, float)) and not isinstance(v, bool):
+                   yield key, float(v)
+     Then writer.writerow([scenario, window, seed, key, value])
+     for each (key, value) in _flatten(final_metrics).
+
+  2) WINDOWS['paper']['asset_files_glob'] →
+       'legacy-cpp/executable/data/ftse-original/table*.csv'
+     Update the note + date_start / date_end if the paper-window dates
+     differ from the FTSE-updated dates (paper §V-A says 2006-2012;
+     verify via the actual CSV first row, fall back to "loose" dates
+     if data spans differently). Existing 'extended' window stays
+     pointing at FTSE-updated.
+
+  What NOT to do:
+    - Don't touch experiment_manager.py, data_loader.py (W9-1/W9-2 territory).
+    - Don't refactor build_experiment_config — just feed WINDOWS through.
+    - Don't add caching, async, progress bars, or extend SCENARIOS.
+---
+
+# W10-1 — validation_matrix tightening
+
+Keystone for W10: closes W9-CARRY-3 + W8-1-CARRY-1, unblocks
+W10-2..W10-5 smoke-tests.

--- a/.dfg/retrospectives/W10/W10-1.md
+++ b/.dfg/retrospectives/W10/W10-1.md
@@ -1,0 +1,118 @@
+---
+unit: W10-1
+wave: W10
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Two surgical edits to validation_matrix.py:
+   - `_flatten_metrics(d, prefix)` recurses nested final_metrics into
+     `<category>.<metric>` rows. ~12 LOC. Booleans + None excluded.
+   - WINDOWS['paper'] switches from FTSE-updated single-CSV (the
+     W8-1 placeholder) to `../legacy-cpp/executable/data/ftse-original/
+     table*.csv` — the real 98-asset FTSE paper-window data. Date
+     range updated to 2003-01 → 2012-11 per IEEE TCYB 2015 §V-A.
+
+  9/9 regression tests PASS in 0.86s, covering: flatten round-trip,
+  flat-dict pass-through, bool/None exclusion, 3-level nesting,
+  empty input, real shape sampled from W9-4 logs, paper-window
+  pattern + loads ≥ 90 assets, extended-window backward compat.
+
+  S0/paper/seed=1 smoke-test on master + W10-1 changes:
+   - Exits 0, status=ok
+   - metrics.csv has **38 rows** (was 0 → W9-CARRY-3 closed)
+   - Algorithm/computational/portfolio/summary categories all
+     flattened with dotted-key names
+   - Runs against real 98-CSV paper-window data (W8-1-CARRY-1 closed)
+what_broke: |
+  REAL-DATA SMOKE-TEST SURFACED PORTFOLIO-EVALUATOR QUALITY BUGS.
+
+  The 38-row metrics include NaN / Infinity values that don't appear
+  when running against the FTSE-updated single-CSV placeholder:
+   - portfolio.portfolio_value = Infinity
+   - portfolio.max_drawdown = NaN
+   - portfolio.calmar_ratio = NaN
+   - summary.final_portfolio_value = Infinity
+   - summary.max_drawdown = NaN
+
+  Compare to W9-4 smoke-test against FTSE-updated single-CSV which
+  had portfolio.portfolio_value = 1.4955 (finite). The Infinity/NaN
+  cluster surfaces only with the real 98-asset paper-window data —
+  Dead-code-coming-alive pattern instance #8 (the 8th since W8-1).
+
+  Root cause is a portfolio-evaluator division-by-zero or invalid
+  metric-calc on real multi-asset data. Probably:
+   - max_drawdown denominator = 0 when prices haven't moved enough yet
+   - portfolio_value = Σ weights × returns where weights × inf returns
+     blow up if a Return column has Inf (W9-4 dedup keeps trading-suspension
+     rows that might produce Inf pct_change)
+
+  My W10-1 scope is validation_matrix.py only. Fixing the portfolio
+  evaluator is W11 / W10-CARRY-1 territory. The smoke-test STILL
+  passes status=ok (no exception); the bad values just propagate
+  into the CSV. Honest scar — not laundered.
+what_youd_change: |
+  Add a `_clean_metric` filter in _flatten_metrics that emits NaN/Inf
+  as the literal string 'NaN' / 'Infinity' (current Python default
+  produces 'nan' / 'inf' — pandas-readable but signals a real issue
+  to a human eyeballing the CSV). Optional; the analytics layer
+  (W8-2 stats) already handles NaN safely.
+
+  Better: add a metric-validity gate in the smoke-test acceptance:
+  "no metric value is NaN or Inf." That would turn the W10-CARRY-1
+  scar into a regression-blocking criterion in W11.
+assumption_to_challenge: |
+  Assumed: switching to real paper-window data is a path-only change.
+  CHALLENGE: synthetic data (the FTSE-updated single CSV) hides
+  numerical issues that real multi-asset data exposes (NaN, Inf,
+  near-zero variances, etc.). The W9-4 smoke-test "passed" against
+  synthetic data because the portfolio evaluator's edge cases never
+  fired. The W10-1 real-data smoke-test fires them.
+
+  This is the same pattern as W9-4's year-end-dedup discovery
+  (sub-papercut #15: synthesized fixtures don't match real substrate).
+  The retiring gate (real-CSV regression tests for data-loader changes)
+  is in place; W10-1 extends the lesson to "real-data smoke-tests
+  surface bugs the synthetic ones can't."
+
+  Closes:
+   - W9-CARRY-3 (metric flattening) — 38 rows, 4 categories
+   - W8-1-CARRY-1 (paper-window per-asset CSV loader) — real glob works
+     end-to-end through validation_matrix → data_loader → pivot
+
+  Partial:
+   - W7-1-CARRY-1 — full closure now blocked by W10-CARRY-1
+     (NaN/Inf values, not 0 rows). One step deeper into the cascade.
+
+  New carries:
+   - W10-CARRY-1: portfolio-evaluator emits NaN / Infinity on real
+     98-asset paper-window data. Likely a division-by-zero or
+     Inf-return propagation. Doesn't crash; just produces useless
+     metrics. Investigation needed in src/experiments/ portfolio
+     evaluator code. M-sized. W11 candidate.
+---
+
+# W10-1 — validation_matrix tightening
+
+## What changed
+
+- `python_refactor/experiments/validation_matrix.py`:
+  - `_flatten_metrics()` helper (12 LOC) recurses nested final_metrics
+  - Metric-writer loop now iterates `_flatten_metrics(final_metrics)`
+  - WINDOWS['paper'] switched to real 98-CSV glob (2003-01 → 2012-11)
+- `python_refactor/tests/test_experiments_validation_matrix.py` (NEW, 9 tests)
+
+## Verification
+
+- 9/9 regression tests PASS
+- S0/paper/seed=1 smoke-test → metrics.csv has 38 rows (was 0)
+- Real paper-window glob loads ≥ 90 assets
+
+## Closes
+
+- W9-CARRY-3 (metric flattening — 38 rows produced)
+- W8-1-CARRY-1 (paper-window per-asset CSV loader — works end-to-end)
+
+## New carry
+
+- W10-CARRY-1: portfolio-evaluator NaN/Infinity on real multi-asset
+  data. Dead-code-coming-alive instance #8. W11 candidate.

--- a/python_refactor/experiments/validation_matrix.py
+++ b/python_refactor/experiments/validation_matrix.py
@@ -95,27 +95,51 @@ SCENARIOS: dict[str, dict[str, Any]] = {
     },
 }
 
-# W8-1 (closes W7-1-CARRY-1 partial): the paper-window's original FTSE
-# data is 98 per-asset CSVs at legacy-cpp/executable/data/ftse-original/
-# table\\ (*).csv — the underlying data_loader doesn't accept glob patterns
-# in its asset_files list (treats each entry as a literal filename).
-# Filed as W8-1-CARRY-1; for now both windows use the FTSE-updated
-# single-CSV path so the scaffold's smoke-test gets past data loading.
-# A future paper-window-loader unit (W9 candidate) will close the gap.
+# W10-1 (closes W8-1-CARRY-1 fully): paper-window now points at the
+# real 98 per-asset CSVs at legacy-cpp/executable/data/ftse-original/
+# table*.csv. W9-2 added glob-expansion to data_loader.load_asset_data,
+# so the loader handles this pattern correctly (verified by W9-2's
+# test_real_paper_window_glob_loads_many_assets → ≥ 90 assets).
+# Date range matches the IEEE 2015 paper §V-A: 2003-01 → 2012-11.
+# `extended` keeps the FTSE-updated single-CSV path for out-of-sample.
 WINDOWS: dict[str, dict[str, str]] = {
     "paper": {
-        "asset_files_glob": "data/ftse-updated/FTSE_100_20121121_20241231.csv",
-        "date_start": "2012-11-21",  # W8-1-CARRY-1: paper-window data needs loader extension
-        "date_end": "2024-12-31",
-        "notes": "Paper-window data loader is a W8-1-CARRY-1; smoke-test temporarily uses the FTSE-updated CSV here.",
+        "asset_files_glob": "../legacy-cpp/executable/data/ftse-original/table*.csv",
+        "date_start": "2003-01-01",
+        "date_end": "2012-11-20",
+        "notes": "Paper window (IEEE TCYB 2015 §V-A): 98 per-asset FTSE CSVs, ~2003-2012.",
     },
     "extended": {
         "asset_files_glob": "data/ftse-updated/FTSE_100_20121121_20241231.csv",
         "date_start": "2012-11-21",
         "date_end": "2024-12-31",
-        "notes": "Out-of-sample window.",
+        "notes": "Out-of-sample window: FTSE-updated single-CSV, 2012-2024.",
     },
 }
+
+
+def _flatten_metrics(d: dict, prefix: str = "") -> "list[tuple[str, float]]":
+    """Recursively flatten a nested metrics dict into [(dotted-key, value), ...].
+
+    W10-1 helper: ExperimentManager returns final_metrics shaped like
+    {'algorithm': {...nums...}, 'portfolio': {...nums...}, 'summary': {...}}.
+    The pre-W10-1 metrics-writer filtered on top-level scalars and got 0
+    rows. This recursion emits 'portfolio.final_value', 'summary.total_return',
+    etc., so the analytics layer can consume them.
+
+    Booleans are skipped: in Python `True/False` are int subclasses but
+    don't belong in a numeric metric column. None values are skipped.
+    """
+    out: list[tuple[str, float]] = []
+    for k, v in d.items():
+        key = f"{prefix}.{k}" if prefix else str(k)
+        if isinstance(v, dict):
+            out.extend(_flatten_metrics(v, key))
+        elif isinstance(v, bool) or v is None:
+            continue
+        elif isinstance(v, (int, float)):
+            out.append((key, float(v)))
+    return out
 
 
 def _git_sha() -> str:
@@ -257,17 +281,21 @@ def run_one(scenario_id: str, window_id: str, seed: int,
                        status="error", error=f"{type(e).__name__}: {e}")
         raise
 
-    # Write a flat metrics.csv that aggregate_validation.py can consume.
-    # Shape: one row per metric (long format), so adding new metrics
-    # doesn't change the column schema.
+    # W10-1 (closes W9-CARRY-3): final_metrics is a NESTED dict
+    # ({'algorithm': {...}, 'portfolio': {...}, 'summary': {...}, ...}).
+    # The pre-W10-1 writer filtered isinstance(value, (int, float)) on
+    # the top level → every value was a sub-dict → 0 rows emitted.
+    # Recurse into '<category>.<metric>' rows so the analytics layer
+    # has something to chew on. Booleans are explicitly excluded (in
+    # Python `True/False` are int subclasses but shouldn't land in a
+    # numeric metric column).
     final_metrics = results.get("final_metrics", {})
     import csv
     with (output_dir / "metrics.csv").open("w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["scenario", "window", "seed", "metric", "value"])
-        for key, value in final_metrics.items():
-            if isinstance(value, (int, float)):
-                writer.writerow([scenario_id, window_id, seed, key, value])
+        for key, value in _flatten_metrics(final_metrics):
+            writer.writerow([scenario_id, window_id, seed, key, value])
 
     write_manifest(output_dir, config, seed, scenario_id, window_id, status="ok")
     print(f"[ok] {config['name']} → {output_dir}")

--- a/python_refactor/tests/test_experiments_validation_matrix.py
+++ b/python_refactor/tests/test_experiments_validation_matrix.py
@@ -1,0 +1,95 @@
+"""
+W10-1 regression tests for validation_matrix.py.
+
+Pins:
+  - _flatten_metrics emits dotted-key rows from nested final_metrics
+    (closes W9-CARRY-3: pre-W10-1 the writer filtered on top-level
+    scalars and wrote 0 rows).
+  - WINDOWS['paper'] points to the real 98-CSV paper-window glob
+    (closes W8-1-CARRY-1 fully).
+"""
+
+import csv
+import unittest
+from pathlib import Path
+
+from experiments.validation_matrix import WINDOWS, _flatten_metrics
+from src.experiments.data_loader import DataLoader
+
+
+class TestFlattenMetrics(unittest.TestCase):
+    """W10-1: nested final_metrics → dotted-key rows."""
+
+    def test_nested_dict_recurses_to_dotted_keys(self):
+        nested = {
+            "portfolio": {"final_value": 1.4955, "total_return": 0.4955},
+            "summary": {"sharpe_ratio": 0.0, "max_drawdown": 0.1},
+        }
+        rows = _flatten_metrics(nested)
+        keys = {k for (k, _) in rows}
+        self.assertIn("portfolio.final_value", keys)
+        self.assertIn("portfolio.total_return", keys)
+        self.assertIn("summary.sharpe_ratio", keys)
+        self.assertIn("summary.max_drawdown", keys)
+        # Values are floats
+        for _, v in rows:
+            self.assertIsInstance(v, float)
+
+    def test_flat_dict_passes_through(self):
+        flat = {"a": 1, "b": 2.5, "c": 3}
+        rows = sorted(_flatten_metrics(flat))
+        self.assertEqual(rows, [("a", 1.0), ("b", 2.5), ("c", 3.0)])
+
+    def test_booleans_and_none_excluded(self):
+        d = {"x": True, "y": False, "z": None, "ok": 1.5}
+        rows = _flatten_metrics(d)
+        self.assertEqual(rows, [("ok", 1.5)])
+
+    def test_three_level_nesting(self):
+        d = {"L1": {"L2": {"L3": 7.7}}}
+        self.assertEqual(_flatten_metrics(d), [("L1.L2.L3", 7.7)])
+
+    def test_empty_dict_returns_empty(self):
+        self.assertEqual(_flatten_metrics({}), [])
+
+    def test_real_shape_from_experiment_manager(self):
+        """Real shape ExperimentManager emits (sampled from W9-4 smoke-test logs)."""
+        real_final_metrics = {
+            "algorithm": {"generation": 0, "hypervolume": 0.0, "population_size": 20},
+            "portfolio": {"final_value": 1.4955, "concentration": 0.356},
+            "summary": {"total_execution_time": 0.69, "final_portfolio_value": 1.4955},
+        }
+        rows = _flatten_metrics(real_final_metrics)
+        # 7 numeric leaves
+        self.assertEqual(len(rows), 7)
+        # Acceptance criterion: ≥ 5 rows
+        self.assertGreaterEqual(len(rows), 5)
+
+
+class TestPaperWindowGlob(unittest.TestCase):
+    """W10-1: WINDOWS['paper'] points at real 98-CSV glob (W8-1-CARRY-1 closure)."""
+
+    def test_paper_window_pattern_uses_legacy_cpp_glob(self):
+        self.assertIn("legacy-cpp", WINDOWS["paper"]["asset_files_glob"])
+        self.assertIn("table*.csv", WINDOWS["paper"]["asset_files_glob"])
+
+    def test_paper_window_glob_loads_many_assets(self):
+        # Resolve relative to python_refactor (where validation_matrix runs from).
+        repo_root = Path(__file__).parents[2]
+        pattern = repo_root / "python_refactor" / WINDOWS["paper"]["asset_files_glob"]
+        # Normalize the '../' prefix
+        pattern = pattern.resolve()
+        if not pattern.parent.exists():
+            self.skipTest(f"paper-window data dir not present at {pattern.parent}")
+        loader = DataLoader()
+        df = loader.load_asset_data([str(pattern)], date_range={}, assets=[])
+        self.assertGreaterEqual(len(df.columns), 90,
+                                  f"Expected >=90 paper-window assets, got {len(df.columns)}")
+
+    def test_extended_window_unchanged(self):
+        # Backward compat: extended still points at FTSE-updated single-CSV.
+        self.assertIn("ftse-updated", WINDOWS["extended"]["asset_files_glob"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `_flatten_metrics()` recurses nested `final_metrics` into `<category>.<metric>` rows
- S0/paper smoke-test now produces **38 rows** in metrics.csv (was 0)
- WINDOWS['paper'] switched to real 98-CSV glob (closes W8-1-CARRY-1 fully)
- 9/9 regression tests PASS

## Closes

- ✅ W9-CARRY-3 (metric flattening)
- ✅ W8-1-CARRY-1 (paper-window per-asset CSV loader works end-to-end)

## Honest scar (W10-CARRY-1)

Real-data smoke-test surfaces NaN/Infinity values in portfolio-evaluator metrics (`max_drawdown`, `calmar_ratio`, `portfolio_value`). Doesn't crash — just produces bad values. **Dead-code-coming-alive instance #8** (synthetic FTSE-updated CSV hid the edge case; real 98-asset paper data fires it). W11 candidate for portfolio-evaluator investigation.

## Test plan

- [x] 9/9 unit tests PASS
- [x] S0/paper/seed=1 smoke-test → status=ok + metrics.csv 38 rows
- [x] WINDOWS pattern + real load ≥ 90 assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)