### PR TITLE
W11-1: SMS-EMOA learn_population dispatch fix

### DIFF
--- a/.dfg/agents/W11-1-sms-emoa-learn-population-dispatch.md
+++ b/.dfg/agents/W11-1-sms-emoa-learn-population-dispatch.md
@@ -1,0 +1,40 @@
+---
+id: W11-1
+role: code-fixer
+name: Fix SMS-EMOA learning dispatch (prefer learn_population)
+purpose: "Closes W10-CARRY-2 half. _apply_anticipatory_learning prefers learn_population when subclass overrides it; falls back to per-solution loop for base AnticipatoryLearning."
+wave: W11
+unit: W11-1
+depends_on: []
+blocks: [W11-3]
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/algorithms/sms_emoa.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/sms_emoa.py
+    - python_refactor/tests/test_sms_emoa_dispatch.py
+  branch_name: feat/w11-1-sms-emoa-learn-population-dispatch
+  acceptance: >
+    _apply_anticipatory_learning detects whether the learner overrides
+    learn_population (not inherited from base) and routes to it; falls
+    back to per-solution loop otherwise. ≥ 2 regression tests covering
+    base + override paths.
+dispatch_instructions: |
+  Surgical fix at sms_emoa.py:200-208. Change the loop body to
+  first check whether learn_population is overridden on the learner's
+  type (vs the base AnticipatoryLearning class), and call it once
+  for the unlearned subset if so. Per-solution loop becomes fallback.
+
+  What NOT to do:
+    - Don't touch portfolio_evaluator.py (W11-2).
+    - Don't refactor _run_generation or other methods.
+    - Don't import learner subclasses directly (use override detection
+      via type.__mro__ or `learn_population.__qualname__` check).
+---
+
+# W11-1 — SMS-EMOA learn_population dispatch fix

--- a/.dfg/retrospectives/W11/W11-1.md
+++ b/.dfg/retrospectives/W11/W11-1.md
@@ -1,0 +1,78 @@
+---
+unit: W11-1
+wave: W11
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  SMS-EMOA _apply_anticipatory_learning now routes correctly:
+   - If `hasattr(learner, 'learn_population')` (subclass-defined),
+     call it ONCE for the unlearned subset.
+   - Otherwise fall back to the per-solution loop calling
+     learn_single_solution.
+
+  Detection is `hasattr` not MRO walk, because the audit revealed
+  the base AnticipatoryLearning class does NOT define
+  learn_population at all (only TIPIntegrated and MultiHorizon do).
+  Any class with learn_population is by definition a learning-aware
+  subclass.
+
+  5/5 regression tests pass in 0.90s:
+   - override-learner routes to learn_population (once, with unlearned subset)
+   - base-learner falls back to per-solution loop
+   - None learner is no-op
+   - all-anticipated population is no-op
+   - real-class sanity: base lacks learn_population; TIPIntegrated +
+     MultiHorizon define it
+what_broke: |
+  First implementation tried MRO walk to "detect override" by
+  comparing `learner.learn_population` against
+  `AnticipatoryLearning.learn_population`. Test self-fail showed
+  the base CLASS doesn't have the method at all — `RealBase.learn_population`
+  raises AttributeError. Simplified to hasattr check.
+what_youd_change: |
+  Should add an instrumentation hook (a log line or counter) so a
+  future smoke-test can detect dispatch by side-effect:
+    `[TIPIntegratedAnticipatoryLearning] learn_population called
+     @gen=N, |pop|=M`
+  Helps debug if dispatch ever silently flips back to fallback path.
+  Deferred to W11-3 (which adds the differentiation regression gate).
+assumption_to_challenge: |
+  Assumed: the W11 audit-agent's MRO-walking fix shape was correct
+  because it cited line numbers + code structure. CHALLENGE: even
+  with a careful audit, the recommended code shape carried an
+  unstated assumption (base defines learn_population). The actual
+  code shape was simpler than the audit suggested. Always verify
+  the audit by running the test against real classes.
+
+  Closes (partial):
+   - W10-CARRY-2 — the dispatch half. After this lands, S1/S2/S3/S4
+     will route through their respective override methods. W11-3
+     verifies the metrics actually differentiate.
+   - W7-1-CARRY-1 — moves closer to full closure (joint with W11-2).
+
+  No new carries.
+
+  Scars carried forward:
+   - W10-CARRY-1 (portfolio NaN/Inf) — W11-2 territory.
+   - W7-1-CARRY-1 — full closure pending W11-3 verification.
+---
+
+# W11-1 — SMS-EMOA learn_population dispatch fix
+
+## What changed
+
+- `python_refactor/src/algorithms/sms_emoa.py:200-234`:
+  `_apply_anticipatory_learning` prefers `learn_population` when the
+  learner has it (subclass-defined). Falls back to per-solution loop
+  for base learner.
+- `python_refactor/tests/test_sms_emoa_dispatch.py` (NEW, 5 tests).
+
+## Verification
+
+- 5/5 regression tests PASS
+- Real class confirmation: base lacks `learn_population`;
+  TIPIntegrated + MultiHorizon define it
+
+## Closes (partial)
+
+- W10-CARRY-2 dispatch half (verification of differentiation in W11-3)

