### PR TITLE
W14-1: walk-forward orchestrator (thesis §7.2.2 rolling-period)

### DIFF
--- a/.dfg/agents/W14-1-walk-forward-orchestrator.md
+++ b/.dfg/agents/W14-1-walk-forward-orchestrator.md
@@ -1,0 +1,57 @@
+---
+id: W14-1
+role: tooling-author
+name: Walk-forward rolling-period orchestrator (thesis §7.2.2)
+purpose: "New module: at each rolling period t, train SMS-EMOA on 1.5-year window → extract Pareto → compute Ŝ_{t+1} via W13-2 against next-period MLE Gaussian → return list per seed."
+wave: W14
+unit: W14-1
+depends_on: []
+blocks: [W14-2]
+governance_tier: VT1
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    - docs/THESIS-INDEX.md
+    - python_refactor/experiments/oos_evaluator.py
+    - python_refactor/experiments/oos_report.py
+    - python_refactor/experiments/validation_matrix.py
+output_contract:
+  files:
+    - python_refactor/experiments/walk_forward.py
+    - python_refactor/tests/test_experiments_walk_forward.py
+  branch_name: feat/w14-1-walk-forward-orchestrator
+  acceptance: >
+    walk_forward.py exposes run_walk_forward(scenario, seed,
+    full_returns, train_window_days≈378, step_days=50, n_mc=1000, rng)
+    → list of Ŝ_{t+1}. Defaults match thesis §7.2.3. Per-period output
+    includes trained Pareto weights + Ŝ_{t+1}. ≥ 5 regression tests.
+dispatch_instructions: |
+  Rolling protocol per thesis §7.2.2:
+    For t in 1..T-1 where T = floor((len(full_returns) - train_window_days) / step_days) + 1:
+      train_start = (t-1) * step_days
+      train_end   = train_start + train_window_days
+      oos_start   = train_end
+      oos_end     = oos_start + step_days  (the next period)
+      if oos_end > len(full_returns): break
+      train       = full_returns.iloc[train_start:train_end]
+      oos         = full_returns.iloc[oos_start:oos_end]
+
+      # train SMS-EMOA on `train` (in-process; same pattern as
+      # oos_report._run_one_scenario_seed)
+      # extract Pareto weights
+      # call compute_oos_efhv(weights, oos, n_samples=n_mc, rng) → Ŝ_{t+1}
+
+  Per-period results returned as a list of dicts:
+    {'period': t, 'train_range': (train_start, train_end),
+     'oos_range': (oos_start, oos_end), 'n_pareto': N,
+     'efhv_mean': Ŝ_{t+1}, 'efhv_std': MC std}
+
+  What NOT to do:
+    - Don't re-implement compute_oos_efhv (reuse W13-2).
+    - Don't change the algorithm — only the periodization.
+    - Don't ship the runner CLI (that's W14-2).
+---
+
+# W14-1 — Walk-forward orchestrator

