### PR TITLE
W16-3: preserve rank-1 extrema in SMS-EMOA reduce step (BACKLOG H6)

### DIFF
--- a/python_refactor/src/algorithms/sms_emoa.py
+++ b/python_refactor/src/algorithms/sms_emoa.py
@@ -112,7 +112,15 @@ class SMSEMOA:
         self.pareto_front = []
         self.hypervolume_history = []
         self.stochastic_hypervolume_history = []
-        
+
+        # W16-3: per-generation [ROI_max, ROI_min, risk_max, risk_min]
+        # trace, computed from rank-1 (Pareto front) only. Used to
+        # diagnose whether the front extent shrinks over generations
+        # (which it should NOT — extrema preservation is the W16-3
+        # fix). Each entry is a dict {gen, roi_max, roi_min,
+        # risk_max, risk_min}.
+        self.extrema_trace: List[Dict[str, float]] = []
+
         # Performance tracking
         self.function_evaluations = 0
         self.current_generation = 0
@@ -535,21 +543,77 @@ class SMSEMOA:
         return best_idx
     
     def _remove_worst_solution(self):
-        """Remove the solution with the lowest hypervolume contribution."""
-        # Remove solutions until population size is correct
+        """
+        Remove the solution with the lowest hypervolume contribution.
+
+        W16-3: rank-1 extrema (argmax(ROI), argmin(risk)) are protected
+        from removal so the HV bounding box doesn't shrink over
+        generations. Per standard SMS-EMOA practice (Beume et al. 2007
+        EJOR 181(3):1653-1669) the HV indicator is most sensitive to
+        anchor solutions which define the bounding box; pruning them
+        introduces sawtooth instability in the per-gen HV trajectory.
+
+        Edge cases:
+          - Rank-1 with < 3 solutions: fall back to no protection
+            (otherwise reduce can't proceed at all).
+          - Rank-1 anchors that happen to coincide (same solution is
+            both argmax(ROI) AND argmin(risk)): protect that single
+            solution.
+        """
         while len(self.population) > self.population_size:
-            # Find worst solution
-            worst_idx = 0
-            worst_contribution = getattr(self.population[0], 'hypervolume_contribution', float('inf'))
-            
+            # ── W16-3: identify protected anchor indices ──────────
+            protected = self._identify_protected_anchors()
+
+            # Find worst solution among non-protected
+            worst_idx = -1
+            worst_contribution = float('inf')
+
             for i, solution in enumerate(self.population):
+                if i in protected:
+                    continue
                 contribution = getattr(solution, 'hypervolume_contribution', float('inf'))
                 if contribution < worst_contribution:
                     worst_contribution = contribution
                     worst_idx = i
-            
+
+            # Edge case: every solution is protected (rank-1 too small).
+            # Fall back to the original behavior (pick globally worst,
+            # may evict an anchor — better than infinite loop).
+            if worst_idx == -1:
+                worst_idx = 0
+                worst_contribution = getattr(self.population[0], 'hypervolume_contribution', float('inf'))
+                for i, solution in enumerate(self.population):
+                    contribution = getattr(solution, 'hypervolume_contribution', float('inf'))
+                    if contribution < worst_contribution:
+                        worst_contribution = contribution
+                        worst_idx = i
+
             # Remove worst solution
             self.population.pop(worst_idx)
+
+    def _identify_protected_anchors(self) -> set:
+        """
+        Identify rank-1 extrema (argmax(ROI), argmin(risk)) — W16-3.
+
+        Returns:
+            set of population indices to protect from reduce-step eviction.
+            Empty set if rank-1 has < 3 solutions (then protection is
+            counter-productive — would block reduce entirely).
+        """
+        # Pareto front (rank 0 = first non-dominated front; some code
+        # paths use rank 0, others rank 1 — be permissive).
+        rank1 = [
+            (i, s) for i, s in enumerate(self.population)
+            if getattr(s, 'Pareto_rank', None) in (0, 1)
+        ]
+        if len(rank1) < 3:
+            # Edge case: rank-1 too small to protect anchors safely.
+            return set()
+
+        # argmax(ROI) and argmin(risk) within rank-1.
+        argmax_roi_idx = max(rank1, key=lambda pair: pair[1].P.ROI)[0]
+        argmin_risk_idx = min(rank1, key=lambda pair: pair[1].P.risk)[0]
+        return {argmax_roi_idx, argmin_risk_idx}
     
     def _update_pareto_front(self):
         """Update the Pareto front."""
@@ -561,11 +625,23 @@ class SMSEMOA:
             # Compute current hypervolume
             hypervolume = self._compute_hypervolume()
             self.hypervolume_history.append(hypervolume)
