### PR TITLE
W16 replan: λ^K consumption + txn costs in HV + extrema preservation

### DIFF
--- a/.dfg/agents/W16-1-lambda-k-consumption.md
+++ b/.dfg/agents/W16-1-lambda-k-consumption.md
@@ -1,0 +1,138 @@
+---
+id: W16-1
+role: code-fixer
+name: Implement λ^K consumption in compute_anticipatory_learning_rate (BACKLOG H2 + W15-3-CARRY-1)
+purpose: "Closes BACKLOG H2 + W15-3-CARRY-1 consumption half. Verify both λ^H and λ^K arms fire per thesis Eq 7.16; implement λ^K (normalized KF squared-residual sum) if missing. The W16 keystone — highest-probability lever for closing the remaining 9% gap."
+wave: W16
+unit: W16-1
+depends_on: []
+blocks: [W16-4, W16-5]
+governance_tier: VT1
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    # Grounding details (pages, excerpts, reasons) in contract body
+    # below per BACKLOG §6 (schema requires plain-string list here).
+    - docs/BACKLOG.md
+    - docs/Azevedo_CarlosRenatoBelo_D.pdf
+    - python_refactor/src/algorithms/anticipatory_learning.py
+    - python_refactor/src/algorithms/multi_horizon_anticipatory.py
+    - python_refactor/src/algorithms/kalman_filter.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/anticipatory_learning.py
+    - python_refactor/tests/test_lambda_k_consumption.py
+  branch_name: feat/w16-1-lambda-k-consumption
+  acceptance: >
+    compute_anticipatory_learning_rate (or its callers) consume self.window_size
+    (K) to drive the λ^K arm per thesis Eq 7.16. λ = (1/2)(λ^H + λ^K) is the
+    canonical formula; verify or implement. ≥ 4 regression tests covering:
+    K=0 (λ^K=0, only λ^H fires), K>0 (both arms fire), squared-residual
+    accumulation correctness, balanced-tension semantic.
+dispatch_instructions: |
+  Closes BACKLOG: H2 + W15-3-CARRY-1 consumption half.
+
+  Surgical changes (in priority order):
+
+  1. AUDIT FIRST. Read compute_anticipatory_learning_rate in
+     anticipatory_learning.py. Determine:
+       - Is λ_t+h computed as a single scalar or as (1/2)(λ^H + λ^K)?
+       - Is λ^K (squared KF residual sum) computed at all?
+       - Does the function consume self.window_size?
+     Document the audit verdict in the PR description before any code change.
+
+  2. IF λ^K is missing (most likely per W15-5 retro hypothesis): implement
+     it per thesis Eq 7.16 + Eq (6.9). The formula uses normalized sum of
+     KF squared residuals over the historical window of size K. Required
+     state per portfolio: a deque/array of past KF prediction errors
+     of length ≤ K. On each invocation, accumulate (measurement - prediction)^T
+     (measurement - prediction); normalize to [0,1] sigmoid-style; combine
+     with λ^H via the (1/2) average.
+
+  3. IF self.window_size is already consumed but the formula is wrong:
+     fix the formula match thesis Eq 7.16 verbatim.
+
+  4. Add per-call trace export (just λ^H + λ^K + λ scalars per call, NOT
+     the full M3 instrumentation — that's W17). Sufficient for W16-4
+     verifier to confirm both arms fire.
+
+  What NOT to do:
+    - Don't touch sms_emoa.py — only anticipatory_learning.py + tests.
+    - Don't refactor the constructor signature (W15-3 + W15-5 already
+      fixed window_size kwarg threading).
+    - Don't add txn costs to HV (W16-2).
+    - Don't implement extrema preservation (W16-3).
+    - Don't ship the M-item instrumentation (W17).
+
+  PR body MUST echo the thesis Eq 7.16 verbatim + the audit verdict
+  (was λ^K missing or just wrong?) per BACKLOG §6 grounding discipline.
+---
+
+# W16-1 — Implement λ^K consumption per thesis Eq 7.16
+
+Closes BACKLOG.md items: **H2** (λ formula completeness) + **W15-3-CARRY-1**
+consumption half (constructor wired in W15-5 but consumption may be absent).
+
+## Thesis grounding
+
+**§7.2.3 Bayesian Tracking Parameters, Eq (7.16) (p. 146)** — verbatim:
+> "λ_{t+h} = (1/2)(λ_{t+h}^(H) + λ_{t+h}^(K)), for which the anticipation
+>  horizon is H = 2 (one-step-ahead prediction). The anticipation rate of
+>  each portfolio is thus determined not only by the estimated temporal
+>  incomparability probability between the current and the predictive
+>  objective distribution (λ_{t+h}^(H)), but also by the observed
+>  normalized sum of KF squared residuals (λ_{t+h}^(K))."
+>
+> "The motivation for taking the average (the 1/2 factor) of the two
+>  aforementioned self-adjustment strategies for setting λ_{t+h} can be
+>  explained by the intuition of providing a *balanced tension* in the
+>  OAL rule between:
+>  - The desire of *trusting* in decision paths that *were shown* to
+>    lead to higher predictable consequences *in the past*
+>    (λ^{K}_{t+h} in Eq (6.9)); and
+>  - The desire of *trusting* in decision paths that *are estimated* to
+>    lead to higher predictable consequences *in the future*
+>    (λ^{H}_{t+h} in Eq (6.6))."
+
+**§6.1.3 Eq (6.6), p. 117** — defines `λ_{t+h}^(H)` (TIP-based, future-looking).
+
+**§6.1.4 Eq (6.9), p. 119** — defines `λ_{t+h}^(K)` (squared-KF-residual,
+past-looking). Specifically: normalized sum of KF squared residuals over
+the historical window of size K periods.
+
+**§7.1.1 Investigated Algorithmic Variants (p. 140)** — K ∈ {0, 1, 2, 3}.
+For K = 0, λ^K = 0 by construction (no historical window).
+
+## Why this is the W16 keystone
+
+W15-5 retro analysis: the remaining -8.75% gap (S2 < S0) after closing
+all 4 BLOCKERS most likely traces to λ^K not consuming K. If only λ^H
+fires (TIP-driven future-looking arm), the OAL rule has *unbalanced*
+tension — only future trust, no past-validation. This degrades tracking
+quality, which directly degrades anticipatory HV estimation.
+
+## Files to touch
+
+- `python_refactor/src/algorithms/anticipatory_learning.py` — audit +
+  fix target. compute_anticipatory_learning_rate likely needs the λ^K
+  arm.
+- `python_refactor/src/algorithms/multi_horizon_anticipatory.py` —
+  W15-5 wired window_size kwarg into __init__; verify K propagates
+  to the rate computation.
+- `python_refactor/src/algorithms/kalman_filter.py` — squared residual
+  accumulation may live here; if so, expose getter.
+- `python_refactor/tests/test_lambda_k_consumption.py` — NEW; ≥ 4
+  regression tests per acceptance criteria.
+
+## Acceptance
+
+- compute_anticipatory_learning_rate consumes self.window_size (K)
+- λ = (1/2)(λ^H + λ^K) is the formula (verbatim Eq 7.16)
+- K=0 collapses to λ = (1/2)(λ^H + 0) — only future arm fires
+- K>0 both arms fire — λ^K is normalized sum of KF squared residuals
+  over last K periods
+- ≥ 4 regression tests covering the cases
+- Per-call trace logging of (λ^H, λ^K, λ) sufficient for W16-4 to
+  verify both arms fire in production

