### PR TITLE
W11-2: portfolio_evaluator returns sanitation

### DIFF
--- a/.dfg/agents/W11-2-portfolio-evaluator-returns-space.md
+++ b/.dfg/agents/W11-2-portfolio-evaluator-returns-space.md
@@ -1,0 +1,40 @@
+---
+id: W11-2
+role: code-fixer
+name: Fix portfolio_evaluator price-vs-returns input
+purpose: "Closes W10-CARRY-1. _get_asset_returns detects price-level input (median |value| > 1.5) and converts via pct_change before downstream cumprod."
+wave: W11
+unit: W11-2
+depends_on: []
+blocks: [W11-3]
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - python_refactor/src/experiments/portfolio_evaluator.py
+output_contract:
+  files:
+    - python_refactor/src/experiments/portfolio_evaluator.py
+    - python_refactor/tests/test_experiments_portfolio_evaluator.py
+  branch_name: feat/w11-2-portfolio-evaluator-returns-space
+  acceptance: >
+    _get_asset_returns auto-detects price-level input (median |value| > 1.5)
+    and converts to returns via pct_change(); returns-shaped input passes
+    through. No more Infinity in portfolio_value on real paper-window data.
+    ≥ 2 regression tests.
+dispatch_instructions: |
+  Surgical fix at portfolio_evaluator.py:87-103. Wrap the
+  `if isinstance(...) ... return data['assets']` with a
+  price-level detector + pct_change conversion. Threshold 1.5 is
+  conservative: real daily equity returns sit in [-0.2, +0.2];
+  index/price levels are typically 100s-1000s.
+
+  What NOT to do:
+    - Don't touch sms_emoa.py (W11-1).
+    - Don't refactor _calculate_portfolio_performance.
+    - Don't change the function signature.
+---
+
+# W11-2 — portfolio_evaluator returns-space fix

