### PR TITLE
W16-1: λ^K consumption per thesis Eq 7.16 + Eq 6.9 (BACKLOG H2 + W15-3-CARRY-1)

### DIFF
--- a/python_refactor/src/algorithms/anticipatory_learning.py
+++ b/python_refactor/src/algorithms/anticipatory_learning.py
@@ -169,7 +169,19 @@ class AnticipatoryLearning:
         
         # Anticipative distributions storage
         self.anticipative_distributions = []
-        
+
+        # W16-1: per-period KF squared-residual buffer for λ^K (Eq 6.9).
+        # Length-K rolling window; each entry is the sum of per-asset
+        # squared residuals (innovation^T @ innovation) for the most
+        # recent K periods. Used to compute λ^K = normalized(sum(...)).
+        # K=0 disables; in that case λ^K is identically 0 per §7.1.1 K=0.
+        self._kf_residual_window: List[float] = []
+
+        # W16-1: per-call trace of the (λ^H, λ^K, λ, TIP) tuple per
+        # invocation of compute_anticipatory_learning_rate. W16-4
+        # ships CSV emit on top of this list.
+        self._lambda_trace_rows: List[Dict[str, Any]] = []
+
         # Stochastic Pareto frontiers storage for visualization
         self.stochastic_pareto_frontiers = []
         self.anticipative_pareto_frontiers = []
@@ -247,55 +259,167 @@ class AnticipatoryLearning:
         return SimpleNamespace(P=shadow_portfolio)
 
     def compute_anticipatory_learning_rate(self, solution: Solution, min_error: float,
-                                         max_error: float, min_alpha: float, max_alpha: float, 
+                                         max_error: float, min_alpha: float, max_alpha: float,
                                          current_time: int, tip_calculator: Optional[TemporalIncomparabilityCalculator] = None,
-                                         predicted_solution: Optional[Solution] = None, horizon: int = 2) -> float:
+                                         predicted_solution: Optional[Solution] = None, horizon: int = 2,
+                                         generation: int = -1, solution_rank: int = -1) -> float:
         """
-        Compute anticipatory learning rate using TIP integration (Equation 7.16).
-        
-        This implements the enhanced formula that combines TIP and Kalman Filter residuals:
+        Compute anticipatory learning rate per thesis Eq 7.16 (W16-1).
+
         λ_{t+h} = (1/2) * (λ^{(H)}_{t+h} + λ^{(K)}_{t+h})
-        
+
+        where:
+          λ^H_{t+h} = TIP-based future-looking rate (Eq 6.6, §6.1.3 p.117)
+          λ^K_{t+h} = normalized sum of KF squared residuals over the
+                      last K periods (Eq 6.9, §6.1.4 p.119)
+
+        Per §7.1.1 (p. 140), K ∈ {0,1,2,3}. For K = 0 (myopic SMS-EMOA),
+        λ^K is identically 0 by construction (no historical window).
+        For K > 0, λ^K accumulates squared residuals from
+        self._kf_residual_window (managed by the caller via
+        record_kf_residual / _maybe_record_kf_residual).
+
+        The (1/2) factor is the verbatim Eq 7.16 "balanced tension"
+        average between past-trust (λ^K) and future-trust (λ^H).
+
         Args:
             solution: Solution to compute learning rate for
-            min_error: Minimum prediction error in population
-            max_error: Maximum prediction error in population
-            min_alpha: Minimum alpha in population
-            max_alpha: Maximum alpha in population
+            min_error: Minimum prediction error in population (for fallback λ^K)
+            max_error: Maximum prediction error in population (for fallback λ^K)
+            min_alpha: Minimum alpha in population (for fallback λ^K)
+            max_alpha: Maximum alpha in population (for fallback λ^K)
             current_time: Current time step
-            tip_calculator: TIP calculator instance
+            tip_calculator: TIP calculator instance (drives λ^H)
             predicted_solution: Predicted solution for TIP calculation
-            horizon: Prediction horizon
-            
+            horizon: Prediction horizon (default 2 per Eq 7.16)
+            generation: Generation index for trace (W16-4 plumbing)
+            solution_rank: Rank index for trace (W16-4 plumbing)
+
         Returns:
-            Anticipatory learning rate
+            Anticipatory learning rate λ_{t+h} ∈ [0, 0.5]
         """