--- a/.dfg/agents/W16-2-transaction-costs-in-hv.md
+++ b/.dfg/agents/W16-2-transaction-costs-in-hv.md
@@ -1,0 +1,153 @@
+---
+id: W16-2
+role: code-fixer
+name: Integrate transaction costs into anticipatory HV objective (BACKLOG H1)
+purpose: "Closes BACKLOG H1. Subtract h(u_t, u*_{t-1}) (brokerage fees per thesis Table 7.1) from anticipatory ROI estimate before computing HV, so the optimizer sees and avoids high-churn portfolios per thesis §7.2 Eqs (7.4)-(7.5)."
+wave: W16
+unit: W16-2
+depends_on: []
+blocks: [W16-5]
+governance_tier: VT1
+sized: M
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    # Grounding details (pages, excerpts, reasons) in contract body
+    # below per BACKLOG §6 (schema requires plain-string list here).
+    - docs/BACKLOG.md
+    - docs/Azevedo_CarlosRenatoBelo_D.pdf
+    - python_refactor/src/config/thesis_parameters.py
+    - python_refactor/src/portfolio/portfolio.py
+    - python_refactor/src/portfolio/portfolio_evaluator.py
+    - python_refactor/src/algorithms/sms_emoa.py
+output_contract:
+  files:
+    - python_refactor/src/portfolio/portfolio.py
+    - python_refactor/src/algorithms/sms_emoa.py
+    - python_refactor/experiments/walk_forward.py
+    - python_refactor/tests/test_transaction_costs_in_hv.py
+  branch_name: feat/w16-2-transaction-costs-in-hv
+  acceptance: >
+    Transaction-cost function h(u_t, u*_{t-1}) integrated into the
+    anticipatory ROI computed by the SMS-EMOA evaluator. Brazilian
+    SEC fee schedule per thesis Table 7.1 (p. 144) implemented (proportional
+    + fixed by traded-value bracket). Previous-period implemented portfolio
+    (u*_{t-1}) threaded into the walk-forward driver so the optimizer
+    sees churn costs. ≥ 4 regression tests covering the fee schedule
+    + the optimizer-sees-cost integration.
+dispatch_instructions: |
+  Closes BACKLOG: H1.
+
+  Background. The current code (per BACKLOG H1) declares
+  TRANSACTION_COST_RATE=0.001 in thesis_parameters.py but only uses
+  it in the wealth-evaluation path (portfolio_evaluator), NOT in the
+  optimization objective. The optimizer is therefore BLIND to churn:
+  it can pick an EMFC whose realized future Hypv is eaten by trading
+  fees, and never know.
+
+  Surgical changes:
+
+  1. Add a `compute_transaction_cost(weights_new, weights_prev, portfolio_value)`
+     helper to portfolio.py implementing thesis Table 7.1 brackets:
+        traded_value = |weights_new - weights_prev| * portfolio_value, per asset
+        sum brokerage fee per bracket per asset
+        return total_fee / portfolio_value (i.e., cost as fraction of wealth)
+
+  2. Thread previous-period implemented portfolio u*_{t-1} into the
+     SMS-EMOA call site. In walk_forward.py rolling loop, capture the
+     implemented portfolio from period t-1 and pass it through to
+     run_optimization (default to equal-weight on first period).
+
+  3. In sms_emoa._evaluate_solution (or _compute_objectives), subtract
+     transaction cost from the ROI objective:
+        ROI_net = ROI - h(u_t, u*_{t-1})
+        solution.objectives = [ROI_net, risk]
+     (Keep `non_robust_ROI` as gross-of-cost for reporting; only the
+     objective passed to NDS + HV is net.)
+
+  4. Tests:
+     - Fee schedule brackets match thesis Table 7.1 within rounding
+     - Zero churn → zero cost
+     - Optimizer sees the cost: identical 2-portfolio pop where one
+       requires high churn from u*_{t-1} — verify the lower-churn one
+       wins HV contribution
+     - Walk-forward chain preserves u*_{t-1} across periods
+
+  What NOT to do:
+    - Don't touch anticipatory_learning.py (W16-1).
+    - Don't touch the operators (W15-2 — those are the right ones).
+    - Don't touch extrema preservation (W16-3).
+    - Don't enable txn costs in the wealth-evaluation path (already
+      done elsewhere; just integrate into HV objective).
+
+  PR body MUST echo thesis Eq (7.4)-(7.5) + Table 7.1 verbatim per
+  BACKLOG §6 grounding discipline.
+---
+
+# W16-2 — Integrate transaction costs into anticipatory HV objective
+
+Closes BACKLOG.md items: **H1**.
+
+## Thesis grounding
+
+**§7.2 Eqs (7.4)-(7.5), p. 142** — verbatim:
+> "Following the AS-MOO notation,
+>  z_t|u*_{t-1} = g(u_t, χ_t) + h(u_t, u*_{t-1}),
+>  where:
+>  g(u_t, χ_t) = (u_t^T Σ̂_{r,t} u_t, μ̂_{r,t}^T u_t)^T   (7.4)
+>  and
+>  h(u_t, u*_{t-1}) = (0, h(u_t, u*_{t-1}))^T            (7.5),
+>  in which h is a cost function representing all incurring
+>  transaction fees and commissions."
+
+The objective vector includes the h-cost component; the AS-MOO solver
+sees it in `z_t = g(u_t, χ_t) + h(u_t, u*_{t-1})`. Critically, h enters
+the OPTIMIZATION step, not just the wealth-evaluation step.
+
+**§7.2.3 "Brokerage Fees", Table 7.1 (p. 144)** — Brazilian Securities
+Commission fee schedule used by the thesis:
+
+| Traded value | Proportional Fee | Fixed Fee |
+|---|---|---|
+| < 135.07 | 0.0% | 2.70 |
+| ≥ 135.08 and < 498.62 | 2.0% | 0.00 |
+| ≥ 498.63 and < 1,514.69 | 1.5% | 2.49 |
+| ≥ 1,514.70 and < 3,029.38 | 1.0% | 10.06 |
+| ≥ 3,029.39 | 0.5% | 25.21 |
+
+**§5.2.4 "Time-Linkage Formulation", p. 105** — formal derivation of
+why h enters the objective at the OPTIMIZATION step, not just the
+wealth-evaluation step.
+
+## Why this contributes to closing the 9% gap
+
+Without txn costs in HV: the anticipatory rule may keep flipping the
+"best" EMFC every period because the optimizer cannot distinguish
+high-churn flexible choices from low-churn ones. The resulting
+realized future hypervolume (out-of-sample) is then eroded by costs
+the optimizer never modeled. This is consistent with the W15-5
+direction (S2 still < S0) — the anticipation IS happening but it's
+implementing portfolios that look better in the objective space than
+they actually realize.
+
+## Files to touch
+
+- `python_refactor/src/portfolio/portfolio.py` — add
+  `compute_transaction_cost(weights_new, weights_prev, portfolio_value)`
+- `python_refactor/src/algorithms/sms_emoa.py` — subtract cost from ROI
+  in _evaluate_solution
+- `python_refactor/experiments/walk_forward.py` — thread u*_{t-1}
+  through the rolling loop
+- `python_refactor/src/config/thesis_parameters.py` — Table 7.1
+  brackets as constants
+- `python_refactor/tests/test_transaction_costs_in_hv.py` — NEW
+
+## Acceptance
+
+- Brazilian SEC fee schedule per Table 7.1 implemented (≥ 4 brackets)
+- Optimizer sees the cost (ROI_net = ROI - h in NDS objective)
+- u*_{t-1} threaded across periods (equal-weight on period 1)
+- ≥ 4 regression tests
+- `non_robust_ROI` preserved as gross-of-cost for reporting (only
+  objective vector uses net)