--- a/.dfg/retrospectives/W11/W11-2.md
+++ b/.dfg/retrospectives/W11/W11-2.md
@@ -1,0 +1,93 @@
+---
+unit: W11-2
+wave: W11
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  Two-layer guard in _get_asset_returns:
+
+  Layer 1 — price-level detection (defensive): median |value| > 1.5
+  triggers pct_change conversion. Protects callers that supply raw
+  prices.
+
+  Layer 2 — returns sanitation (the actual W10-CARRY-1 root cause):
+  the real 98-CSV FTSE archive contains 2 Inf returns (pct_change
+  crossing a zero-price row) plus implausible outliers like 97999,
+  42149, 28927 (one-day "returns" from data quirks). Without
+  sanitation, portfolio_value = Σ weight × Inf = Inf. Layer 2:
+   - df.replace([inf, -inf], 0.0) — no-information treatment
+   - df.clip(-1.0, 1.0) — cap at ±100% daily move
+
+  8/8 regression tests PASS in 0.42s. Real-data end-to-end test
+  confirms: pre-W11-2 data has Inf values; post-W11-2 sanitation
+  output is bounded in [-1, 1] with no Inf.
+what_broke: |
+  The W11 audit-agent diagnosed the root cause as "price-level
+  cumprod overflow" — the suggested 1-layer pct_change conversion.
+  W11-2 self-test against the real dataset revealed the audit was
+  wrong: the data is ALREADY returns (median magnitude 0.0086).
+  The actual Inf comes from a small number of dirty data points,
+  NOT from price-level input.
+
+  Honest scar: audit agents work from reading code but miss
+  empirical realities. The contract was "fix the price-level
+  overflow"; the truth was "data is dirty, fix the sanitation."
+  Implementation expanded to a 2-layer guard covering both the
+  audit's diagnosis (defensive) AND the actual problem (root cause).
+what_youd_change: |
+  Clip at ±1.0 is somewhat arbitrary — a really volatile asset
+  could legitimately move >100% in a single day (e.g., a small-cap
+  pre-IPO). A more principled cap might be ±3.0 (300%) or a per-asset
+  rolling-volatility-based threshold. For paper-window FTSE-100
+  (large-cap index components) ±1.0 is safe.
+
+  Also: log dropped Inf / clipped values to surface data-quality
+  issues to the operator. Currently silent.
+assumption_to_challenge: |
+  Assumed: the audit agent's code-reading correctly identified the
+  root cause. CHALLENGE: even careful audits miss data realities —
+  always validate the diagnosis against the actual failing data
+  before committing to a fix shape. The empirical test ("does the
+  proposed input look like prices or returns?") should be part of
+  the audit, not a post-fix verification.
+
+  Closes:
+   - W10-CARRY-1 — portfolio Inf/NaN now resolved at the source.
+     The W11-3 smoke-test will verify finite portfolio_value
+     downstream.
+
+  No new carries.
+
+  Scars carried forward:
+   - W10-CARRY-2 (scenario differentiation) — W11-1 fixed dispatch;
+     W11-3 verifies.
+   - W7-1-CARRY-1 — full closure pending W11-3.
+---
+
+# W11-2 — portfolio_evaluator returns-space + sanitation
+
+## What changed
+
+- `python_refactor/src/experiments/portfolio_evaluator.py:87-130`:
+  Two-layer guard in `_get_asset_returns`:
+   1. Price-level detection (defensive, audit-suggested)
+   2. Returns sanitation: replace Inf, clip ±1.0 (actual root cause)
+- `python_refactor/tests/test_experiments_portfolio_evaluator.py` (NEW, 8 tests)
+
+## Verification
+
+- 8/8 regression tests PASS
+- Real paper-window dataset: 2 Inf values pre-W11-2 → 0 Inf post-W11-2
+- All values bounded in [-1, 1]
+
+## Closes
+
+- W10-CARRY-1 (portfolio NaN/Inf on real data)
+
+## Honest scar
+
+W11 audit-agent diagnosis was partially right (price-level overflow
+was a plausible cause) but missed the empirical truth (data is
+already returns; dirty Inf/outliers are the real problem). 2-layer
+guard covers both. Future audits should validate root cause against
+actual failing data, not just code structure.

--- a/python_refactor/src/experiments/portfolio_evaluator.py
+++ b/python_refactor/src/experiments/portfolio_evaluator.py
@@ -85,9 +85,44 @@ class PortfolioEvaluator:
             return {'Asset_0': 1.0}
     
     def _get_asset_returns(self, data: Dict[str, Any]) -> pd.DataFrame:
-        """Get asset returns from data."""
+        """Get asset returns from data.
+
+        W11-2 (closes W10-CARRY-1): two-layer guard for the
+        downstream `(1 + portfolio_returns).cumprod()` overflow:
+
+        1. Price-level guard (defensive): if the input median |value|
+           > 1.5, treat as price-level and convert via pct_change.
+           The W9-2 data_loader pivot DOES return returns (not prices)
+           for the standard path, but this protects callers that
+           supply raw prices.
+
+        2. Returns sanitation (the actual W10-CARRY-1 root cause):
+           the real 98-CSV paper-window dataset contains Inf returns
+           (pct_change crosses a zero-price quote — 2 occurrences in
+           the FTSE archive) plus implausible outliers (97999, 42149,
+           28927 — one-day "returns" from data-source quirks).
+           Without sanitation, portfolio_value = Σ weight × Inf = Inf.
+           Cap any |return| > 1.0 (100% daily move) at ±1.0 and replace
+           Inf with 0.0 (no-information treatment).
+        """
         if 'assets' in data and isinstance(data['assets'], pd.DataFrame):
-            return data['assets']
+            df = data['assets']
+            if df.empty:
+                return df
+            # Layer 1: price-level detection.
+            try:
+                median_magnitude = df.abs().median().median()
+            except Exception:
+                median_magnitude = 0.0
+            if median_magnitude > 1.5:
+                df = df.pct_change().dropna(how='all').fillna(0.0)
+            # Layer 2: returns sanitation — eliminate Inf and clip
+            # implausible outliers. Operates on returns-shaped output
+            # regardless of which path produced it.
+            import numpy as _np
+            df = df.replace([_np.inf, -_np.inf], 0.0)
+            df = df.clip(lower=-1.0, upper=1.0)
+            return df
         elif 'assets' in data and isinstance(data['assets'], dict):
             # Combine multiple asset dataframes
             combined_data = []

--- a/python_refactor/tests/test_experiments_portfolio_evaluator.py
+++ b/python_refactor/tests/test_experiments_portfolio_evaluator.py
@@ -1,0 +1,120 @@
+"""
+W11-2 regression tests for portfolio_evaluator._get_asset_returns.
+
+Pins the W10-CARRY-1 fix: when input DataFrame is price-level
+(median |value| > 1.5), convert via pct_change before returning.
+Returns-shaped input passes through unchanged.
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from src.experiments.portfolio_evaluator import PortfolioEvaluator
+
+
+class TestPriceVsReturnsDetection(unittest.TestCase):
+    """W11-2: price-level → pct_change; returns pass-through."""
+
+    def setUp(self):
+        self.ev = PortfolioEvaluator()
+
+    def test_price_level_input_is_converted_to_returns(self):
+        # Index/price levels in the thousands → median magnitude > 1.5.
+        prices = pd.DataFrame({
+            "AAPL": [150.0, 151.5, 149.0, 152.0],
+            "GOOG": [2800.0, 2830.0, 2780.0, 2810.0],
+        })
+        out = self.ev._get_asset_returns({"assets": prices})
+        # Returns shape is one row shorter (first row dropped by dropna).
+        self.assertEqual(len(out), 3)
+        # Values look like daily returns (|v| < 0.1 typically).
+        self.assertTrue((out.abs().max() < 0.1).all())
+        # Specific: (151.5 - 150) / 150 = 0.01
+        self.assertAlmostEqual(out["AAPL"].iloc[0], 0.01, places=6)
+
+    def test_returns_level_input_passes_through(self):
+        # Real return values < 0.2 in magnitude.
+        returns = pd.DataFrame({
+            "AAPL": [0.01, -0.005, 0.02, -0.01],
+            "GOOG": [0.005, 0.01, -0.015, 0.008],
+        })
+        out = self.ev._get_asset_returns({"assets": returns})
+        # No pct_change applied → exact pass-through.
+        pd.testing.assert_frame_equal(out, returns)
+
+    def test_returns_sanitation_replaces_inf(self):
+        """W10-CARRY-1 root cause: data_loader already produces returns
+        but they contain Inf values from pct_change crossing zero-price
+        quotes. The W11-2 second layer sanitizes them."""
+        dirty = pd.DataFrame({
+            "A": [0.01, float("inf"), -0.02, 0.005],
+            "B": [-0.005, 0.01, float("-inf"), 0.003],
+        })
+        out = self.ev._get_asset_returns({"assets": dirty})
+        self.assertFalse(np.isinf(out.values).any(), "Inf must be replaced")
+        # Inf → 0.0 (no-information treatment).
+        self.assertEqual(out["A"].iloc[1], 0.0)
+        self.assertEqual(out["B"].iloc[2], 0.0)
+
+    def test_returns_sanitation_clips_implausible_outliers(self):
+        """Real FTSE archive has one-day returns of 97999, 42149, 28927
+        from data-source quirks. Clip at ±1.0."""
+        outliers = pd.DataFrame({
+            "A": [0.01, 97999.0, -0.02, 0.005],
+            "B": [-0.005, 0.01, -42149.0, 0.003],
+        })
+        out = self.ev._get_asset_returns({"assets": outliers})
+        self.assertLessEqual(out.values.max(), 1.0)
+        self.assertGreaterEqual(out.values.min(), -1.0)
+        # Specific clips
+        self.assertEqual(out["A"].iloc[1], 1.0)
+        self.assertEqual(out["B"].iloc[2], -1.0)
+
+    def test_real_paper_window_no_inf_after_sanitation(self):
+        """End-to-end: real 98-CSV paper-window passes through
+        portfolio_evaluator with all values finite + bounded."""
+        from pathlib import Path
+        from src.experiments.data_loader import DataLoader
+        repo_root = Path(__file__).parents[2]
+        glob_path = repo_root / "legacy-cpp" / "executable" / "data" / "ftse-original" / "table*.csv"
+        if not glob_path.parent.exists():
+            self.skipTest(f"paper-window data not present at {glob_path.parent}")
+        loader = DataLoader()
+        assets_df = loader.load_asset_data([str(glob_path)], date_range={}, assets=[])
+        if assets_df.empty:
+            self.skipTest("data_loader returned empty")
+        # Pre-W11-2: there ARE Inf values in the real data.
+        self.assertGreater(np.isinf(assets_df.values).sum(), 0,
+                            "expected Inf values in pre-W11-2 data")
+        # Post-W11-2 sanitation: no Inf, bounded values.
+        out = self.ev._get_asset_returns({"assets": assets_df})
+        self.assertFalse(np.isinf(out.values).any())
+        self.assertLessEqual(np.nanmax(out.values), 1.0)
+        self.assertGreaterEqual(np.nanmin(out.values), -1.0)
+
+    def test_empty_dataframe_returns_empty(self):
+        empty = pd.DataFrame()
+        out = self.ev._get_asset_returns({"assets": empty})
+        self.assertTrue(out.empty)
+
+    def test_threshold_at_boundary_just_above(self):
+        # Median magnitude > 1.5 → triggers price-level conversion.
+        prices = pd.DataFrame({"x": [2.0, 2.04, 1.98, 2.02]})
+        out = self.ev._get_asset_returns({"assets": prices})
+        # Converted to returns (3 rows post-dropna), bounded.
+        self.assertEqual(len(out), 3)
+        self.assertTrue((out.abs() < 0.1).all().all())
+
+    def test_threshold_at_boundary_just_below(self):
+        # Median magnitude ≤ 1.5 → pass-through (no conversion).
+        # Values < 1.0 so sanitation clip is a no-op.
+        returns = pd.DataFrame({"x": [0.5, 0.6, -0.4, 0.3]})
+        out = self.ev._get_asset_returns({"assets": returns})
+        # Same shape, same values (no clip needed; no conversion).
+        pd.testing.assert_frame_equal(out, returns)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 2-layer guard in `_get_asset_returns`: price-level detection + returns sanitation (replace Inf, clip ±1.0)
- Real root cause: 2 Inf values + outliers (97999x) in actual FTSE archive — NOT price-level overflow as the audit suggested
- 8/8 tests including real-data end-to-end

## Closes

- ✅ W10-CARRY-1 (portfolio NaN/Inf on real data)

## Honest scar

Audit agent's code-reading diagnosis was partial. Self-test against real data revealed the empirical truth differed from the audit. Now both diagnoses are guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)