--- a/.dfg/retrospectives/W14/W14-1.md
+++ b/.dfg/retrospectives/W14/W14-1.md
@@ -1,0 +1,103 @@
+---
+unit: W14-1
+wave: W14
+template: ADR-004-four-question
+schema_version: 1.0.0
+what_worked: |
+  ~160-line walk_forward.py module implementing thesis §7.2.2
+  rolling-period protocol:
+
+  enumerate_periods(n_days, train_window_days=378, step_days=50) →
+    list of {period, train_start, train_end, oos_start, oos_end}
+    per t = 1..T-1 where oos_end <= n_days.
+
+  run_walk_forward(scenario, seed, full_returns, train_window_days,
+                   step_days, n_mc, rng) →
+    list of per-period dicts with {period, train/oos ranges, n_pareto,
+    efhv_mean (Ŝ_{t+1}), efhv_std} for each rolling period.
+
+  aggregate_per_seed(per_period_results) →
+    {n_periods_ok, n_periods_total, grand_mean, grand_std}.
+
+  Reuses W13-2's compute_oos_efhv per period — no algorithmic
+  duplication. The orchestrator is pure periodization + glue.
+
+  9/9 regression tests pass in ~3s:
+   - Period enumeration arithmetic (basic 2-period case; thesis-config
+     yields 44 periods on our 2600-day window; train/oos non-overlap;
+     edge cases for too-long-train + no-oos-room)
+   - Aggregation (grand mean across periods; excludes errors/NaN;
+     all-errors returns NaN)
+   - End-to-end smoke: S0 × 2 periods on real 98-asset paper-window
+     data produces finite EFHV per period (~3s wall-clock; algorithm
+     completes; OOS evaluator gives non-degenerate values)
+what_broke: |
+  First version of the smoke test miscomputed the period count.
+  With n_days=500, train=200, step=50 I claimed "2 periods" but
+  the formula gives floor((500 − 200 − 50)/50) + 1 = 6 periods.
+  Caught by the test failure; fixed by using n_days=400 to get
+  exactly 2 periods. Lesson: re-derive period count from the
+  arithmetic every time.
+
+  The smoke test does NOT use the thesis defaults (378/50/1000)
+  because the full thesis config would run ~80 min for a single
+  test (44 periods × 30 generations × 1000 MC). Used reduced
+  (300/50/50) to keep test < 5s. Production runs in W14-2 will
+  use thesis defaults.
+what_youd_change: |
+  The current orchestrator runs serially within a (scenario, seed).
+  W14-2 will parallelize across (scenario, seed) pairs via
+  ProcessPoolExecutor (same pattern as W12-1 sweep).
+
+  Could add a checkpoint/resume mode: persist per-period results
+  to disk so a 6-hour 30-seed run can be resumed mid-run if
+  interrupted. Deferred to W14-2 if needed (~30-90 min compute
+  budget is acceptable without resume).
+
+  enumerate_periods uses INDEX-based slicing (.iloc[start:end])
+  rather than date-based. If the data has gaps (missing trading
+  days), the 50-day-shift granularity isn't exactly 2.5 months
+  in calendar terms — it's 50 trading-day rows. This matches
+  thesis "50 business days roughly corresponds to two and a half
+  months" (§7.2.3 footnote 4). OK as-is.
+assumption_to_challenge: |
+  Assumed: the W11-1 dispatch fix is sufficient for the
+  walk-forward training to ACTIVATE the anticipation property.
+  CHALLENGE: dispatch is necessary but not sufficient. Even if
+  learn_population is called at each generation, the algorithm
+  may not be USING the K-historical window (W13-CARRY-1) to
+  self-adjust λ_{t+h}. The K parameter isn't threaded through
+  SCENARIOS yet.
+
+  In other words: walk-forward EVALUATES at the right cadence
+  (period-by-period rolling), but the algorithm being walked-
+  forward may still be the wrong algorithm (K=0 effectively).
+  W14-2 will reveal whether this matters: if S2 mean OOS EFHV
+  STILL ≤ S0 under walk-forward, W13-CARRY-1 (K-aware
+  SCENARIOS, Option B / W15) becomes the next probe.
+
+  Closes nothing yet. Builds W14-2.
+
+  No new carries — W13-CARRY-1 and W13-CARRY-2 are still in
+  play; W14-2 will determine which fires.
+---
+
+# W14-1 — Walk-forward orchestrator
+
+## What changed
+
+- `python_refactor/experiments/walk_forward.py` (NEW, ~160 lines)
+- `python_refactor/tests/test_experiments_walk_forward.py` (NEW, 9 tests)
+
+## Verification
+
+- 9/9 tests pass in ~3s
+- Real-data smoke (S0 × 2 periods on paper-window 98-asset CSVs)
+  produces finite EFHV per period
+- Reuses W13-2 compute_oos_efhv — no algorithm duplication
+
+## Builds W14-2
+
+W14-2 will: enumerate (scenario, seed) pairs → call run_walk_forward
+per pair (likely in parallel via ProcessPoolExecutor) → aggregate
+to per-scenario grand mean ± std → update VALIDATION-RESULTS.md.