--- a/.dfg/agents/W16-3-extrema-preservation.md
+++ b/.dfg/agents/W16-3-extrema-preservation.md
@@ -1,0 +1,119 @@
+---
+id: W16-3
+role: code-fixer
+name: Preserve rank-1 extrema (anchor) points in SMS-EMOA reduce step (BACKLOG H6)
+purpose: "Closes BACKLOG H6. Make rank-1 best-ROI and best-risk anchor solutions immune to SMS-EMOA's reduce step so the HV bounding box doesn't shrink over generations per standard SMS-EMOA / NSGA-II practice."
+wave: W16
+unit: W16-3
+depends_on: []
+blocks: [W16-5]
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    # Grounding details (pages, excerpts, reasons) in contract body
+    # below per BACKLOG §6 (schema requires plain-string list here).
+    - docs/BACKLOG.md
+    - docs/Azevedo_CarlosRenatoBelo_D.pdf
+    - python_refactor/src/algorithms/sms_emoa.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/sms_emoa.py
+    - python_refactor/tests/test_extrema_preservation.py
+  branch_name: feat/w16-3-extrema-preservation
+  acceptance: >
+    SMS-EMOA reduce step identifies rank-1 anchor solutions (max-ROI
+    and min-risk) and protects them from removal. Per-generation
+    [ROI_max, ROI_min, risk_max, risk_min] trace exported. ≥ 3
+    regression tests covering the protection invariant and the trace.
+dispatch_instructions: |
+  Closes BACKLOG: H6.
+
+  Background. SMS-EMOA's standard reduce step picks the worst-HV
+  contributor in the worst non-dominated rank for removal. This can
+  prune extrema if they happen to be in a crowded rank or if their
+  HV contribution is locally small. Over many generations the Pareto
+  front extent shrinks; the HV indicator (which is most sensitive to
+  bounding-box corners) becomes unstable.
+
+  Surgical changes:
+
+  1. In sms_emoa._reduce_population (or wherever the worst-contributor
+     selection lives), identify the rank-1 anchor solutions as the
+     argmax(ROI) and argmin(risk) within the current rank-1 set. Mark
+     them as protected (e.g., via a boolean flag or via a "skip-these-
+     indices" set passed to the worst-contributor selector).
+
+  2. If reduce wants to evict an anchor, evict the next-worst non-anchor
+     instead. Handle the edge case where rank-1 has < 3 solutions
+     (rare but possible).
+
+  3. Add a per-generation [ROI_max, ROI_min, risk_max, risk_min] trace
+     to metrics for downstream diagnosis.
+
+  4. Tests:
+     - Synthetic 10-portfolio rank-1 set with known extrema; verify
+       reduce never evicts the argmax(ROI) or argmin(risk).
+     - Stress: 100 reduce steps with anchor at borderline HV contribution;
+       verify anchor survives all 100.
+     - Trace: verify per-gen extrema-trace populated and monotone in
+       expected direction (front extent non-decreasing in best-case).
+
+  What NOT to do:
+    - Don't touch the operators (W15-2).
+    - Don't touch anticipatory_learning.py (W16-1).
+    - Don't touch txn costs (W16-2).
+    - Don't replace the SMS-EMOA reduce step algorithm — only add
+      anchor protection on top of the existing logic.
+
+  PR body MUST echo the relevant thesis + REF excerpts per BACKLOG §6.
+---
+
+# W16-3 — Preserve rank-1 extrema in SMS-EMOA reduce
+
+Closes BACKLOG.md items: **H6**.
+
+## Thesis grounding
+
+**§3.4.2 "S-Metric Selection Evolutionary Algorithm (SMS-EMOA)",
+pp. 69-70** — describes the base SMS-EMOA reduce step (Beume et al.
+2007 [REF 32]).
+
+**REF [Beume, Naujoks, Emmerich 2007] EJOR 181(3):1653-1669** —
+original SMS-EMOA paper; standard practice preserves extrema because
+the HV indicator is most sensitive to anchor solutions which define
+the bounding box.
+
+**STD** — standard SMS-EMOA / NSGA-II implementations explicitly
+preserve rank-1 anchors. The thesis inherits this convention
+implicitly.
+
+## Why this contributes to closing the 9% gap
+
+If extrema get pruned mid-generation, the HV indicator becomes
+non-monotone over time and the optimizer's selection pressure
+oscillates. This shows up empirically as:
+- Front extent shrinking over generations
+- HV trajectory non-monotone (sawtooth in per-gen HV plot)
+- Anticipatory rule trying to anticipate a moving target whose
+  bounding box is itself collapsing
+
+For the OOS-Future-HV metric, an unstable bounding box means we are
+predicting a moving target, which biases the predicted-vs-realized
+delta in unpredictable ways.
+
+## Files to touch
+
+- `python_refactor/src/algorithms/sms_emoa.py` — augment _reduce_population
+  with anchor protection + per-gen extrema trace.
+- `python_refactor/tests/test_extrema_preservation.py` — NEW; ≥ 3
+  regression tests.
+
+## Acceptance
+
+- argmax(ROI) and argmin(risk) within rank-1 are protected from reduce
+- Per-generation [ROI_max, ROI_min, risk_max, risk_min] trace
+- ≥ 3 regression tests
+- Edge case: rank-1 with < 3 solutions handled

--- a/.dfg/agents/W16-4-lambda-tip-trace-export.md
+++ b/.dfg/agents/W16-4-lambda-tip-trace-export.md
@@ -1,0 +1,132 @@
+---
+id: W16-4
+role: code-fixer
+name: Per-call λ + TIP trace export for W16-1 verification (BACKLOG M3 + M4 partial)
+purpose: "Closes BACKLOG M3 + M4 (partial — instrumentation scope). Export per-call (period, generation, solution_rank, λ^H, λ^K, λ, TIP) trace as CSV so W16-5 verifier can confirm both λ arms fire in production."
+wave: W16
+unit: W16-4
+depends_on: [W16-1]
+blocks: [W16-5]
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    # Grounding details (pages, excerpts, reasons) in contract body
+    # below per BACKLOG §6 (schema requires plain-string list here).
+    - docs/BACKLOG.md
+    - docs/Azevedo_CarlosRenatoBelo_D.pdf
+    - python_refactor/src/algorithms/anticipatory_learning.py
+    - python_refactor/experiments/walk_forward.py
+output_contract:
+  files:
+    - python_refactor/src/algorithms/anticipatory_learning.py
+    - python_refactor/experiments/walk_forward.py
+    - python_refactor/tests/test_lambda_tip_trace.py
+  branch_name: feat/w16-4-lambda-tip-trace-export
+  acceptance: >
+    Per-call (period, generation, solution_rank, λ^H, λ^K, λ, TIP)
+    rows accumulated during anticipatory rate computation. Exported as
+    `lambda_tip_trace.csv` alongside the existing metrics.csv in each
+    experiment-output directory. ≥ 2 regression tests covering the
+    trace row schema + the CSV emit.
+dispatch_instructions: |
+  Closes BACKLOG: M3 + M4 (partial — trace export scope only; full
+  Fig 7.4-7.13 rendering is W17 / W18).
+
+  Background. W16-1 implements λ^K consumption. W16-5 needs to
+  empirically confirm both λ arms fire in a real walk-forward run.
+  Without a trace, the smoke can only measure aggregate HV delta;
+  with the trace, we can verify the λ formula is operating as
+  designed before accepting the smoke result.
+
+  This unit ships MINIMAL instrumentation — just the (period, generation,
+  solution_rank, λ^H, λ^K, λ, TIP) tuple per anticipatory-learning
+  invocation. Full per-portfolio diagnostic plots are W17 / W18 (the
+  M-item instrumentation wave).
+
+  Surgical changes:
+
+  1. In anticipatory_learning.py, augment compute_anticipatory_learning_rate
+     to append a row to self._trace_rows: a list of dicts with keys
+     {period, generation, solution_rank, lambda_h, lambda_k, lambda,
+     tip}. Add a flush method to write self._trace_rows to a CSV.
+
+  2. In walk_forward.py, after each period's optimization completes,
+     call flush_trace to persist that period's rows to
+     `<results_dir>/lambda_tip_trace.csv` (append mode).
+
+  3. Tests:
+     - Trace row shape: each row has all 7 keys and correct dtypes.
+     - CSV emit: invoke a minimal AnticipatoryLearning, populate trace,
+       flush, read back, assert row count == calls.
+
+  Defer to W17 / W18:
+    - Full per-portfolio per-period λ plots (Figs 7.4-7.13)
+    - 1 - E[TIP] reduction over ranks (the figure shape)
+    - Per-seed aggregation + bootstrap CI
+
+  What NOT to do:
+    - Don't compute the figures (defer to W18).
+    - Don't add coherence/POCID/wealth trace (M6-M8 → W17).
+    - Don't touch sms_emoa.py beyond what's needed to pass period+
+      generation into the rate-computation call.
+    - Don't break the trace if W16-1's λ^K isn't yet wired (record
+      λ^K=NaN if missing; W16-5 will catch via the verifier).
+
+  PR body MUST cite TH Eq (6.4) (TIP) + Eq (7.16) (λ) verbatim per
+  BACKLOG §6.
+---
+
+# W16-4 — Per-call λ + TIP trace export
+
+Closes BACKLOG.md items: **M3** + **M4** (partial — trace export scope
+only; full Fig 7.4-7.13 rendering is W17 / W18).
+
+## Thesis grounding
+
+**§7.3.1 "Estimated Confidence Over the Stochastic Pareto Frontiers
+(SPFs)", p. 148** — verbatim:
+> "We recall that, according to the OAL rules proposed in chapter 6,
+>  the available KF predictive objective distributions of portfolios
+>  associated with higher predictive confidence are more intensely
+>  incorporated into the resulting anticipatory distributions...
+>  Moreover, recall that rank 1 portfolios correspond to the highest
+>  risk/return, whereas a rank 20 one corresponds to the lowest
+>  risk/return in the population."
+
+**§6.1.3 Eq (6.4), p. 116** — TIP (Temporal Incomparability Probability)
+definition.
+
+**§7.3.1 Figs 7.4-7.13, pp. 150-155** — show `1 - E[TIP]` per portfolio
+rank, averaged over all periods, for each (instance, K, DM) combination.
+This is the visualization downstream of the trace.
+
+**§7.2.3 Eq (7.16), p. 146** — λ = (1/2)(λ^H + λ^K). The trace records
+all 3 scalars per call so W16-5 can confirm both arms fire after W16-1.
+
+## Why this contributes to closing the 9% gap
+
+This is verifier-infrastructure for W16-1 + W16-5. Without the trace,
+W16-5 can only measure aggregate HV delta and infer whether λ^K is
+firing — high inference noise. With the trace, we can directly assert
+"both λ^H AND λ^K are nonzero in production for K>0 scenarios" and
+distinguish "λ^K firing but didn't help" from "λ^K silently zero".
+
+## Files to touch
+
+- `python_refactor/src/algorithms/anticipatory_learning.py` —
+  self._trace_rows + flush method
+- `python_refactor/experiments/walk_forward.py` — call flush after
+  each period
+- `python_refactor/tests/test_lambda_tip_trace.py` — NEW; ≥ 2 tests
+
+## Acceptance
+
+- Trace rows have schema {period, generation, solution_rank,
+  lambda_h, lambda_k, lambda, tip}
+- CSV `lambda_tip_trace.csv` emitted in each experiment-output dir
+- ≥ 2 regression tests
+- Works even if W16-1 cycle-1 left λ^K=NaN (then trace shows NaN
+  honestly)