--- a/python_refactor/src/algorithms/sms_emoa.py
+++ b/python_refactor/src/algorithms/sms_emoa.py
@@ -198,14 +198,50 @@ class SMSEMOA:
         portfolio.stability = 1.0 / (1.0 + np.std(solution.P.investment))
     
     def _apply_anticipatory_learning(self, generation: int):
-        """Apply anticipatory learning to population."""
+        """Apply anticipatory learning to population.
+
+        W11-1 (closes W10-CARRY-2): the pre-W11-1 loop always called
+        learn_single_solution, which is defined only on the base
+        AnticipatoryLearning class. TIPIntegratedAnticipatoryLearning
+        and MultiHorizonAnticipatoryLearning override learn_population
+        (paper Eq 13 / Eq 14 / Eq 15) but NOT learn_single_solution,
+        so all "learning-enabled" scenarios collapsed to base behavior
+        (S1=S2=S3=S4 produced identical metrics).
+
+        Fix: detect whether the learner overrides learn_population
+        (not inherited from base) and call it once for the unlearned
+        subset; fall back to the per-solution loop only when no
+        override exists.
+        """
         if self.anticipatory_learning is None:
             return
-        
-        # Apply to each solution that hasn't been learned yet
-        for solution in self.population:
-            if not hasattr(solution, 'anticipation') or not solution.anticipation:
-                self.anticipatory_learning.learn_single_solution(solution, generation)
+
+        unlearned = [s for s in self.population
+                     if not getattr(s, 'anticipation', False)]
+        if not unlearned:
+            return
+
+        # The base AnticipatoryLearning class does NOT define
+        # learn_population — only subclasses (TIPIntegrated, MultiHorizon)
+        # do. So `hasattr(learner, 'learn_population')` is a sufficient
+        # detector: True → subclass-defined → route through population
+        # entry point (paper Eq 13 TIP arm + Eq 14/15 multi-horizon
+        # convex combination). False → base → per-solution fallback.
+        #
+        # Note: we re-check whether learn_population was defined on a
+        # non-base class via __mro__ walk, BUT skipping that check
+        # when the base lacks it entirely (the actual project shape)
+        # is equivalent: any class with learn_population is a subclass
+        # override of nothing.
+        learner = self.anticipatory_learning
+        if hasattr(learner, 'learn_population'):
+            # Subclass-defined entry point (paper Eq 13/14/15).
+            learner.learn_population(unlearned, generation)
+            return
+
+        # Fallback: per-solution loop (the base / legacy path).
+        for solution in unlearned:
+            learner.learn_single_solution(solution, generation)
     
     def _run_generation(self):
         """Run one generation of SMS-EMOA."""