-            
+
             # Compute expected future hypervolume if using anticipatory learning
             if self.anticipatory_learning is not None:
                 future_hypervolume = self._compute_expected_future_hypervolume()
                 self.stochastic_hypervolume_history.append(future_hypervolume)
+
+            # W16-3: per-generation Pareto front extrema trace
+            rois = [s.P.ROI for s in self.pareto_front]
+            risks = [s.P.risk for s in self.pareto_front]
+            self.extrema_trace.append({
+                "gen": self.current_generation,
+                "roi_max": float(max(rois)),
+                "roi_min": float(min(rois)),
+                "risk_max": float(max(risks)),
+                "risk_min": float(min(risks)),
+                "front_size": len(self.pareto_front),
+            })
     
     def _compute_hypervolume(self) -> float:
         """Compute hypervolume of current Pareto front."""

--- a/python_refactor/tests/test_extrema_preservation.py
+++ b/python_refactor/tests/test_extrema_preservation.py
@@ -1,0 +1,220 @@
+"""
+W16-3: regression tests for rank-1 extrema preservation in SMS-EMOA
+reduce step (BACKLOG H6).
+
+Thesis / REF grounding:
+
+§3.4.2 SMS-EMOA (pp. 69-70) — base SMS-EMOA reduce step (Beume et al.
+2007 [REF 32]).
+
+REF [Beume, Naujoks, Emmerich 2007] EJOR 181(3):1653-1669 — original
+SMS-EMOA paper; standard practice preserves extrema (HV indicator is
+most sensitive to anchor solutions because they define the bounding
+box).
+
+STD — standard SMS-EMOA / NSGA-II implementations explicitly preserve
+rank-1 anchors. The thesis inherits this convention implicitly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.algorithms.sms_emoa import SMSEMOA
+from src.algorithms.solution import Solution
+from src.portfolio.portfolio import Portfolio
+
+
+@pytest.fixture(autouse=True)
+def _reset_portfolio_class_state():
+    """Reset Portfolio class variables (test-isolation hygiene from W16-1)."""
+    prev_mean = Portfolio.mean_ROI
+    prev_cov = Portfolio.covariance
+    Portfolio.mean_ROI = None
+    Portfolio.covariance = None
+    try:
+        yield
+    finally:
+        Portfolio.mean_ROI = prev_mean
+        Portfolio.covariance = prev_cov
+
+
+def _make_solution(roi: float, risk: float,
+                   pareto_rank: int = 0,
+                   hv_contribution: float = 1.0,
+                   num_assets: int = 5) -> Solution:
+    """Helper: minimal Solution with the fields reduce reads."""
+    sol = Solution(num_assets=num_assets)
+    sol.P.ROI = roi
+    sol.P.risk = risk
+    sol.Pareto_rank = pareto_rank
+    sol.hypervolume_contribution = hv_contribution
+    return sol
+
+
+def _make_sms(population_size: int = 10) -> SMSEMOA:
+    return SMSEMOA(population_size=population_size, generations=1)
+
+
+class TestIdentifyProtectedAnchors:
+    """W16-3: _identify_protected_anchors picks argmax(ROI) + argmin(risk)."""
+
+    def test_anchors_in_rank1_protected(self):
+        """The rank-1 argmax(ROI) and argmin(risk) indices are returned."""
+        sms = _make_sms()
+        # 5 rank-1 portfolios with distinct ROI/risk
+        sms.population = [
+            _make_solution(roi=0.01, risk=0.05),  # 0: argmin(risk)
+            _make_solution(roi=0.05, risk=0.10),  # 1: middle
+            _make_solution(roi=0.10, risk=0.15),  # 2: argmax(ROI)
+            _make_solution(roi=0.03, risk=0.08),  # 3
+            _make_solution(roi=0.07, risk=0.12),  # 4
+        ]
+        protected = sms._identify_protected_anchors()
+        assert protected == {0, 2}, \
+            f"expected {{argmin_risk_idx=0, argmax_roi_idx=2}}, got {protected}"
+
+    def test_single_anchor_when_argmax_equals_argmin(self):
+        """If one solution is both argmax(ROI) AND argmin(risk), set has 1 elt."""
+        sms = _make_sms()
+        sms.population = [
+            _make_solution(roi=0.20, risk=0.05),  # 0: both anchors
+            _make_solution(roi=0.05, risk=0.10),  # 1
+            _make_solution(roi=0.08, risk=0.15),  # 2
+        ]
+        protected = sms._identify_protected_anchors()
+        assert protected == {0}, f"expected {{0}}, got {protected}"
+
+    def test_edge_case_rank1_too_small_returns_empty(self):
+        """rank-1 with < 3 solutions → empty protected set (avoid deadlock)."""
+        sms = _make_sms()
+        sms.population = [
+            _make_solution(roi=0.05, risk=0.10),
+            _make_solution(roi=0.10, risk=0.15),
+        ]
+        protected = sms._identify_protected_anchors()
+        assert protected == set(), \
+            "rank-1 with 2 solutions must yield empty protected set"
+
+    def test_non_rank1_solutions_ignored(self):
+        """Only rank-1 (or rank-0) solutions enter anchor identification."""
+        sms = _make_sms()
+        sms.population = [
+            _make_solution(roi=0.01, risk=0.05, pareto_rank=0),  # 0: rank-0 argmin(risk)
+            _make_solution(roi=0.05, risk=0.10, pareto_rank=0),  # 1: rank-0
+            _make_solution(roi=0.10, risk=0.15, pareto_rank=0),  # 2: rank-0 argmax(ROI)
+            _make_solution(roi=0.99, risk=0.001, pareto_rank=3),  # 3: rank-3 (ignored)
+        ]
+        protected = sms._identify_protected_anchors()
+        # rank-3 must be ignored even though it has the global extrema
+        assert protected == {0, 2}, \
+            f"rank-3 must be excluded from anchor protection, got {protected}"
+
+
+class TestReduceStepProtectsAnchors:
+    """W16-3: _remove_worst_solution protects rank-1 anchors."""
+
+    def test_reduce_never_evicts_argmax_roi(self):
+        """argmax(ROI) survives reduce even when its HV contribution is worst."""
+        sms = _make_sms(population_size=4)
+        sms.population = [
+            _make_solution(roi=0.01, risk=0.05, hv_contribution=0.5),
+            _make_solution(roi=0.05, risk=0.10, hv_contribution=0.5),
+            _make_solution(roi=0.10, risk=0.15, hv_contribution=0.5),  # argmax(ROI)
+            _make_solution(roi=0.07, risk=0.20, hv_contribution=0.5),
+            _make_solution(roi=0.08, risk=0.25, hv_contribution=1e-9),  # eviction target
+        ]
+        argmax_roi_initial = max(sms.population, key=lambda s: s.P.ROI).P.ROI
+
+        sms._remove_worst_solution()
+
+        # Population is now size 4 and argmax(ROI) is still 0.10
+        assert len(sms.population) == 4
+        argmax_roi_after = max(sms.population, key=lambda s: s.P.ROI).P.ROI
+        assert argmax_roi_after == argmax_roi_initial, \
+            f"argmax(ROI) was evicted: {argmax_roi_initial} → {argmax_roi_after}"
+
+    def test_reduce_never_evicts_argmin_risk(self):
+        """argmin(risk) survives reduce even when its HV contribution is worst."""
+        sms = _make_sms(population_size=4)
+        sms.population = [
+            _make_solution(roi=0.05, risk=0.05, hv_contribution=1e-9),  # argmin(risk), worst HV
+            _make_solution(roi=0.06, risk=0.10, hv_contribution=0.5),
+            _make_solution(roi=0.07, risk=0.15, hv_contribution=0.5),
+            _make_solution(roi=0.08, risk=0.20, hv_contribution=0.5),
+            _make_solution(roi=0.10, risk=0.25, hv_contribution=0.2),  # eviction target (not anchor)
+        ]
+        argmin_risk_initial = min(sms.population, key=lambda s: s.P.risk).P.risk
+
+        sms._remove_worst_solution()
+
+        assert len(sms.population) == 4
+        argmin_risk_after = min(sms.population, key=lambda s: s.P.risk).P.risk
+        assert argmin_risk_after == argmin_risk_initial, \
+            f"argmin(risk) was evicted: {argmin_risk_initial} → {argmin_risk_after}"
+
+    def test_stress_100_reduces_anchor_survives(self):
+        """100 reduce calls with worst-HV anchor — survives all of them."""
+        sms = _make_sms(population_size=5)
+        # Build a population where the argmin(risk) has perpetually worst HV
+        base_pop = [
+            _make_solution(roi=0.01, risk=0.001, hv_contribution=1e-9),  # anchor, worst HV
+            _make_solution(roi=0.05, risk=0.10, hv_contribution=0.5),
+            _make_solution(roi=0.07, risk=0.15, hv_contribution=0.4),
+            _make_solution(roi=0.10, risk=0.20, hv_contribution=0.6),  # other anchor (argmax ROI)
+            _make_solution(roi=0.08, risk=0.18, hv_contribution=0.3),
+        ]
+        for _ in range(100):
+            # Re-seed: add a dummy that should always lose
+            sms.population = list(base_pop) + [_make_solution(
+                roi=0.06, risk=0.30, hv_contribution=1e-15,
+            )]
+            sms._remove_worst_solution()
+            argmin_risk = min(sms.population, key=lambda s: s.P.risk).P.risk
+            argmax_roi = max(sms.population, key=lambda s: s.P.ROI).P.ROI
+            assert argmin_risk == 0.001, f"argmin(risk) evicted at iter, found {argmin_risk}"
+            assert argmax_roi == 0.10, f"argmax(ROI) evicted at iter, found {argmax_roi}"
+
+    def test_edge_case_small_front_falls_back(self):
+        """Front with 2 solutions — no protection; reduce still proceeds."""
+        sms = _make_sms(population_size=1)
+        sms.population = [
+            _make_solution(roi=0.05, risk=0.10, hv_contribution=0.5),
+            _make_solution(roi=0.10, risk=0.20, hv_contribution=0.3),
+        ]
+        # _identify_protected_anchors → set() (rank-1 < 3); reduce can still
+        # pick a worst and remove it. Verify no deadlock + correct size.
+        sms._remove_worst_solution()
+        assert len(sms.population) == 1
+
+
+class TestExtremaTrace:
+    """W16-3: per-gen extrema trace populated by _track_hypervolume."""
+
+    def test_trace_initially_empty(self):
+        """extrema_trace starts empty before any tracking call."""
+        sms = _make_sms()
+        assert sms.extrema_trace == []
+
+    def test_trace_populated_after_tracking_call(self):
+        """One _track_hypervolume call appends one row with the right schema."""
+        sms = _make_sms()
+        sms.current_generation = 7
+        # Seed pareto_front directly (bypassing _update_pareto_front)
+        sms.pareto_front = [
+            _make_solution(roi=0.05, risk=0.10),
+            _make_solution(roi=0.10, risk=0.15),
+            _make_solution(roi=0.01, risk=0.05),
+        ]
+        sms._track_hypervolume()
+        assert len(sms.extrema_trace) == 1
+        row = sms.extrema_trace[0]
+        assert set(row.keys()) == {
+            "gen", "roi_max", "roi_min", "risk_max", "risk_min", "front_size",
+        }
+        assert row["gen"] == 7
+        assert row["roi_max"] == 0.10
+        assert row["roi_min"] == 0.01
+        assert row["risk_max"] == 0.15
+        assert row["risk_min"] == 0.05
+        assert row["front_size"] == 3


### PR DESCRIPTION
## Summary

Make rank-1 argmax(ROI) and argmin(risk) immune to SMS-EMOA's reduce step so the HV bounding box doesn't shrink over generations. Add per-generation [ROI_max, ROI_min, risk_max, risk_min] trace.

## Thesis / REF grounding

**§3.4.2 SMS-EMOA (pp. 69-70)** — base SMS-EMOA reduce step (Beume et al. 2007 [REF 32]).

**REF [Beume, Naujoks, Emmerich 2007] EJOR 181(3):1653-1669** — original SMS-EMOA paper; standard practice preserves extrema (HV indicator is most sensitive to anchor solutions which define the bounding box).

**STD** — standard SMS-EMOA / NSGA-II implementations explicitly preserve rank-1 anchors. The thesis inherits this convention implicitly.

## Implementation

- \`_identify_protected_anchors()\` — NEW; returns rank-1 argmax(ROI) + argmin(risk) indices; empty when rank-1 < 3 (edge case)
- \`_remove_worst_solution()\` — AUGMENTED; skips protected indices, falls back if every solution protected
- \`extrema_trace: List[Dict]\` — NEW per-gen trace populated by \`_track_hypervolume\`

## Tests (10 shipped, ≥ 3 required)

| Group | Tests |
|---|---|
| Identify (4) | rank-1 anchors found; argmax==argmin single elt; small-front returns ∅; non-rank-1 excluded |
| Reduce (4) | argmax(ROI) survives; argmin(risk) survives; 100-stress; small-front fallback |
| Trace (2) | initially empty; populated with correct schema |

All 10 green. 25/25 when combined with W15 thesis-spec tests + W16-1 λ^K tests.

## Why this contributes to closing the 9% gap

If extrema get pruned mid-generation, the HV indicator becomes non-monotone. For OOS-Future-HV, an unstable bounding box means we predict a moving target, biasing the predicted-vs-realized delta unpredictably. Per-gen extrema trace enables W16-5 / W18 to plot front-extent stability.

Closes BACKLOG: **H6**.

## Test plan
- [x] 10 new W16-3 tests green
- [x] No new regressions vs. master (compatible with W15/W16-1 tests)
- [x] PR body echoes thesis §3.4.2 + Beume et al. 2007 REF per BACKLOG §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)