--- a/.dfg/agents/W16-5-integration-smoke.md
+++ b/.dfg/agents/W16-5-integration-smoke.md
@@ -1,0 +1,111 @@
+---
+id: W16-5
+role: verifier
+name: Integration smoke with W16 fixes (λ^K + txn costs + extrema)
+purpose: "Verify W16-1+W16-2+W16-3+W16-4 combined effect: re-run 2-seed walk-forward smoke on {SMS_RDM_K0, ASMS_mHDM_K3}; report Δ(S2 vs S0); commit empirical receipt + λ^K + λ^H trace assertions."
+wave: W16
+unit: W16-5
+depends_on: [W16-1, W16-2, W16-3, W16-4]
+blocks: []
+governance_tier: VT1
+sized: S
+hardening_max_cycles: 1
+prompt_version: 1
+read_contract:
+  must_read:
+    # Grounding details (reasons) in contract body below per BACKLOG §6
+    # (schema requires plain-string list here).
+    - docs/BACKLOG.md
+    - docs/OOS-EFHV-W15-INTEGRATION-SMOKE.md
+    - python_refactor/experiments/walk_forward_report.py
+output_contract:
+  files:
+    - docs/OOS-EFHV-W16-INTEGRATION-SMOKE.md
+    - .dfg/retrospectives/W16/W16-5.md
+  branch_name: feat/w16-5-integration-smoke
+  acceptance: >
+    Re-run W15-5 walk-forward smoke with SMS_RDM_K0 + ASMS_mHDM_K3
+    after W16-1..W16-4 land. Empirical Δ(S2 − S0) reported honestly.
+    Assertions over lambda_tip_trace.csv: both λ^H AND λ^K nonzero for
+    K>0 scenarios; λ^K=0 (or trivially small) for K=0 scenario.
+    Retro qualitative inspection.
+dispatch_instructions: |
+  Run smoke (2 seeds × 2 scenarios × paper-window date range), same
+  shape as W15-5.
+
+  Expected wall-clock: similar to W15-5 (~15 min). Use foreground
+  invocation (NOT walk_forward_report.py with ProcessPoolExecutor —
+  it silently masks per-pair errors per W15-5-CARRY-1).
+
+  Report direction honestly:
+    - If S2 > S0: W7→W16 chain structurally complete; paper claim
+      direction replicates. WAVE-CLOSE VERDICT = PASS-DIRECTION-REPLICATED.
+    - If S2 ≤ S0 but gap < W15-5's -8.75%: incremental improvement;
+      remaining gap is in M-items (instrumentation) or H4 (asset
+      universe). WAVE-CLOSE VERDICT = PASS-FURTHER-GAP-CLOSURE.
+    - If S2 ≤ S0 and gap ≥ W15-5: regression. Investigate λ^K + txn
+      cost interaction; possible that lambda_tip_trace.csv shows λ^K
+      always 0 or always 1 (saturation). WAVE-CLOSE VERDICT = HOLD-FOR-DEBUG.
+
+  Trace assertions (load lambda_tip_trace.csv from one of the
+  ASMS_mHDM_K3 runs; assert):
+    - λ^H ∈ [0,1] for all rows
+    - λ^K ∈ [0,1] for all rows
+    - For K=3 runs: mean(λ^K) > 0.01 (truly fires, not just 0)
+    - For K=0 runs: mean(λ^K) < 1e-6 (effectively zero by construction)
+    - λ ≈ 0.5*(λ^H + λ^K) within 1e-9 (formula correctness)
+
+  What NOT to do:
+    - Don't ship the analytics (W18).
+    - Don't refactor walk_forward_report.py (file the per-pair error
+      visibility as W16-CARRY if surfaced).
+    - Don't run the full 30-seed grid (still a smoke; full grid is W18).
+---
+
+# W16-5 — Integration smoke with W16 fixes
+
+Closes BACKLOG.md items: integration receipt + trace verification of
+W16-1..W16-4.
+
+## Background
+
+W15-5 smoke result (post-BLOCKERS, pre-W16):
+  SMS_RDM_K0    = 4.041e-04 ± 2.66e-05
+  ASMS_mHDM_K3  = 3.687e-04 ± 1.17e-05
+  Δ(S2 − S0)    = -8.75%
+
+W15 closed 65% of the gap from W14-2's -24.86%. The remaining 9% is
+hypothesized (per W15-5 retro analysis) to come from:
+  1. λ^K not consumed (W16-1)
+  2. Transaction costs not in HV (W16-2)
+  3. Extrema oscillation (W16-3)
+
+W16-5 measures the COMBINED effect.
+
+## Trace assertions
+
+W16-4 emits `lambda_tip_trace.csv`. The verifier loads it and runs
+the following assertions:
+
+- λ^H ∈ [0,1] for all rows
+- λ^K ∈ [0,1] for all rows
+- mean(λ^K) > 0.01 for K=3 scenarios (proof of life)
+- mean(λ^K) < 1e-6 for K=0 scenarios (correct by construction)
+- λ ≈ 0.5*(λ^H + λ^K) within 1e-9 (Eq 7.16 verbatim)
+
+If any assertion fails: W16-1's λ^K consumption is mis-wired even if
+the smoke shows direction reversal.
+
+## Wave-close verdict matrix
+
+| Outcome | Verdict |
+|---|---|
+| S2 > S0 | PASS-DIRECTION-REPLICATED |
+| S2 ≤ S0, gap < -8.75% (W15-5 baseline) | PASS-FURTHER-GAP-CLOSURE |
+| S2 ≤ S0, gap ≥ -8.75% | HOLD-FOR-DEBUG |
+
+## Files
+
+- `docs/OOS-EFHV-W16-INTEGRATION-SMOKE.md` — smoke report with
+  receipts + trace-assertion outcomes
+- `.dfg/retrospectives/W16/W16-5.md` — ADR-004 four-question retro