--- a/python_refactor/experiments/walk_forward.py
+++ b/python_refactor/experiments/walk_forward.py
@@ -1,0 +1,193 @@
+"""
+W14-1 Walk-forward OOS evaluator per thesis §7.2.2.
+
+The thesis evaluates at each rolling investment period t:
+  - Train SMS-EMOA on a 1.5-year window of historical returns
+  - Extract the trained Pareto-flexible set
+  - Observe the next-period MLE Gaussian χ_{t+1} on a 50-day window
+  - Compute Ŝ_{t+1} via W13-2 thesis Eqs (7.10)+(7.11)
+  - Roll the window forward by 50 business days; repeat
+
+Aggregation across periods (T-1 of them) + seeds (30) gives ~720
+observations per scenario — the unit on which paper Table 7.2's
+ANOVA is computed.
+
+Critical distinction from W13-3 (single-shot 80/20):
+  - At each period t, the algorithm sees ONLY data up to t (the
+    anticipation property is activated)
+  - The OOS evaluation uses the IMMEDIATELY NEXT period (not a
+    distant 20% tail) — matches the thesis's "investment period
+    decision" semantic
+  - Aggregation has ~24× the statistical power
+
+Defaults from thesis §7.2.3:
+  - train_window_days = 378 (~1.5 business years)
+  - step_days = 50 (~2.5 months — the rolling-shift granularity)
+  - n_mc = 1000 (E in Eq 7.11)
+  - z_ref = (0.2, 0.0)^T (handled by compute_oos_efhv default)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from experiments.oos_evaluator import compute_oos_efhv
+
+
+# ---------------------------------------------------------------------------
+# Period enumeration
+# ---------------------------------------------------------------------------
+
+def enumerate_periods(n_days: int, train_window_days: int = 378,
+                       step_days: int = 50) -> list[dict[str, int]]:
+    """Enumerate (train_range, oos_range) tuples for walk-forward.
+
+    Given a return-data length `n_days`, generate all periods t such that:
+      train_start = (t-1) * step_days
+      train_end   = train_start + train_window_days
+      oos_start   = train_end
+      oos_end     = oos_start + step_days
+    Where oos_end <= n_days. Period index starts at 1 (matching thesis).
+    """
+    periods: list[dict[str, int]] = []
+    t = 1
+    while True:
+        train_start = (t - 1) * step_days
+        train_end = train_start + train_window_days
+        oos_start = train_end
+        oos_end = oos_start + step_days
+        if oos_end > n_days:
+            break
+        periods.append({
+            "period": t,
+            "train_start": train_start,
+            "train_end": train_end,
+            "oos_start": oos_start,
+            "oos_end": oos_end,
+        })
+        t += 1
+    return periods
+
+
+# ---------------------------------------------------------------------------
+# Per-period training + OOS eval
+# ---------------------------------------------------------------------------
+
+def _train_and_extract_pareto(scenario: str, seed: int,
+                               train_returns: pd.DataFrame
+                               ) -> tuple[list[np.ndarray], int]:
+    """Train SMS-EMOA on the train window; extract Pareto weights.
+
+    Mirrors oos_report._run_one_scenario_seed but takes the pre-sliced
+    train block instead of loading the full window.
+    """
+    from experiments.validation_matrix import build_experiment_config
+    from src.experiments.experiment_manager import ExperimentManager
+
+    config = build_experiment_config(scenario, "paper", seed)
+    np.random.seed(seed)
+    suite_config = {
+        "experiment_name": f"wf_{scenario}_seed{seed}",
+        "description": "W14-1 walk-forward training",
+        "version": "W14-1",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+    mgr = ExperimentManager(suite_config)
+    n_assets = train_returns.values.shape[1]
+    data = {"assets": train_returns, "market": pd.DataFrame(),
+            "config": config.get("data", {})}
+    results = mgr._run_algorithm(config, data)
+    pareto = results.get("pareto_front", [])
+    weights: list[np.ndarray] = []
+    for sol in pareto:
+        w = getattr(sol.P, "investment", None)
+        if w is None:
+            continue
+        w_arr = np.asarray(w, dtype=float)
+        if w_arr.shape == (n_assets,):
+            weights.append(w_arr)
+    return weights, n_assets
+
+
+def run_walk_forward(scenario: str,
+                      seed: int,
+                      full_returns: pd.DataFrame,
+                      train_window_days: int = 378,
+                      step_days: int = 50,
+                      n_mc: int = 1000,
+                      rng: np.random.Generator | None = None
+                      ) -> list[dict[str, Any]]:
+    """Walk-forward evaluate one (scenario, seed) across all rolling periods.
+
+    Returns a list of per-period dicts:
+      {
+        'period': t (1-indexed),
+        'train_range': (train_start, train_end),
+        'oos_range': (oos_start, oos_end),
+        'n_pareto': int,
+        'efhv_mean': float (Ŝ_{t+1} from Eq 7.11),
+        'efhv_std': float (MC std across the E=n_mc scenarios),
+        'error': str (only if training failed; omitted otherwise)
+      }
+    """
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    periods = enumerate_periods(len(full_returns), train_window_days, step_days)
+    results: list[dict[str, Any]] = []
+    for p in periods:
+        train = full_returns.iloc[p["train_start"]:p["train_end"]]
+        oos = full_returns.iloc[p["oos_start"]:p["oos_end"]]
+        try:
+            weights, n_assets = _train_and_extract_pareto(scenario, seed, train)
+        except Exception as exc:
+            results.append({**p, "error": f"{type(exc).__name__}: {exc}",
+                              "efhv_mean": float("nan"), "efhv_std": float("nan"),
+                              "n_pareto": 0})
+            continue
+        if not weights:
+            results.append({**p, "n_pareto": 0,
+                              "efhv_mean": 0.0, "efhv_std": 0.0})
+            continue
+        # OOS slice must have at least 2 rows for cov estimation.
+        if len(oos) < 2:
+            results.append({**p, "n_pareto": len(weights),
+                              "efhv_mean": float("nan"), "efhv_std": float("nan"),
+                              "error": "oos_window_too_short"})
+            continue
+        efhv = compute_oos_efhv(
+            pareto_weights=weights,
+            oos_returns=oos,
+            n_samples=n_mc,
+            rng=rng,
+        )
+        results.append({
+            **p,
+            "n_pareto": len(weights),
+            "efhv_mean": efhv["efhv_mean"],
+            "efhv_std": efhv["efhv_std"],
+        })
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers (used by W14-2)
+# ---------------------------------------------------------------------------
+
+def aggregate_per_seed(per_period_results: list[dict[str, Any]]) -> dict[str, float]:
+    """Collapse per-period Ŝ_{t+1} into per-seed grand mean."""
+    valid = [r["efhv_mean"] for r in per_period_results
+              if "error" not in r and np.isfinite(r["efhv_mean"])]
+    if not valid:
+        return {"n_periods_ok": 0, "grand_mean": float("nan"),
+                "grand_std": float("nan")}
+    arr = np.asarray(valid, dtype=float)
+    return {
+        "n_periods_ok": len(arr),
+        "n_periods_total": len(per_period_results),
+        "grand_mean": float(arr.mean()),
+        "grand_std": float(arr.std(ddof=1)) if len(arr) >= 2 else 0.0,
+    }

--- a/python_refactor/tests/test_experiments_walk_forward.py
+++ b/python_refactor/tests/test_experiments_walk_forward.py
@@ -1,0 +1,142 @@
+"""
+W14-1 regression tests for walk_forward.
+
+Focuses on period-enumeration arithmetic + aggregation helpers.
+The training-loop call is exercised by a single S0-2-period
+integration smoke (fast — S0 takes ~0.5s/period).
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from experiments.walk_forward import (
+    aggregate_per_seed,
+    enumerate_periods,
+    run_walk_forward,
+)
+
+
+class TestEnumeratePeriods(unittest.TestCase):
+    def test_basic_enumeration(self):
+        # 500 days, 378 train + 50 step → t=1: train=[0,378), oos=[378,428); fits.
+        # t=2: train=[50,428), oos=[428,478); fits.
+        # t=3: train=[100,478), oos=[478,528); 528 > 500, NO.
+        periods = enumerate_periods(n_days=500, train_window_days=378,
+                                      step_days=50)
+        self.assertEqual(len(periods), 2)
+        self.assertEqual(periods[0]["period"], 1)
+        self.assertEqual(periods[0]["train_start"], 0)
+        self.assertEqual(periods[0]["train_end"], 378)
+        self.assertEqual(periods[0]["oos_start"], 378)
+        self.assertEqual(periods[0]["oos_end"], 428)
+        self.assertEqual(periods[1]["period"], 2)
+        self.assertEqual(periods[1]["train_start"], 50)
+        self.assertEqual(periods[1]["train_end"], 428)
+        self.assertEqual(periods[1]["oos_end"], 478)
+
+    def test_thesis_default_yields_about_24_periods(self):
+        # Paper-window data spans ~2600 trading days (2003-2012).
+        # With 378-day train + 50-day step:
+        # max periods = floor((2600 - 378 - 50) / 50) + 1 = floor(2172/50)+1 ≈ 44.
+        # Thesis FTSE has T=24 because they use a SHORTER total span (2006-2012).
+        # We verify the formula here for our larger dataset.
+        periods = enumerate_periods(n_days=2600, train_window_days=378,
+                                      step_days=50)
+        # 2172 / 50 = 43.44 → floor = 43; +1 = 44
+        self.assertEqual(len(periods), 44)
+
+    def test_train_oos_non_overlap(self):
+        periods = enumerate_periods(n_days=1000, train_window_days=300,
+                                      step_days=50)
+        for p in periods:
+            self.assertLess(p["train_end"], p["oos_end"])
+            self.assertEqual(p["oos_start"], p["train_end"])
+
+    def test_no_periods_when_train_too_long(self):
+        # Train alone is 600 days but data only has 500 days.
+        periods = enumerate_periods(n_days=500, train_window_days=600,
+                                      step_days=50)
+        self.assertEqual(periods, [])
+
+    def test_no_periods_when_oos_doesnt_fit(self):
+        # Train=378 fits; but train+step=428 > 400 (no OOS room).
+        periods = enumerate_periods(n_days=400, train_window_days=378,
+                                      step_days=50)
+        self.assertEqual(periods, [])
+
+
+class TestAggregatePerSeed(unittest.TestCase):
+    def test_grand_mean_across_periods(self):
+        per_period = [
+            {"period": 1, "efhv_mean": 0.001, "efhv_std": 1e-5},
+            {"period": 2, "efhv_mean": 0.002, "efhv_std": 1e-5},
+            {"period": 3, "efhv_mean": 0.003, "efhv_std": 1e-5},
+        ]
+        agg = aggregate_per_seed(per_period)
+        self.assertEqual(agg["n_periods_ok"], 3)
+        self.assertAlmostEqual(agg["grand_mean"], 0.002, places=10)
+
+    def test_excludes_errors_and_nans(self):
+        per_period = [
+            {"period": 1, "efhv_mean": 0.001},
+            {"period": 2, "efhv_mean": float("nan"), "error": "train failure"},
+            {"period": 3, "efhv_mean": 0.003},
+        ]
+        agg = aggregate_per_seed(per_period)
+        # Only periods 1 + 3 contribute.
+        self.assertEqual(agg["n_periods_ok"], 2)
+        self.assertAlmostEqual(agg["grand_mean"], 0.002, places=10)
+
+    def test_all_errors_returns_nan(self):
+        per_period = [
+            {"period": 1, "efhv_mean": float("nan"), "error": "x"},
+            {"period": 2, "efhv_mean": float("nan"), "error": "y"},
+        ]
+        agg = aggregate_per_seed(per_period)
+        self.assertEqual(agg["n_periods_ok"], 0)
+        self.assertTrue(np.isnan(agg["grand_mean"]))
+
+
+class TestRunWalkForwardSmoke(unittest.TestCase):
+    """Integration smoke: S0 × 2 periods. Slow-ish (~5s) but pins
+    the end-to-end glue between W14-1 and W13-2."""
+
+    def test_s0_few_periods_returns_finite_efhv(self):
+        # Load real paper-window data for the smoke (the algorithm
+        # needs realistic returns to produce non-degenerate Pareto fronts).
+        from pathlib import Path
+        from src.experiments.data_loader import DataLoader
+        repo_root = Path(__file__).parents[2]
+        glob_path = repo_root / "legacy-cpp" / "executable" / "data" / "ftse-original" / "table*.csv"
+        if not glob_path.parent.exists():
+            self.skipTest(f"paper-window data not at {glob_path.parent}")
+        loader = DataLoader()
+        full_returns = loader.load_asset_data([str(glob_path)],
+                                                date_range={}, assets=[])
+        # Use small train + step to keep the smoke fast.
+        # n_days=400, train=300, step=50:
+        #   t=1: train=[0,300), oos=[300,350); fits
+        #   t=2: train=[50,350), oos=[350,400); fits
+        #   t=3: train=[100,400), oos=[400,450); NO (450 > 400)
+        # → 2 periods.
+        full_returns = full_returns.iloc[:400]
+        results = run_walk_forward(
+            scenario="S0", seed=1,
+            full_returns=full_returns,
+            train_window_days=300,
+            step_days=50,
+            n_mc=50,  # small E for speed
+            rng=np.random.default_rng(1),
+        )
+        # Periods enumerated; all should produce finite EFHV.
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertNotIn("error", r)
+            self.assertGreater(r["n_pareto"], 0)
+            self.assertTrue(np.isfinite(r["efhv_mean"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

~160-line walk_forward.py implementing thesis §7.2.2 rolling-period evaluation. Reuses W13-2 compute_oos_efhv. 9/9 tests including real-data smoke.

## Tests

5 period-enumeration arithmetic + 3 aggregation helpers + 1 real-data smoke (S0 × 2 periods finite EFHV). 

## Builds W14-2

The orchestrator that consumes this to produce per-scenario grand mean ± std and update VALIDATION-RESULTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)