### PR TITLE
W16-2: txn costs in HV objective per thesis §7.2 Eq (7.4-7.5) + Table 7.1 (BACKLOG H1)

### DIFF
--- a/python_refactor/experiments/walk_forward.py
+++ b/python_refactor/experiments/walk_forward.py
@@ -78,12 +78,19 @@ def enumerate_periods(n_days: int, train_window_days: int = 378,
 # ---------------------------------------------------------------------------
 
 def _train_and_extract_pareto(scenario: str, seed: int,
-                               train_returns: pd.DataFrame
+                               train_returns: pd.DataFrame,
+                               previous_weights: np.ndarray | None = None,
                                ) -> tuple[list[np.ndarray], int]:
     """Train SMS-EMOA on the train window; extract Pareto weights.
 
     Mirrors oos_report._run_one_scenario_seed but takes the pre-sliced
     train block instead of loading the full window.
+
+    W16-2 (BACKLOG H1): optional ``previous_weights`` threads u*_{t-1}
+    into the SMS-EMOA evaluator so the optimizer subtracts thesis
+    Table 7.1 transaction costs from the ROI objective per §7.2
+    Eqs (7.4)-(7.5). On period 1 / no prior portfolio, pass None →
+    no cost subtraction.
     """
     from experiments.validation_matrix import build_experiment_config
     from src.experiments.experiment_manager import ExperimentManager
@@ -100,6 +107,11 @@ def _train_and_extract_pareto(scenario: str, seed: int,
     n_assets = train_returns.values.shape[1]
     data = {"assets": train_returns, "market": pd.DataFrame(),
             "config": config.get("data", {})}
+    # W16-2: thread previous-period implemented portfolio to
+    # ExperimentManager → SMS-EMOA via the data dict (so the manager's
+    # algorithm setter can call set_previous_weights post-init).
+    if previous_weights is not None:
+        data["previous_weights"] = np.asarray(previous_weights, dtype=float)
     results = mgr._run_algorithm(config, data)
     pareto = results.get("pareto_front", [])
     weights: list[np.ndarray] = []
@@ -138,11 +150,18 @@ def run_walk_forward(scenario: str,
         rng = np.random.default_rng(seed)
     periods = enumerate_periods(len(full_returns), train_window_days, step_days)
     results: list[dict[str, Any]] = []
+    # W16-2 (BACKLOG H1): u*_{t-1} thread across rolling periods.
+    # Per thesis convention, the "implemented" portfolio is the
+    # argmax-EFHV (or first if EFHV not yet computed) from the
+    # previous period's Pareto front. None on period 1 (no prior).
+    previous_weights: np.ndarray | None = None
     for p in periods:
         train = full_returns.iloc[p["train_start"]:p["train_end"]]
         oos = full_returns.iloc[p["oos_start"]:p["oos_end"]]
         try:
-            weights, n_assets = _train_and_extract_pareto(scenario, seed, train)
+            weights, n_assets = _train_and_extract_pareto(
+                scenario, seed, train, previous_weights=previous_weights,
+            )
         except Exception as exc:
             results.append({**p, "error": f"{type(exc).__name__}: {exc}",
                               "efhv_mean": float("nan"), "efhv_std": float("nan"),
@@ -164,6 +183,11 @@ def run_walk_forward(scenario: str,
             n_samples=n_mc,
             rng=rng,
         )
+        # W16-2: persist the period's implemented portfolio as
+        # u*_{t-1} for the NEXT period's optimization. Convention:
+        # the first portfolio in the Pareto front (or argmax-EFHV
+        # if richer DM logic is available — W17 territory).
+        previous_weights = weights[0]
         results.append({
             **p,
             "n_pareto": len(weights),

--- a/python_refactor/src/algorithms/sms_emoa.py
+++ b/python_refactor/src/algorithms/sms_emoa.py
@@ -9,7 +9,7 @@ Revised implementation to include:
 """
 
 import numpy as np
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -121,9 +121,40 @@ class SMSEMOA:
         # risk_max, risk_min}.
         self.extrema_trace: List[Dict[str, float]] = []
 
+        # W16-2 (BACKLOG H1): previous-period implemented portfolio
+        # u*_{t-1}. When set, _evaluate_solution subtracts the thesis
+        # Table 7.1 transaction cost h(u_t, u*_{t-1}) from the ROI
+        # objective so the optimizer sees and avoids high-churn
+        # rebalancings (per thesis §7.2 Eqs (7.4)-(7.5)).
+        #
+        # None on the first period (no prior portfolio yet → no
+        # rebalancing → no cost). Caller (walk_forward driver) calls
+        # set_previous_weights(u_prev) before each period's optimization.
+        self.previous_weights: Optional[np.ndarray] = None
+        self.portfolio_value: float = 1.0  # default wealth scale
+
         # Performance tracking
         self.function_evaluations = 0
         self.current_generation = 0
+
+    def set_previous_weights(self, weights: Optional[np.ndarray],
+                              portfolio_value: float = 1.0) -> None:
+        """
+        Set the previous-period implemented portfolio u*_{t-1} (W16-2).
+
+        The walk-forward driver calls this before each period's
+        optimization, passing the prior period's realized maximal
+        flexible choice. None on period 1 (no prior period).
+
+        Args:
+            weights: u*_{t-1} length-d array (or None on period 1)
+            portfolio_value: total wealth (for sizing the bracket lookup)
+        """
+        if weights is None:
+            self.previous_weights = None
+        else:
+            self.previous_weights = np.asarray(weights, dtype=float).copy()
+        self.portfolio_value = float(portfolio_value)
         
     def set_learning(self, learning: AnticipatoryLearning):
         """Set anticipatory learning component."""
@@ -260,19 +291,53 @@ class SMSEMOA:
         ])
     
     def _evaluate_solution(self, solution: Solution, data: Dict[str, Any]):
-        """Evaluate solution and update objectives."""
-        # Compute portfolio metrics
+        """Evaluate solution and update objectives.
+
+        W16-2 (BACKLOG H1): if self.previous_weights is set, subtract
+        the thesis Table 7.1 transaction cost from the OBJECTIVE ROI
+        so the optimizer sees the rebalancing cost. The PORTFOLIO
+        ROI (portfolio.ROI) is preserved as gross-of-cost for
+        downstream reporting (so wealth-evaluation code still has
+        the un-netted ROI).
+
+        Per thesis §7.2 Eq (7.4)-(7.5), p. 142:
+            z_t|u*_{t-1} = g(u_t, χ_t) + h(u_t, u*_{t-1})
+        i.e. the optimizer's z-vector ROI component is
+        net-of-transaction-cost.
+        """
         portfolio = solution.P
-        
+
         # Update Kalman filter with current observation if available
         if hasattr(solution.P, 'kalman_state') and solution.P.kalman_state is not None:
             from .kalman_filter import kalman_update
             measurement = np.array([portfolio.ROI, portfolio.risk])
             kalman_update(solution.P.kalman_state, measurement)
-        
-        # Store objectives
-        solution.objectives = [portfolio.ROI, portfolio.risk]
-        
+
+        # W16-2: compute net-of-cost ROI for the NDS/HV objective.
+        # Gross ROI stays on portfolio.ROI for reporting; only the
+        # objective vector (used by dominance + HV contribution)
+        # uses ROI_net.
+        roi_objective = portfolio.ROI
+        if self.previous_weights is not None:
+            from ..portfolio.portfolio import Portfolio
+            txn_cost = Portfolio.compute_thesis_transaction_cost(
+                weights_new=np.asarray(portfolio.investment, dtype=float),
+                weights_prev=self.previous_weights,
+                portfolio_value=self.portfolio_value,
+            )
+            roi_objective = portfolio.ROI - txn_cost
+            # Stash on solution for diagnostics (W16-5 trace + W18 viz)
+            solution.transaction_cost = txn_cost
+            solution.roi_gross = portfolio.ROI
+            solution.roi_net = roi_objective
+        else:
+            solution.transaction_cost = 0.0
+            solution.roi_gross = portfolio.ROI
+            solution.roi_net = portfolio.ROI
+
+        # Store objectives (NET-of-cost ROI per Eq 7.4-7.5; risk unchanged)
+        solution.objectives = [roi_objective, portfolio.risk]
+
         # Compute stability (simplified)
         portfolio.stability = 1.0 / (1.0 + np.std(solution.P.investment))
     

--- a/python_refactor/src/config/thesis_parameters.py
+++ b/python_refactor/src/config/thesis_parameters.py
@@ -104,7 +104,27 @@ class ThesisParameters:
     
     # Portfolio Parameters
     INITIAL_WEALTH: float = 100000.0  # R$ 100,000
-    TRANSACTION_COST_RATE: float = 0.001  # 0.1% per trade
+    TRANSACTION_COST_RATE: float = 0.001  # 0.1% per trade — DEPRECATED;
+    # W16-2 (BACKLOG H1) replaces flat-rate with thesis Table 7.1
+    # bracket schedule (see THESIS_TABLE_71_BRACKETS below). Kept
+    # for backward-compat with config dicts that still reference it.
+
+    # ─── W16-2: Brazilian SEC fee schedule per thesis Table 7.1 (p. 144) ──
+    # Bracket = (traded_value_lower_bound, proportional_fee, fixed_fee).
+    # Per the thesis verbatim:
+    #
+    #   Traded value         | Proportional Fee | Fixed Fee
+    #   --------------------+------------------+----------
+    #   < 135.07            | 0.0%             | 2.70
+    #   ≥ 135.08, < 498.62  | 2.0%             | 0.00
+    #   ≥ 498.63, < 1514.69 | 1.5%             | 2.49
+    #   ≥ 1514.70, < 3029.38| 1.0%             | 10.06
+    #   ≥ 3029.39           | 0.5%             | 25.21
+    #
+    # Brackets listed in ascending-lower-bound order; consumer
+    # iterates and picks the bracket whose lower_bound ≤ value <
+    # next_bracket_lower_bound (or +∞ for last).
+    THESIS_TABLE_71_BRACKETS: list = None  # set in __post_init__
     
     # =============================================================================
     # Decision Maker Parameters (Section 7.3)
@@ -150,6 +170,16 @@ class ThesisParameters:
         """Initialize derived parameters after dataclass creation."""
         if self.DECISION_MAKER_TYPES is None:
             self.DECISION_MAKER_TYPES = ['Hv-DM', 'R-DM', 'M-DM']
+        # W16-2: Brazilian SEC fee schedule per thesis Table 7.1 (p. 144).
+        # Each entry: (lower_bound_inclusive, proportional_fee, fixed_fee).
+        if self.THESIS_TABLE_71_BRACKETS is None:
+            self.THESIS_TABLE_71_BRACKETS = [
+                (0.00,    0.000, 2.70),    # < 135.07
+                (135.08,  0.020, 0.00),    # 135.08 ≤ v < 498.62
+                (498.63,  0.015, 2.49),    # 498.63 ≤ v < 1514.69
+                (1514.70, 0.010, 10.06),   # 1514.70 ≤ v < 3029.38
+                (3029.39, 0.005, 25.21),   # ≥ 3029.39
+            ]
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert parameters to dictionary for easy access."""

--- a/python_refactor/src/experiments/experiment_manager.py
+++ b/python_refactor/src/experiments/experiment_manager.py
@@ -256,7 +256,15 @@ class ExperimentManager:
                     from ..algorithms.anticipatory_learning import AnticipatoryLearning
                     learning = AnticipatoryLearning(**learning_config.get('parameters', {}))
                 algorithm.set_learning(learning)
-            
+
+            # W16-2 (BACKLOG H1): thread previous-period implemented
+            # portfolio u*_{t-1} into the SMS-EMOA evaluator so the
+            # ROI objective is net of thesis Table 7.1 transaction
+            # costs. Walk-forward driver passes it via data dict.
+            prev_weights = data.get("previous_weights")
+            if prev_weights is not None and hasattr(algorithm, "set_previous_weights"):
+                algorithm.set_previous_weights(prev_weights)
+
             # Run algorithm
             population = algorithm.run(data)
             

--- a/python_refactor/src/portfolio/portfolio.py
+++ b/python_refactor/src/portfolio/portfolio.py
@@ -288,14 +288,86 @@ class Portfolio:
     def card(cls, portfolio: 'Portfolio') -> float:
         """
         Compute portfolio cardinality (number of non-zero weights).
-        
+
         Args:
             portfolio: Portfolio object
-        
+
         Returns:
             Portfolio cardinality
         """
         return np.sum(portfolio.investment > 1e-6)
+
+    # ─── W16-2: thesis Table 7.1 transaction-cost computation ─────
+    # Closes BACKLOG H1. The cost is computed per asset based on the
+    # absolute traded value (|Δweight| × portfolio_value); each asset's
+    # cost picks the bracket from Table 7.1 (p. 144) whose lower_bound
+    # is met. Total cost is the sum across assets, returned as a
+    # fraction of portfolio_value so it can be subtracted from the
+    # ROI objective directly.
+    @staticmethod
+    def compute_thesis_transaction_cost(weights_new: np.ndarray,
+                                        weights_prev: np.ndarray,
+                                        portfolio_value: float = 1.0,
+                                        brackets: list | None = None) -> float:
+        """
+        Compute total transaction cost per thesis Table 7.1 (W16-2).
+
+        Per thesis §7.2 Eqs (7.4)-(7.5): the optimizer's ROI objective
+        must net out h(u_t, u*_{t-1}), the brokerage fee on the trades
+        implied by rebalancing from u*_{t-1} → u_t.
+
+        Args:
+            weights_new: target weights u_t (length d, sums to 1)
+            weights_prev: previous-period implemented weights u*_{t-1}
+                (length d, sums to 1)
+            portfolio_value: total wealth (default 1.0; cost returned
+                in same units)
+            brackets: optional override of Table 7.1 brackets; default
+                is loaded from ThesisParameters().THESIS_TABLE_71_BRACKETS
+
+        Returns:
+            Total transaction cost (fraction of portfolio_value),
+            i.e. (sum of per-asset fees) / portfolio_value.
+
+        Thesis grounding:
+            §7.2 Eqs (7.4)-(7.5), p. 142:
+                z_t|u*_{t-1} = g(u_t, χ_t) + h(u_t, u*_{t-1})
+                h(u_t, u*_{t-1}) = (0, h)^T  where h is the trade cost
+
+            §7.2.3 Table 7.1, p. 144 — Brazilian SEC fee schedule
+            (Brackets in thesis_parameters.THESIS_TABLE_71_BRACKETS).
+        """
+        if weights_prev is None:
+            return 0.0  # no previous → first period → no rebalancing
+        weights_new = np.asarray(weights_new, dtype=float)
+        weights_prev = np.asarray(weights_prev, dtype=float)
+        if weights_new.shape != weights_prev.shape:
+            return 0.0  # shape mismatch → no meaningful cost
+
+        if brackets is None:
+            # Lazy import to avoid circular dep at module load.
+            from ..config.thesis_parameters import ThesisParameters
+            brackets = ThesisParameters().THESIS_TABLE_71_BRACKETS
+
+        # Per-asset absolute traded value.
+        traded_value_per_asset = np.abs(weights_new - weights_prev) * portfolio_value
+
+        total_fee = 0.0
+        # Sort brackets descending by lower_bound so we pick the
+        # FIRST bracket the value qualifies for.
+        brackets_desc = sorted(brackets, key=lambda b: -b[0])
+
+        for tv in traded_value_per_asset:
+            if tv == 0.0:
+                continue  # no trade, no fee (still skip bracket 0 fixed fee)
+            for lower_bound, prop_fee, fixed_fee in brackets_desc:
+                if tv >= lower_bound:
+                    total_fee += tv * prop_fee + fixed_fee
+                    break
+
+        # Return as fraction of portfolio_value so it's directly
+        # subtractable from a normalized ROI.
+        return float(total_fee / portfolio_value) if portfolio_value > 0.0 else 0.0
     
     @classmethod
     def moving_average(cls, returns_data: np.ndarray) -> np.ndarray:

--- a/python_refactor/tests/test_transaction_costs_in_hv.py
+++ b/python_refactor/tests/test_transaction_costs_in_hv.py
@@ -1,0 +1,185 @@
+"""
+W16-2: regression tests for transaction-cost integration into the
+anticipatory HV objective per thesis §7.2 Eqs (7.4)-(7.5) +
+Table 7.1 (BACKLOG H1).
+
+Thesis grounding (verbatim):
+
+§7.2 Eqs (7.4)-(7.5), p. 142:
+    "z_t|u*_{t-1} = g(u_t, χ_t) + h(u_t, u*_{t-1}),
+     where: g(u_t, χ_t) = (u_t^T Σ̂_{r,t} u_t, μ̂_{r,t}^T u_t)^T
+     and h(u_t, u*_{t-1}) = (0, h(u_t, u*_{t-1}))^T,
+     in which h is a cost function representing all incurring
+     transaction fees and commissions."
+
+§7.2.3 Table 7.1, p. 144 — Brazilian SEC fee schedule:
+
+    Traded value         Proportional   Fixed
+    < 135.07             0.0%           2.70
+    ≥ 135.08, < 498.62   2.0%           0.00
+    ≥ 498.63, < 1514.69  1.5%           2.49
+    ≥ 1514.70, < 3029.38 1.0%           10.06
+    ≥ 3029.39            0.5%           25.21
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.algorithms.sms_emoa import SMSEMOA
+from src.algorithms.solution import Solution
+from src.portfolio.portfolio import Portfolio
+from src.config.thesis_parameters import ThesisParameters
+
+
+@pytest.fixture(autouse=True)
+def _reset_portfolio_class_state():
+    """Reset Portfolio class variables between tests (W16-1 hygiene)."""
+    prev_mean = Portfolio.mean_ROI
+    prev_cov = Portfolio.covariance
+    Portfolio.mean_ROI = None
+    Portfolio.covariance = None
+    try:
+        yield
+    finally:
+        Portfolio.mean_ROI = prev_mean
+        Portfolio.covariance = prev_cov
+
+
+class TestThesisTable71Brackets:
+    """Bracket lookups match thesis Table 7.1 verbatim."""
+
+    def test_brackets_loaded_into_parameters(self):
+        """ThesisParameters().__post_init__ populates the brackets list."""
+        params = ThesisParameters()
+        assert params.THESIS_TABLE_71_BRACKETS is not None
+        assert len(params.THESIS_TABLE_71_BRACKETS) == 5
+
+    def test_bracket_lower_bound_lt_135(self):
+        """Traded value < 135.07 → 0% proportional + 2.70 fixed."""
+        # 100 traded → 100 * 0.0 + 2.70 = 2.70 cost
+        weights_new = np.array([0.50, 0.50])
+        weights_prev = np.array([0.45, 0.55])  # |Δ| = [0.05, 0.05] × 1000 = 50, 50
+        cost = Portfolio.compute_thesis_transaction_cost(
+            weights_new, weights_prev, portfolio_value=1000.0,
+        )
+        # Each asset's traded value = 50 (in bracket 1: 0.0% + 2.70 fixed)
+        # Wait — 50 < 135.07 → bracket 0 → 0% + 2.70. Two assets:
+        # total_fee = 2*2.70 = 5.40 ; cost_frac = 5.40 / 1000 = 0.0054
+        assert cost == pytest.approx(0.0054, abs=1e-6)
+
+    def test_bracket_proportional_active(self):
+        """Traded value in bracket 1 [135.08, 498.62) → 2% proportional."""
+        # |Δw_1| * V = 200 → bracket 1 (≥ 135.08, < 498.62)
+        # Fee = 200 * 0.02 + 0.00 = 4.00
+        weights_new = np.array([0.50, 0.50])
+        weights_prev = np.array([0.30, 0.70])  # |Δ| = [0.20, 0.20] × 1000 = 200, 200
+        cost = Portfolio.compute_thesis_transaction_cost(
+            weights_new, weights_prev, portfolio_value=1000.0,
+        )
+        # Each asset: 200 * 0.02 + 0.00 = 4.00; total = 8.00 / 1000 = 0.008
+        assert cost == pytest.approx(0.008, abs=1e-6)
+
+    def test_high_bracket_low_proportional(self):
+        """Traded value ≥ 3029.39 → 0.5% proportional + 25.21 fixed."""
+        # |Δw_1| * V = 5000 → bracket 4 (≥ 3029.39): 0.5% + 25.21
+        # Fee = 5000 * 0.005 + 25.21 = 25.00 + 25.21 = 50.21
+        weights_new = np.array([1.00, 0.00])
+        weights_prev = np.array([0.50, 0.50])  # |Δ| = [0.50, 0.50] × 10000 = 5000, 5000
+        cost = Portfolio.compute_thesis_transaction_cost(
+            weights_new, weights_prev, portfolio_value=10000.0,
+        )
+        # Each asset: 5000 * 0.005 + 25.21 = 50.21; total = 100.42 / 10000 = 0.010042
+        assert cost == pytest.approx(0.010042, abs=1e-6)
+
+    def test_zero_churn_zero_cost(self):
+        """weights_new == weights_prev → traded_value = 0 → cost = 0."""
+        weights = np.array([0.30, 0.40, 0.30])
+        cost = Portfolio.compute_thesis_transaction_cost(
+            weights, weights, portfolio_value=1000.0,
+        )
+        assert cost == 0.0
+
+    def test_none_prev_zero_cost(self):
+        """previous_weights = None (first period) → cost = 0."""
+        weights = np.array([0.30, 0.40, 0.30])
+        cost = Portfolio.compute_thesis_transaction_cost(
+            weights, None, portfolio_value=1000.0,
+        )
+        assert cost == 0.0
+
+
+class TestSMSEMOATxnCostIntegration:
+    """W16-2: _evaluate_solution subtracts txn cost from objective ROI."""
+
+    def test_default_no_previous_weights_no_cost_subtraction(self):
+        """Without set_previous_weights, objective ROI == gross ROI."""
+        sms = SMSEMOA(population_size=4, generations=1)
+        sol = Solution(num_assets=5)
+        sol.P.investment = np.array([0.20, 0.20, 0.20, 0.20, 0.20])
+        sol.P.ROI = 0.10
+        sol.P.risk = 0.05
+        # previous_weights is None by default
+        sms._evaluate_solution(sol, data={})
+        assert sol.objectives == [0.10, 0.05]
+        assert sol.transaction_cost == 0.0
+        assert sol.roi_gross == 0.10
+        assert sol.roi_net == 0.10
+
+    def test_set_previous_weights_then_objective_is_net(self):
+        """With previous_weights set, objective ROI = gross ROI - txn cost."""
+        sms = SMSEMOA(population_size=4, generations=1)
+        sol = Solution(num_assets=5)
+        sol.P.investment = np.array([0.20, 0.20, 0.20, 0.20, 0.20])
+        sol.P.ROI = 0.10
+        sol.P.risk = 0.05
+
+        # u*_{t-1} = uniform [0.5, 0.5, 0, 0, 0]
+        prev = np.array([0.50, 0.50, 0.00, 0.00, 0.00])
+        sms.set_previous_weights(prev, portfolio_value=1000.0)
+
+        sms._evaluate_solution(sol, data={})
+
+        # |Δ| per asset (× 1000) = [300, 300, 200, 200, 200]
+        # Assets 0,1 in bracket 1 (300 ∈ [135.08, 498.62)): 300 * 0.02 + 0 = 6.00
+        # Assets 2,3,4 in bracket 1: 200 * 0.02 + 0 = 4.00
+        # Total = 2*6.00 + 3*4.00 = 12.00 + 12.00 = 24.00
+        # Cost fraction = 24.00 / 1000 = 0.024
+        # ROI_net = 0.10 - 0.024 = 0.076
+        assert sol.transaction_cost == pytest.approx(0.024, abs=1e-6)
+        assert sol.roi_gross == 0.10
+        assert sol.roi_net == pytest.approx(0.076, abs=1e-6)
+        assert sol.objectives[0] == pytest.approx(0.076, abs=1e-6)
+        assert sol.objectives[1] == 0.05  # risk unchanged
+
+    def test_optimizer_sees_cost_low_churn_wins(self):
+        """Two solutions with same gross ROI/risk; low-churn one has higher objective ROI."""
+        sms = SMSEMOA(population_size=4, generations=1)
+
+        prev = np.array([0.50, 0.50, 0.00])
+        sms.set_previous_weights(prev, portfolio_value=1000.0)
+
+        sol_low_churn = Solution(num_assets=3)
+        sol_low_churn.P.investment = np.array([0.55, 0.45, 0.00])  # |Δ| = [50, 50, 0]
+        sol_low_churn.P.ROI = 0.10
+        sol_low_churn.P.risk = 0.05
+
+        sol_high_churn = Solution(num_assets=3)
+        sol_high_churn.P.investment = np.array([0.00, 0.00, 1.00])  # |Δ| = [500, 500, 1000]
+        sol_high_churn.P.ROI = 0.10
+        sol_high_churn.P.risk = 0.05
+
+        sms._evaluate_solution(sol_low_churn, data={})
+        sms._evaluate_solution(sol_high_churn, data={})
+
+        assert sol_low_churn.transaction_cost < sol_high_churn.transaction_cost
+        assert sol_low_churn.objectives[0] > sol_high_churn.objectives[0], \
+            "Low-churn solution must have higher NET ROI (objective)"
+
+    def test_set_previous_weights_none_resets(self):
+        """set_previous_weights(None) clears prior u*_{t-1}."""
+        sms = SMSEMOA(population_size=4, generations=1)
+        sms.set_previous_weights(np.array([0.5, 0.5]), portfolio_value=100.0)
+        assert sms.previous_weights is not None
+        sms.set_previous_weights(None)
+        assert sms.previous_weights is None


### PR DESCRIPTION
## Summary

Integrate the Brazilian SEC fee schedule (thesis Table 7.1) into the SMS-EMOA HV objective so the optimizer subtracts transaction costs from the ROI it tries to maximize. Per §7.2 Eq (7.4)-(7.5), this enters at the OPTIMIZATION step, not just wealth evaluation.

## Pre-W16-2 gap

\`TRANSACTION_COST_RATE=0.001\` was declared in thesis_parameters.py but only used in the wealth-evaluation path. The optimizer was BLIND to churn: it could pick a high-churn EMFC whose realized future Hypv is eaten by trading fees, and never know.

## Thesis grounding

**§7.2 Eqs (7.4)-(7.5), p. 142** — verbatim:
> "z_t|u*_{t-1} = g(u_t, χ_t) + h(u_t, u*_{t-1}),
>  where: g(u_t, χ_t) = (u_t^T Σ̂_{r,t} u_t, μ̂_{r,t}^T u_t)^T
>  and h(u_t, u*_{t-1}) = (0, h(u_t, u*_{t-1}))^T,
>  in which h is a cost function representing all incurring transaction fees and commissions."

**§7.2.3 Table 7.1, p. 144** — Brazilian SEC fee schedule:

| Traded value | Proportional | Fixed |
|---|---|---|
| < 135.07 | 0.0% | 2.70 |
| ≥ 135.08, < 498.62 | 2.0% | 0.00 |
| ≥ 498.63, < 1514.69 | 1.5% | 2.49 |
| ≥ 1514.70, < 3029.38 | 1.0% | 10.06 |
| ≥ 3029.39 | 0.5% | 25.21 |

**§5.2.4, p. 105** — formal derivation: h enters at the OPTIMIZATION step.

## Implementation

- \`ThesisParameters.THESIS_TABLE_71_BRACKETS\` — new constants in \`__post_init__\`
- \`Portfolio.compute_thesis_transaction_cost(weights_new, weights_prev, portfolio_value)\` — new @staticmethod implementing the bracket lookup
- \`SMSEMOA.previous_weights\` + \`SMSEMOA.set_previous_weights(weights, portfolio_value)\` — caller passes u*_{t-1} per period (None on period 1)
- \`SMSEMOA._evaluate_solution\` — when previous_weights set, \`objective[0] = ROI - txn_cost\`; gross ROI preserved on \`portfolio.ROI\`
- \`ExperimentManager._run_algorithm\` — reads \`data["previous_weights"]\`, calls setter
- \`walk_forward.run_walk_forward\` — tracks u*_{t-1} across periods; passes via \`data["previous_weights"]\` for next period

## Tests (10 shipped, ≥ 4 required)

| Group | Tests |
|---|---|
| Brackets (6) | populated; bracket 0 / 1 / 4 correct; zero churn → 0; None previous → 0 |
| Integration (4) | no previous → gross=net; with previous → net=gross-cost; low-churn beats high-churn on objective; None resets |

All 10 green. 52/52 in the full W15/W16 thesis-spec suite.

## Why this contributes to closing the 9% gap

W15-5 retro hypothesis (ranked #2 after λ^K): the optimizer can't distinguish high-churn flexible choices from low-churn ones, so realized future Hypv is eroded by costs it never modeled. W16-2 closes that gap structurally.

Closes BACKLOG: **H1**.

## Test plan
- [x] 10 new W16-2 tests green
- [x] 52/52 full W15/W16 thesis-spec suite
- [x] PR body echoes thesis Eq (7.4)-(7.5) + Table 7.1 verbatim per BACKLOG §6
- [x] u*_{t-1} threading wired end-to-end (walk_forward → ExperimentManager → SMS-EMOA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)