--- a/.dfg/plan.yaml
+++ b/.dfg/plan.yaml
@@ -1162,3 +1162,106 @@ waves:
         - "W15-5 integration smoke completes; Δ(S2 vs S0) reported honestly"
         - "Retros at .dfg/retrospectives/W15/W15-N.md with ADR-004 canonical keys"
       checkpoint_file: .dfg/checkpoints/W15-gate.md
+
+  - id: W16
+    name: λ^K consumption + txn costs in HV + extrema preservation + trace export
+    state: PLANNED
+    # Added 2026-05-17 via post-W15 replan. W16 keystone = W16-1
+    # (λ^K consumption per Eq 7.16) per W15-gate critical-path
+    # analysis. Targets the remaining -8.75% Δ(S2−S0) gap.
+    units:
+      - id: W16-1
+        slug: lambda-k-consumption
+        name: Implement λ^K consumption in compute_anticipatory_learning_rate (BACKLOG H2 + W15-3-CARRY-1)
+        purpose: "Closes BACKLOG H2 + W15-3-CARRY-1 consumption half. Verify both λ^H and λ^K arms fire per thesis Eq 7.16; implement λ^K (normalized KF squared-residual sum) if missing. W16 keystone."
+        files:
+          - python_refactor/src/algorithms/anticipatory_learning.py
+          - python_refactor/tests/test_lambda_k_consumption.py
+        depends_on: []
+        size: M
+        acceptance_criteria:
+          - "compute_anticipatory_learning_rate consumes self.window_size (K)"
+          - "λ = (1/2)(λ^H + λ^K) formula matches thesis Eq 7.16 verbatim"
+          - "K=0 collapses to λ = (1/2)(λ^H + 0) — only future arm fires"
+          - "K>0 both arms fire — λ^K is normalized sum of KF squared residuals over last K periods"
+          - "≥ 4 regression tests covering the cases above"
+
+      - id: W16-2
+        slug: transaction-costs-in-hv
+        name: Integrate transaction costs into anticipatory HV objective (BACKLOG H1)
+        purpose: "Closes BACKLOG H1. Subtract h(u_t, u*_{t-1}) brokerage fees per Table 7.1 from ROI before HV so optimizer sees churn per §7.2 Eqs (7.4)-(7.5)."
+        files:
+          - python_refactor/src/portfolio/portfolio.py
+          - python_refactor/src/algorithms/sms_emoa.py
+          - python_refactor/experiments/walk_forward.py
+          - python_refactor/tests/test_transaction_costs_in_hv.py
+        depends_on: []
+        size: M
+        acceptance_criteria:
+          - "compute_transaction_cost helper implements Brazilian SEC fee schedule per thesis Table 7.1"
+          - "Optimizer sees the cost: ROI_net = ROI - h in NDS objective vector"
+          - "u*_{t-1} threaded across periods in walk_forward.py (equal-weight on period 1)"
+          - "non_robust_ROI preserved as gross-of-cost for reporting (only objective vector uses net)"
+          - "≥ 4 regression tests: fee schedule brackets + optimizer-sees-cost integration"
+
+      - id: W16-3
+        slug: extrema-preservation
+        name: Preserve rank-1 extrema (anchor) points in SMS-EMOA reduce step (BACKLOG H6)
+        purpose: "Closes BACKLOG H6. Make rank-1 best-ROI and best-risk anchor solutions immune to SMS-EMOA reduce step so HV bounding box doesn't shrink over generations per standard SMS-EMOA practice."
+        files:
+          - python_refactor/src/algorithms/sms_emoa.py
+          - python_refactor/tests/test_extrema_preservation.py
+        depends_on: []
+        size: S
+        acceptance_criteria:
+          - "argmax(ROI) and argmin(risk) within rank-1 protected from reduce eviction"
+          - "Per-generation [ROI_max, ROI_min, risk_max, risk_min] trace exported"
+          - "≥ 3 regression tests (synthetic + stress + trace)"
+          - "Edge case: rank-1 with < 3 solutions handled"
+
+      - id: W16-4
+        slug: lambda-tip-trace-export
+        name: Per-call λ + TIP trace export for W16-1 verification (BACKLOG M3+M4 partial)
+        purpose: "Closes BACKLOG M3 + M4 (partial trace-export scope). Export per-call (period, generation, solution_rank, λ^H, λ^K, λ, TIP) as CSV so W16-5 can confirm both λ arms fire."
+        files:
+          - python_refactor/src/algorithms/anticipatory_learning.py
+          - python_refactor/experiments/walk_forward.py
+          - python_refactor/tests/test_lambda_tip_trace.py
+        depends_on: [W16-1]
+        size: S
+        acceptance_criteria:
+          - "Trace rows schema: {period, generation, solution_rank, lambda_h, lambda_k, lambda, tip}"
+          - "lambda_tip_trace.csv emitted in each experiment-output dir"
+          - "≥ 2 regression tests covering row schema + CSV emit"
+          - "Honest NaN for λ^K if W16-1 cycle-1 leaves it unset"
+
+      - id: W16-5
+        slug: integration-smoke
+        name: Integration smoke with W16 fixes (λ^K + txn costs + extrema)
+        purpose: "Verify W16-1..W16-4 combined effect: re-run walk-forward smoke; report Δ(S2 vs S0); commit empirical receipt + λ^K + λ^H trace assertions."
+        files:
+          - docs/OOS-EFHV-W16-INTEGRATION-SMOKE.md
+          - .dfg/retrospectives/W16/W16-5.md
+        depends_on: [W16-1, W16-2, W16-3, W16-4]
+        size: S
+        acceptance_criteria:
+          - "Re-run W15-5 smoke shape (2 seeds × {SMS_RDM_K0, ASMS_mHDM_K3} × paper window)"
+          - "Empirical Δ(S2 − S0) reported honestly with comparison vs W15-5 baseline (-8.75%)"
+          - "Trace assertions: λ ≈ 0.5*(λ^H + λ^K) within 1e-9; mean(λ^K) > 0.01 for K=3"
+          - "Wave-close verdict per W16-5 matrix: PASS-DIRECTION-REPLICATED / PASS-FURTHER-GAP-CLOSURE / HOLD-FOR-DEBUG"
+
+    parallel_groups:
+      - [W16-1, W16-3]
+      - [W16-2]
+      - [W16-4]
+      - [W16-5]
+
+    gate:
+      gate_type: wave-gate
+      criteria:
+        - "All 5 units MERGED with green pre-pr battery"
+        - "BACKLOG items H1, H2, H6 closed; M3+M4 partially closed (trace-export half)"
+        - "All 5 unit contracts follow BACKLOG §6 canonical template (plain-string must_read + body grounding with verbatim thesis excerpts)"
+        - "W16-5 integration smoke completes; trace assertions pass; Δ(S2 vs S0) reported honestly with verdict per W16-5 matrix"
+        - "Retros at .dfg/retrospectives/W16/W16-N.md with ADR-004 canonical keys"
+      checkpoint_file: .dfg/checkpoints/W16-gate.md