-        # Traditional learning rate (Kalman Filter based)
-        traditional_rate = self._compute_traditional_learning_rate(
+        # ── λ^K: past-looking (Eq 6.9) ──────────────────────────────
+        # If K = 0 OR the residual window is empty: λ^K = 0 (thesis
+        # §7.1.1 K=0 myopic SMS-EMOA collapse). Otherwise λ^K =
+        # normalized sum of KF squared residuals over the last K periods.
+        lambda_k = self._compute_lambda_k(
             solution, min_error, max_error, min_alpha, max_alpha, current_time
         )
-        
-        # TIP-based learning rate (Equation 6.6)
-        tip_rate = 0.0
+
+        # ── λ^H: future-looking (Eq 6.6) ────────────────────────────
+        lambda_h = 0.0
+        tip_value = float("nan")
         if tip_calculator is not None and predicted_solution is not None:
             try:
-                # Calculate TIP
-                tip = tip_calculator.calculate_tip(solution, predicted_solution)
-                
-                # Calculate TIP-based learning rate (Equation 6.6)
-                tip_rate = tip_calculator.calculate_anticipatory_learning_rate_tip(tip, horizon)
-                
+                tip_value = tip_calculator.calculate_tip(solution, predicted_solution)
+                lambda_h = tip_calculator.calculate_anticipatory_learning_rate_tip(
+                    tip_value, horizon
+                )
             except Exception as e:
-                logger.warning(f"TIP calculation failed: {e}, using traditional rate only")
-                tip_rate = 0.0
-        
-        # Combined learning rate (Equation 7.16)
-        if tip_rate > 0.0:
-            combined_rate = 0.5 * (traditional_rate + tip_rate)
-        else:
-            combined_rate = traditional_rate
-        
-        return combined_rate
+                logger.warning(f"TIP calculation failed: {e}; λ^H set to 0")
+                lambda_h = 0.0
+                tip_value = float("nan")
+
+        # ── Combined λ per Eq 7.16 verbatim ─────────────────────────
+        # ALWAYS the (1/2) average, even when one arm is 0. Per the
+        # thesis motivation: "balanced tension" between past-trust
+        # and future-trust requires the average, not a fall-back.
+        # Pre-W16-1 code short-circuited to traditional_rate when
+        # tip_rate==0, which violated Eq 7.16 (the formula is the
+        # average even if one term is zero).
+        lambda_combined = 0.5 * (lambda_h + lambda_k)
+
+        # ── W16-1 trace plumbing (W16-4 builds CSV emit on top) ────
+        self._lambda_trace_rows.append({
+            "period": current_time,
+            "generation": generation,
+            "solution_rank": solution_rank,
+            "lambda_h": lambda_h,
+            "lambda_k": lambda_k,
+            "lambda": lambda_combined,
+            "tip": tip_value,
+        })
+
+        return lambda_combined
+
+    def _compute_lambda_k(self, solution: Solution, min_error: float,
+                          max_error: float, min_alpha: float, max_alpha: float,
+                          current_time: int) -> float:
+        """
+        Compute λ^K per thesis Eq 6.9 (§6.1.4 p.119, W16-1).
+
+        λ^K_{t+h} is the normalized sum of KF squared residuals over
+        the historical window of size K (= self.window_size).
+
+        Per §7.1.1 (p. 140), K = 0 disables anticipation entirely.
+        In that case λ^K ≡ 0 by construction (no historical window
+        exists to sum residuals over).
+
+        For K > 0 with an empty / under-filled residual buffer
+        (warm-up periods before K real residuals have been recorded),
+        we fall back to the per-solution traditional rate
+        (uncertainty + accuracy / 2 in [0, 0.5]), which is the
+        original C++ implementation's notion of "KF-based rate".
+        This preserves backward-compat behavior for the warm-up
+        regime where the K-period sum is not yet meaningful.
+
+        Once the residual buffer holds ≥ 1 entry, λ^K is computed
+        as a sigmoid-normalized sum-over-window, mapped to [0, 0.5]
+        to match λ^H's range (so λ = 0.5*(λ^H + λ^K) ∈ [0, 0.5]).
+        """
+        if self.window_size == 0:
+            # K=0: myopic SMS-EMOA. λ^K ≡ 0 per §7.1.1.
+            return 0.0
+
+        if not self._kf_residual_window:
+            # Warm-up: no residuals recorded yet. Fall back to the
+            # pre-W16-1 per-solution traditional rate as a
+            # well-defined non-zero value (it lives in [0, 0.5]).
+            return self._compute_traditional_learning_rate(
+                solution, min_error, max_error,
+                min_alpha, max_alpha, current_time,
+            )
+
+        # K > 0 and residual buffer non-empty:
+        # λ^K = sigmoid-normalized squared-residual sum mapped to [0, 0.5].
+        # Per Eq 6.9 the residuals are accumulated as innovation^T innovation
+        # over the K-period window; the normalization choice (sigmoid here)
+        # is unconstrained by the thesis text but must map ℝ_+ → [0, 0.5]
+        # to match λ^H's range. We use a sigmoid centered at the running
+        # mean so the rate is meaningful at any scale of residuals.
+        residual_sum = float(np.sum(self._kf_residual_window))
+        # Normalize to [0, 1] via 1 - exp(-residual_sum / scale)
+        # where scale = max(1, mean(window)) keeps the rate sensitive
+        # at any magnitude. Map to [0, 0.5] to match λ^H's range.
+        scale = max(1.0, float(np.mean(self._kf_residual_window)))
+        normalized = 1.0 - float(np.exp(-residual_sum / (len(self._kf_residual_window) * scale)))
+        return 0.5 * normalized
+
+    def record_kf_residual(self, residual_squared_sum: float) -> None:
+        """
+        Append a per-period KF squared-residual scalar to the rolling
+        window of size K = self.window_size (W16-1 + Eq 6.9).
+
+        The caller (typically the walk-forward driver after each period's
+        Kalman update) passes the sum-of-squared-innovations across all
+        portfolios / both objectives for the period. The buffer is
+        truncated to length K so older periods are forgotten.
+
+        Per §7.1.1: if K = 0 we never record (no historical window).
+        """
+        if self.window_size == 0:
+            return
+        self._kf_residual_window.append(float(residual_squared_sum))
+        if len(self._kf_residual_window) > self.window_size:
+            self._kf_residual_window = self._kf_residual_window[-self.window_size:]
+
+    def reset_lambda_trace(self) -> None:
+        """Clear the per-call λ trace (W16-1, used by W16-4 between flushes)."""
+        self._lambda_trace_rows = []
+
+    def get_lambda_trace(self) -> List[Dict[str, Any]]:
+        """Return a copy of the per-call λ trace rows (W16-1 / W16-4)."""
+        return list(self._lambda_trace_rows)
     
     def _compute_traditional_learning_rate(self, solution: Solution, min_error: float, 
                                          max_error: float, min_alpha: float, max_alpha: float, 

--- a/python_refactor/tests/test_lambda_k_consumption.py
+++ b/python_refactor/tests/test_lambda_k_consumption.py
@@ -1,0 +1,214 @@
+"""
+W16-1: regression tests for λ^K consumption in
+compute_anticipatory_learning_rate per thesis Eq 7.16 + Eq 6.9.
+
+Closes BACKLOG.md H2 + W15-3-CARRY-1 consumption half.
+
+Thesis grounding (verbatim):
+
+§7.2.3 Eq (7.16), p. 146:
+    "λ_{t+h} = (1/2)(λ_{t+h}^(H) + λ_{t+h}^(K)), for which the
+     anticipation horizon is H = 2 (one-step-ahead prediction)."
+
+§7.1.1 (p. 140):
+    "The anticipation factor is controlled by four levels of window
+     size (K): K ∈ {0, 1, 2, 3}. For K = 0, we have the myopic
+     baseline SMS-EMOA (SMS, in short)..."
+
+§6.1.4 Eq (6.9), p. 119:
+    λ^K_{t+h} is defined as the normalized sum of KF squared
+    residuals over the historical window of size K.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.algorithms.anticipatory_learning import (
+    AnticipatoryLearning,
+    TIPIntegratedAnticipatoryLearning,
+)
+from src.algorithms.solution import Solution
+from src.portfolio.portfolio import Portfolio
+
+
+@pytest.fixture(autouse=True)
+def _reset_portfolio_class_state():
+    """
+    Portfolio.mean_ROI / covariance are CLASS variables cached across
+    tests. Without isolation, earlier tests may leave a length-3
+    mean_ROI cached and our Solution(num_assets=5) crashes on matmul.
+    Reset to None so Solution.__init__ skips compute_efficiency.
+    """
+    prev_mean = Portfolio.mean_ROI
+    prev_cov = Portfolio.covariance
+    Portfolio.mean_ROI = None
+    Portfolio.covariance = None
+    try:
+        yield
+    finally:
+        Portfolio.mean_ROI = prev_mean
+        Portfolio.covariance = prev_cov
+
+
+def _make_solution(num_assets: int = 5,
+                   roi: float = 0.05,
+                   risk: float = 0.10,
+                   prediction_error: float = 0.5,
+                   alpha: float = 0.5) -> Solution:
+    """Helper: minimal Solution with the fields the rate computation reads."""
+    sol = Solution(num_assets=num_assets)
+    sol.P.ROI = roi
+    sol.P.risk = risk
+    sol.prediction_error = prediction_error
+    sol.alpha = alpha
+    return sol
+
+
+class TestLambdaKConsumptionK0:
+    """K = 0: λ^K must be identically 0 (myopic SMS-EMOA per §7.1.1)."""
+
+    def test_k0_lambda_k_is_zero(self):
+        """At K=0, _compute_lambda_k returns exactly 0.0."""
+        al = AnticipatoryLearning(window_size=0)
+        sol = _make_solution()
+        lambda_k = al._compute_lambda_k(
+            sol,
+            min_error=0.0,
+            max_error=1.0,
+            min_alpha=0.0,
+            max_alpha=1.0,
+            current_time=5,
+        )
+        assert lambda_k == 0.0, "K=0 must give λ^K=0 per §7.1.1 myopic baseline"
+
+    def test_k0_record_kf_residual_noop(self):
+        """At K=0, recording residuals must NOT populate the window."""
+        al = AnticipatoryLearning(window_size=0)
+        for _ in range(10):
+            al.record_kf_residual(1.5)
+        assert al._kf_residual_window == [], "K=0 must not accumulate residuals"
+
+    def test_k0_combined_lambda_equals_half_lambda_h(self):
+        """At K=0, λ = 0.5*(λ^H + 0) = 0.5*λ^H — both arms still average."""
+        al = AnticipatoryLearning(window_size=0)
+        sol = _make_solution()
+        # No TIP calculator → λ^H also defaults to 0
+        lam = al.compute_anticipatory_learning_rate(
+            sol, min_error=0.0, max_error=1.0,
+            min_alpha=0.0, max_alpha=1.0, current_time=5,
+        )
+        assert lam == 0.0, "K=0 + no TIP → both arms 0 → λ=0"
+
+
+class TestLambdaKConsumptionKPositive:
+    """K > 0: λ^K consumes the residual window per Eq 6.9."""
+
+    def test_kpos_residual_window_truncated_to_k(self):
+        """record_kf_residual truncates buffer to length K."""
+        K = 3
+        al = AnticipatoryLearning(window_size=K)
+        for i, val in enumerate([1.0, 2.0, 3.0, 4.0, 5.0]):
+            al.record_kf_residual(val)
+        assert al._kf_residual_window == [3.0, 4.0, 5.0], \
+            f"window must keep last K={K} residuals, got {al._kf_residual_window}"
+
+    def test_kpos_lambda_k_fires_after_residuals_recorded(self):
+        """With K>0 and residuals recorded, λ^K is strictly > 0."""
+        al = AnticipatoryLearning(window_size=3)
+        sol = _make_solution()
+        for _ in range(3):
+            al.record_kf_residual(1.5)
+        lambda_k = al._compute_lambda_k(
+            sol,
+            min_error=0.0, max_error=1.0,
+            min_alpha=0.0, max_alpha=1.0,
+            current_time=5,
+        )
+        assert lambda_k > 0.0, "Non-zero residuals must produce λ^K > 0"
+        assert lambda_k <= 0.5, "λ^K range must be [0, 0.5] to match λ^H"
+
+    def test_kpos_warmup_falls_back_to_traditional_rate(self):
+        """K>0 + empty residual buffer → fall back to traditional rate."""
+        al = AnticipatoryLearning(window_size=3)
+        sol = _make_solution(prediction_error=0.5, alpha=1.0)
+        lambda_k = al._compute_lambda_k(
+            sol,
+            min_error=0.0, max_error=1.0,
+            min_alpha=0.0, max_alpha=1.0,
+            current_time=5,  # current_time > 0 + K > 0 → rate_upb = 0.5
+        )
+        # Traditional rate at uncertainty=1.0, accuracy=0.5 →
+        # 0.0 + 0.5*1.0*0.5 + 0.5*0.5*0.5 = 0.25 + 0.125 = 0.375
+        assert 0.0 < lambda_k <= 0.5, \
+            f"Warm-up fallback must be in [0, 0.5], got {lambda_k}"
+
+    def test_kpos_combined_lambda_is_average(self):
+        """λ = 0.5*(λ^H + λ^K) holds verbatim per Eq 7.16."""
+        al = AnticipatoryLearning(window_size=2)
+        sol = _make_solution()
+        for _ in range(2):
+            al.record_kf_residual(2.0)
+        # Compute λ^K alone
+        lambda_k = al._compute_lambda_k(
+            sol, min_error=0.0, max_error=1.0,
+            min_alpha=0.0, max_alpha=1.0, current_time=5,
+        )
+        # Compute λ with no TIP (λ^H = 0)
+        lam = al.compute_anticipatory_learning_rate(
+            sol, min_error=0.0, max_error=1.0,
+            min_alpha=0.0, max_alpha=1.0, current_time=5,
+        )
+        # Eq 7.16 verbatim: λ = 0.5*(0 + λ^K)
+        assert lam == pytest.approx(0.5 * lambda_k, abs=1e-9), \
+            f"Eq 7.16: λ must equal 0.5*(λ^H + λ^K); got λ={lam} but expected {0.5 * lambda_k}"
+
+
+class TestLambdaTracePlumbing:
+    """W16-1 trace plumbing (W16-4 builds CSV emit on top)."""
+
+    def test_trace_appended_per_call(self):
+        """Each compute_anticipatory_learning_rate call appends one trace row."""
+        al = AnticipatoryLearning(window_size=2)
+        sol = _make_solution()
+        for _ in range(3):
+            al.compute_anticipatory_learning_rate(
+                sol, min_error=0.0, max_error=1.0,
+                min_alpha=0.0, max_alpha=1.0, current_time=5,
+                generation=42, solution_rank=7,
+            )
+        rows = al.get_lambda_trace()
+        assert len(rows) == 3
+        for r in rows:
+            assert set(r.keys()) == {
+                "period", "generation", "solution_rank",
+                "lambda_h", "lambda_k", "lambda", "tip",
+            }
+            assert r["generation"] == 42
+            assert r["solution_rank"] == 7
+            assert r["period"] == 5
+
+    def test_reset_trace_clears(self):
+        """reset_lambda_trace empties the buffer."""
+        al = AnticipatoryLearning(window_size=2)
+        sol = _make_solution()
+        al.compute_anticipatory_learning_rate(
+            sol, 0.0, 1.0, 0.0, 1.0, current_time=5,
+        )
+        assert len(al.get_lambda_trace()) == 1
+        al.reset_lambda_trace()
+        assert al.get_lambda_trace() == []
+
+    def test_trace_records_lambda_formula(self):
+        """Trace row's λ equals 0.5*(λ^H + λ^K) verbatim."""
+        al = AnticipatoryLearning(window_size=2)
+        sol = _make_solution()
+        for _ in range(2):
+            al.record_kf_residual(1.0)
+        al.compute_anticipatory_learning_rate(
+            sol, 0.0, 1.0, 0.0, 1.0, current_time=5,
+        )
+        row = al.get_lambda_trace()[-1]
+        assert row["lambda"] == pytest.approx(
+            0.5 * (row["lambda_h"] + row["lambda_k"]), abs=1e-9,
+        )


### PR DESCRIPTION
## Audit verdict

Pre-W16-1, \`compute_anticipatory_learning_rate\`:
- Used \`_compute_traditional_learning_rate\` as the "λ^K" arm — a SINGLE-TIME scalar based on (prediction_error, alpha) of one solution. **NOT** the K-historical-window squared-residual sum per Eq 6.9.
- Short-circuited: when \`tip_rate == 0\`, λ collapsed to \`traditional_rate\` alone, **NOT** \`0.5*(0 + traditional)\`. Violated Eq 7.16 verbatim ("balanced tension" requires the average even if one term is zero).
- Did **NOT** accumulate KF squared residuals over the last K periods.
- Did **NOT** consume \`self.window_size\` in the residual-sum sense.

## Thesis grounding

**§7.2.3 Eq 7.16 (p. 146)** — verbatim:
> "λ_{t+h} = (1/2)(λ_{t+h}^(H) + λ_{t+h}^(K)), for which the anticipation horizon is H = 2 (one-step-ahead prediction). The anticipation rate of each portfolio is thus determined not only by the estimated temporal incomparability probability between the current and the predictive objective distribution (λ_{t+h}^(H)), but also by the observed normalized sum of KF squared residuals (λ_{t+h}^(K))."

> "The motivation for taking the average (the 1/2 factor) of the two aforementioned self-adjustment strategies for setting λ_{t+h} can be explained by the intuition of providing a *balanced tension* in the OAL rule between:
> - The desire of *trusting* in decision paths that *were shown* to lead to higher predictable consequences *in the past* (λ^{K}_{t+h} in Eq (6.9)); and
> - The desire of *trusting* in decision paths that *are estimated* to lead to higher predictable consequences *in the future* (λ^{H}_{t+h} in Eq (6.6))."

**§7.1.1 (p. 140)**: K ∈ {0,1,2,3}; K=0 → myopic SMS-EMOA → λ^K ≡ 0 by construction.

**§6.1.4 Eq 6.9 (p. 119)**: λ^K = normalized sum of KF squared residuals over the last K periods.

## Implementation

- \`_compute_lambda_k(...)\` — NEW; per Eq 6.9
- \`record_kf_residual(residual_squared_sum)\` — NEW; rolling K-length buffer
- \`compute_anticipatory_learning_rate(...)\` — REPLACED; always 0.5*(λ^H + λ^K), no short-circuit; new \`generation\`/\`solution_rank\` kwargs for W16-4 trace plumbing
- \`reset_lambda_trace()\` / \`get_lambda_trace()\` — accessors

## Tests (10 shipped, ≥4 required)

| Group | Tests |
|---|---|
| K=0 (3) | λ^K=0; record no-op; combined=0 |
| K>0 (4) | window truncation; λ^K>0; warm-up fallback; formula correctness |
| Trace plumbing (3) | row schema; reset; formula in trace |

All 10 green. Added autouse fixture to reset \`Portfolio.mean_ROI\` / \`covariance\` class-state between tests (pre-existing test-isolation bug otherwise crashes my tests when run alongside \`test_anticipatory_learning.py\`).

## Scars / out of scope

- Pre-existing \`test_anticipatory_learning.py\` failures (14 of 23) UNCHANGED — they call \`AnticipatoryLearning.compute_transaction_cost\` which lives in \`TIPIntegratedAnticipatoryLearning\`, not the base class. W16-2 (txn costs in HV) will rationalize the class hierarchy.
- W16-4 will ship CSV emit on top of \`self._lambda_trace_rows\`.
- W16-5 will assert "mean(λ^K) > 0 for K=3 scenarios" in real walk-forward smoke.

Closes BACKLOG: **H2** + **W15-3-CARRY-1 consumption half**.

## Test plan
- [x] 10 new W16-1 tests green
- [x] All other W15 tests (sms_emoa_reference_point, scenarios_k_aware, operators_thesis_spec) green (32 of 32 in isolation)
- [x] No new regressions vs. master baseline
- [x] PR body echoes verbatim thesis Eq 7.16 + Eq 6.6 + Eq 6.9 per BACKLOG §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)