--- a/python_refactor/tests/test_sms_emoa_dispatch.py
+++ b/python_refactor/tests/test_sms_emoa_dispatch.py
@@ -1,0 +1,135 @@
+"""
+W11-1 regression tests for SMS-EMOA's _apply_anticipatory_learning.
+
+Pins the W10-CARRY-2 fix: when the learner's class overrides
+`learn_population`, _apply_anticipatory_learning calls it ONCE for
+the unlearned subset. When no override exists (base AnticipatoryLearning),
+it falls back to the per-solution loop calling learn_single_solution.
+"""
+
+import types
+import unittest
+from unittest.mock import MagicMock
+
+from src.algorithms.sms_emoa import SMSEMOA
+
+
+# Mimic the base / subclass shape from anticipatory_learning.py without
+# importing the full graph (which drags in numpy, pandas, etc. that
+# the dispatch logic doesn't actually need to validate).
+
+class AnticipatoryLearning:
+    """Stand-in for the base class. Per the real shape (verified
+    during W11-1 implementation), base defines ONLY
+    learn_single_solution; learn_population is added by subclasses
+    (TIPIntegrated, MultiHorizon) only."""
+    def learn_single_solution(self, solution, generation):
+        pass
+
+
+class OverridingLearner(AnticipatoryLearning):
+    """Stand-in for TIPIntegrated / MultiHorizon — overrides learn_population."""
+    def __init__(self):
+        self.population_calls = []
+        self.single_calls = []
+
+    def learn_population(self, solutions, generation):
+        self.population_calls.append((tuple(solutions), generation))
+
+    def learn_single_solution(self, solution, generation):
+        self.single_calls.append((solution, generation))
+
+
+class BaseLearner(AnticipatoryLearning):
+    """Stand-in for base — does NOT override learn_population."""
+    def __init__(self):
+        self.single_calls = []
+
+    def learn_single_solution(self, solution, generation):
+        self.single_calls.append((solution, generation))
+
+
+def _make_solution(anticipated: bool):
+    sol = types.SimpleNamespace()
+    sol.anticipation = anticipated
+    return sol
+
+
+def _make_algo(learner, population):
+    """Build a minimal SMSEMOA-shaped object exposing only what
+    _apply_anticipatory_learning needs."""
+    # Don't run SMSEMOA.__init__ — too many deps.
+    algo = SMSEMOA.__new__(SMSEMOA)
+    algo.anticipatory_learning = learner
+    algo.population = population
+    return algo
+
+
+class TestDispatch(unittest.TestCase):
+
+    def test_override_learner_uses_learn_population(self):
+        learner = OverridingLearner()
+        pop = [_make_solution(False), _make_solution(False), _make_solution(True)]
+        algo = _make_algo(learner, pop)
+        algo._apply_anticipatory_learning(generation=3)
+        # learn_population called once with the 2 unlearned solutions.
+        self.assertEqual(len(learner.population_calls), 1)
+        called_solutions, called_gen = learner.population_calls[0]
+        self.assertEqual(len(called_solutions), 2)
+        self.assertEqual(called_gen, 3)
+        # Per-solution fallback never fires when override exists.
+        self.assertEqual(learner.single_calls, [])
+
+    def test_base_learner_falls_back_to_per_solution_loop(self):
+        learner = BaseLearner()
+        pop = [_make_solution(False), _make_solution(False), _make_solution(True)]
+        algo = _make_algo(learner, pop)
+        algo._apply_anticipatory_learning(generation=7)
+        # Per-solution called for the 2 unlearned solutions.
+        self.assertEqual(len(learner.single_calls), 2)
+        for _, gen in learner.single_calls:
+            self.assertEqual(gen, 7)
+
+    def test_no_learner_is_noop(self):
+        algo = _make_algo(None, [_make_solution(False)])
+        # Should not raise.
+        algo._apply_anticipatory_learning(generation=0)
+
+    def test_all_solutions_anticipated_is_noop(self):
+        learner = OverridingLearner()
+        pop = [_make_solution(True), _make_solution(True)]
+        algo = _make_algo(learner, pop)
+        algo._apply_anticipatory_learning(generation=5)
+        self.assertEqual(learner.population_calls, [])
+        self.assertEqual(learner.single_calls, [])
+
+    def test_real_subclasses_have_learn_population(self):
+        """Sanity: real TIP and MultiHorizon classes define learn_population
+        (per W11-1 audit); base AnticipatoryLearning does NOT. Skip if
+        import fails (offline / partial env)."""
+        try:
+            from src.algorithms.anticipatory_learning import (
+                AnticipatoryLearning as RealBase,
+                TIPIntegratedAnticipatoryLearning,
+            )
+        except ImportError:
+            self.skipTest("anticipatory_learning module not importable in this env")
+        # Base lacks learn_population entirely.
+        self.assertFalse(hasattr(RealBase, 'learn_population'),
+                          "Base AnticipatoryLearning should NOT have learn_population")
+        # TIPIntegrated defines it (subclass-only).
+        self.assertTrue(hasattr(TIPIntegratedAnticipatoryLearning, 'learn_population'),
+                         "TIPIntegrated must define learn_population for W11-1 routing")
+        # MultiHorizon lives in a different module; tolerate absence here.
+        try:
+            from src.algorithms.multi_horizon_anticipatory import (
+                MultiHorizonAnticipatoryLearning,
+            )
+            self.assertTrue(hasattr(MultiHorizonAnticipatoryLearning, 'learn_population'),
+                             "MultiHorizon must define learn_population for W11-1 routing")
+        except ImportError:
+            pass  # Optional check
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes W10-CARRY-2 dispatch half: TIP + MH subclasses override learn_population but not learn_single_solution; pre-W11-1 the loop always called the latter → S1=S2=S3=S4 degenerated
- Detection via hasattr (base lacks learn_population entirely)
- 5/5 regression tests PASS

## Test plan

- [x] Override-learner routes through learn_population (unlearned subset, once)
- [x] Base-learner falls back to per-solution loop
- [x] Edge cases (no learner, all-anticipated population)
- [x] Real-class sanity check (base lacks; subclasses have)

🤖 Generated with [Claude Code](https://claude.com/claude-code)