### PR DESCRIPTION
## Summary

Replan W16: target the remaining -8.75% Δ(S2−S0) gap after W15-gate's 65% closure.

## 5 units (focused on critical path)

| Unit | Size | Theme | BACKLOG |
|---|---|---|---|
| **W16-1** | M | **λ^K consumption** in compute_anticipatory_learning_rate per Eq 7.16 (KEYSTONE) | H2 + W15-3-CARRY-1 consumption half |
| W16-2 | M | Integrate Brazilian SEC fee schedule (Table 7.1) into HV objective | H1 |
| W16-3 | S | Preserve rank-1 extrema in SMS-EMOA reduce step | H6 |
| W16-4 | S | Per-call (λ^H, λ^K, λ, TIP) trace export | M3 + M4 partial |
| W16-5 | S | Integration smoke + trace assertions | (verifier) |

## Why these 5

W15-5 retro hypothesis ordering for the remaining 9%:
1. λ^K not consumed (constructor wired in W15-5, but consumption likely absent) — W16-1
2. Transaction costs not in HV objective (TRANSACTION_COST_RATE declared but unused in optimization) — W16-2
3. Extrema oscillation (HV bounding box shrinks if anchors get pruned) — W16-3

W16-4 ships minimal instrumentation so W16-5 can directly assert "λ^K fires for K>0" rather than infer it from aggregate HV.

M-item full instrumentation (M1, M2, M5-M8, M13) deferred to W17.
Asset-universe H4 (87 vs 98) deferred to W17 (less likely lever).

## Topology (file-disjoint parallel_groups)

- **L0:** W16-1 (anticipatory_learning.py) + W16-3 (sms_emoa.py)
- **L1:** W16-2 (sms_emoa.py + portfolio.py + walk_forward.py — after W16-3)
- **L2:** W16-4 (anticipatory_learning.py + walk_forward.py — after W16-1 + W16-2)
- **L3:** W16-5 (doc + retro only)

## Contracts

Each W16-N contract follows the **updated BACKLOG §6 template** (PR #87):
- YAML `must_read` = plain-string list
- Body markdown = thesis grounding with verbatim excerpts per item
- Closes-BACKLOG echo in body

## Wave-close verdict matrix (W16-5)

| Outcome | Verdict |
|---|---|
| S2 > S0 | PASS-DIRECTION-REPLICATED (paper claim replicates) |
| S2 ≤ S0, gap < -8.75% | PASS-FURTHER-GAP-CLOSURE |
| S2 ≤ S0, gap ≥ -8.75% | HOLD-FOR-DEBUG |

## Test plan
- [x] dfg validate clean (plan.yaml + 5 contracts)
- [x] parallel_groups file-disjoint
- [ ] W16-1..W16-4 ship as PRs
- [ ] W16-5 integration smoke reports verdict
- [ ] W16-gate emits WaveGatePass

🤖 Generated with [Claude Code](https://claude.com/claude-code)