### PR TITLE
W16-4: λ + TIP per-call trace CSV emit (BACKLOG M3 + M4 partial)

### DIFF
--- a/python_refactor/experiments/walk_forward.py
+++ b/python_refactor/experiments/walk_forward.py
@@ -80,6 +80,7 @@ def enumerate_periods(n_days: int, train_window_days: int = 378,
 def _train_and_extract_pareto(scenario: str, seed: int,
                                train_returns: pd.DataFrame,
                                previous_weights: np.ndarray | None = None,
+                               lambda_trace_csv_path: str | None = None,
                                ) -> tuple[list[np.ndarray], int]:
     """Train SMS-EMOA on the train window; extract Pareto weights.
 
@@ -112,6 +113,9 @@ def _train_and_extract_pareto(scenario: str, seed: int,
     # algorithm setter can call set_previous_weights post-init).
     if previous_weights is not None:
         data["previous_weights"] = np.asarray(previous_weights, dtype=float)
+    # W16-4: thread λ trace CSV path; ExperimentManager flushes per-period.
+    if lambda_trace_csv_path is not None:
+        data["lambda_trace_csv_path"] = str(lambda_trace_csv_path)
     results = mgr._run_algorithm(config, data)
     pareto = results.get("pareto_front", [])
     weights: list[np.ndarray] = []
@@ -131,7 +135,8 @@ def run_walk_forward(scenario: str,
                       train_window_days: int = 378,
                       step_days: int = 50,
                       n_mc: int = 1000,
-                      rng: np.random.Generator | None = None
+                      rng: np.random.Generator | None = None,
+                      lambda_trace_csv_path: str | None = None,
                       ) -> list[dict[str, Any]]:
     """Walk-forward evaluate one (scenario, seed) across all rolling periods.
 
@@ -160,7 +165,9 @@ def run_walk_forward(scenario: str,
         oos = full_returns.iloc[p["oos_start"]:p["oos_end"]]
         try:
             weights, n_assets = _train_and_extract_pareto(
-                scenario, seed, train, previous_weights=previous_weights,
+                scenario, seed, train,
+                previous_weights=previous_weights,
+                lambda_trace_csv_path=lambda_trace_csv_path,
             )
         except Exception as exc:
             results.append({**p, "error": f"{type(exc).__name__}: {exc}",

--- a/python_refactor/src/algorithms/anticipatory_learning.py
+++ b/python_refactor/src/algorithms/anticipatory_learning.py
@@ -420,6 +420,64 @@ class AnticipatoryLearning:
     def get_lambda_trace(self) -> List[Dict[str, Any]]:
         """Return a copy of the per-call λ trace rows (W16-1 / W16-4)."""
         return list(self._lambda_trace_rows)
+
+    # ─── W16-4: λ + TIP trace CSV emit ─────────────────────────────
+    # Closes BACKLOG M3 + M4 (trace-export scope only; full Fig 7.4-
+    # 7.13 rendering is W17/W18). The walk_forward driver calls
+    # flush_lambda_trace_csv(path, append=True) at the end of each
+    # period; rows accumulated during all anticipatory rate calls of
+    # that period are written and the buffer is reset.
+    LAMBDA_TRACE_CSV_HEADER = [
+        "period", "generation", "solution_rank",
+        "lambda_h", "lambda_k", "lambda", "tip",
+    ]
+
+    def flush_lambda_trace_csv(self, path,
+                                 append: bool = True) -> int:
+        """
+        Write accumulated λ trace rows to CSV at ``path`` (W16-4).
+
+        Args:
+            path: target CSV path (created with header if not exists OR
+                if append=False)
+            append: True → append rows to existing file; False →
+                truncate and write header + rows
+
+        Returns:
+            Number of rows written.
+
+        Side effects:
+            Clears self._lambda_trace_rows after writing.
+        """
+        import csv
+        import os
+        from pathlib import Path
+
+        rows = list(self._lambda_trace_rows)
+        if not rows:
+            return 0
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        need_header = (not append) or (not p.exists()) or p.stat().st_size == 0
+        mode = "w" if not append else "a"
+        with open(p, mode, newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=self.LAMBDA_TRACE_CSV_HEADER)
+            if need_header:
+                writer.writeheader()
+            for r in rows:
+                # Coerce dtypes for CSV friendliness; preserve NaN as ""
+                writer.writerow({
+                    "period": r.get("period", -1),
+                    "generation": r.get("generation", -1),
+                    "solution_rank": r.get("solution_rank", -1),
+                    "lambda_h": r.get("lambda_h", float("nan")),
+                    "lambda_k": r.get("lambda_k", float("nan")),
+                    "lambda": r.get("lambda", float("nan")),
+                    "tip": r.get("tip", float("nan")),
+                })
+        n_written = len(rows)
+        self._lambda_trace_rows = []
+        return n_written
     
     def _compute_traditional_learning_rate(self, solution: Solution, min_error: float, 
                                          max_error: float, min_alpha: float, max_alpha: float, 

--- a/python_refactor/src/experiments/experiment_manager.py
+++ b/python_refactor/src/experiments/experiment_manager.py
@@ -267,7 +267,24 @@ class ExperimentManager:
 
             # Run algorithm
             population = algorithm.run(data)
-            
+
+            # W16-4: flush per-period λ + TIP trace CSV. Caller passes
+            # data["lambda_trace_csv_path"] (typically the walk-forward
+            # driver, once per period). Trace is APPENDED across periods.
+            trace_csv_path = data.get("lambda_trace_csv_path")
+            if (trace_csv_path is not None
+                    and hasattr(algorithm, "anticipatory_learning")
+                    and algorithm.anticipatory_learning is not None
+                    and hasattr(algorithm.anticipatory_learning, "flush_lambda_trace_csv")):
+                try:
+                    algorithm.anticipatory_learning.flush_lambda_trace_csv(
+                        trace_csv_path, append=True,
+                    )
+                except Exception as exc:
+                    self.logger.warning(
+                        f"W16-4 λ trace flush failed (non-fatal): {exc}"
+                    )
+
             execution_time = time.time() - start_time
             
             # Collect algorithm metrics.

--- a/python_refactor/tests/test_lambda_tip_trace.py
+++ b/python_refactor/tests/test_lambda_tip_trace.py
@@ -1,0 +1,142 @@
+"""
+W16-4: regression tests for λ + TIP per-call trace CSV emit
+(BACKLOG M3 + M4 partial; trace-export scope only).
+
+Thesis grounding (verbatim):
+
+§7.3.1 "Estimated Confidence Over the Stochastic Pareto Frontiers
+(SPFs)", p. 148:
+    "We recall that, according to the OAL rules proposed in chapter 6,
+     the available KF predictive objective distributions of portfolios
+     associated with higher predictive confidence are more intensely
+     incorporated into the resulting anticipatory distributions...
+     Moreover, recall that rank 1 portfolios correspond to the highest
+     risk/return, whereas a rank 20 one corresponds to the lowest
+     risk/return in the population."
+
+§6.1.3 Eq (6.4), p. 116 — TIP definition.
+
+§7.2.3 Eq (7.16), p. 146 — λ = (1/2)(λ^H + λ^K). The trace records
+all 3 scalars per call so W16-5 can confirm both arms fire after W16-1.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.algorithms.anticipatory_learning import AnticipatoryLearning
+from src.algorithms.solution import Solution
+from src.portfolio.portfolio import Portfolio
+
+
+@pytest.fixture(autouse=True)
+def _reset_portfolio_class_state():
+    """Reset Portfolio class variables between tests (W16-1 hygiene)."""
+    prev_mean = Portfolio.mean_ROI
+    prev_cov = Portfolio.covariance
+    Portfolio.mean_ROI = None
+    Portfolio.covariance = None
+    try:
+        yield
+    finally:
+        Portfolio.mean_ROI = prev_mean
+        Portfolio.covariance = prev_cov
+
+
+def _make_solution(num_assets: int = 5) -> Solution:
+    sol = Solution(num_assets=num_assets)
+    sol.P.ROI = 0.05
+    sol.P.risk = 0.10
+    sol.prediction_error = 0.5
+    sol.alpha = 0.5
+    return sol
+
+
+class TestLambdaTraceCSVHeader:
+    """The trace CSV header matches the documented schema."""
+
+    def test_header_schema_matches_spec(self):
+        """LAMBDA_TRACE_CSV_HEADER is exactly the documented 7 fields."""
+        expected = [
+            "period", "generation", "solution_rank",
+            "lambda_h", "lambda_k", "lambda", "tip",
+        ]
+        assert AnticipatoryLearning.LAMBDA_TRACE_CSV_HEADER == expected
+
+
+class TestLambdaTraceCSVEmit:
+    """Per-call trace rows are flushed to CSV with correct schema."""
+
+    def test_flush_empty_trace_is_noop(self, tmp_path: Path):
+        """Empty trace + flush → returns 0, file not created."""
+        al = AnticipatoryLearning(window_size=2)
+        path = tmp_path / "lambda_tip_trace.csv"
+        written = al.flush_lambda_trace_csv(str(path))
+        assert written == 0
+        assert not path.exists()
+
+    def test_flush_creates_csv_with_header_and_rows(self, tmp_path: Path):
+        """Single flush → header + rows written; trace buffer cleared."""
+        al = AnticipatoryLearning(window_size=2)
+        sol = _make_solution()
+        # 3 calls
+        for gen in range(3):
+            al.compute_anticipatory_learning_rate(
+                sol, min_error=0.0, max_error=1.0,
+                min_alpha=0.0, max_alpha=1.0,
+                current_time=5, generation=gen, solution_rank=gen,
+            )
+        path = tmp_path / "lambda_tip_trace.csv"
+        written = al.flush_lambda_trace_csv(str(path), append=False)
+        assert written == 3
+        assert path.exists()
+
+        # Read back the CSV
+        with open(path) as fh:
+            reader = csv.DictReader(fh)
+            rows = list(reader)
+        assert len(rows) == 3
+        assert list(rows[0].keys()) == AnticipatoryLearning.LAMBDA_TRACE_CSV_HEADER
+        # Verify generation 0/1/2 in order
+        gens = [int(r["generation"]) for r in rows]
+        assert gens == [0, 1, 2]
+
+        # Buffer should be cleared post-flush
+        assert al.get_lambda_trace() == []
+
+    def test_flush_append_mode_concatenates(self, tmp_path: Path):
+        """append=True (default) extends existing CSV without re-emitting header."""
+        al = AnticipatoryLearning(window_size=2)
+        sol = _make_solution()
+        path = tmp_path / "lambda_tip_trace.csv"
+
+        # Period 1: 2 rows
+        for gen in range(2):
+            al.compute_anticipatory_learning_rate(
+                sol, 0.0, 1.0, 0.0, 1.0,
+                current_time=1, generation=gen, solution_rank=0,
+            )
+        n1 = al.flush_lambda_trace_csv(str(path), append=True)
+        assert n1 == 2
+
+        # Period 2: 3 rows
+        for gen in range(3):
+            al.compute_anticipatory_learning_rate(
+                sol, 0.0, 1.0, 0.0, 1.0,
+                current_time=2, generation=gen, solution_rank=1,
+            )
+        n2 = al.flush_lambda_trace_csv(str(path), append=True)
+        assert n2 == 3
+
+        # Read back: should have 5 rows total + 1 header line
+        with open(path) as fh:
+            reader = csv.DictReader(fh)
+            rows = list(reader)
+        assert len(rows) == 5
+        # Header appears exactly once → DictReader sees no extra "period"
+        # entries in body rows
+        periods = [int(r["period"]) for r in rows]
+        assert periods == [1, 1, 2, 2, 2]


### PR DESCRIPTION
## Summary

Minimal instrumentation for W16-5 to empirically verify both λ arms fire after W16-1. Per-call (period, generation, solution_rank, λ^H, λ^K, λ, TIP) rows flushed to CSV at end of each period.

## Scope

**Trace-export only.** Full Fig 7.4-7.13 rendering + per-portfolio per-period aggregation = W17 / W18.

## Implementation

- \`AnticipatoryLearning.LAMBDA_TRACE_CSV_HEADER\` — 7-field class constant
- \`AnticipatoryLearning.flush_lambda_trace_csv(path, append=True)\` — writes buffer + clears
- \`ExperimentManager._run_algorithm\` — reads \`data["lambda_trace_csv_path"]\`; flushes after \`algorithm.run\`
- \`walk_forward.run_walk_forward\` + \`_train_and_extract_pareto\` — optional \`lambda_trace_csv_path\` kwarg threaded via data dict

## Thesis grounding

**§7.3.1 (p. 148)** — OAL rules, rank-1 vs rank-20 risk/return ordering (the trace shape W17/W18 will visualize as Figs 7.4-7.13).

**§6.1.3 Eq (6.4) (p. 116)** — TIP definition (column \`tip\` in trace).

**§7.2.3 Eq (7.16) (p. 146)** — λ = 0.5*(λ^H + λ^K). The trace records all 3 scalars so W16-5 can confirm both arms fire and the formula holds.

## Tests (4 shipped, ≥ 2 required)

- header schema = 7 documented fields
- empty flush → 0 rows, no file
- populated flush → header + rows; buffer cleared
- append mode → no header duplication across calls

All 4 green. 56/56 in the full W15/W16 thesis-spec suite.

## Honest scars (deferred)

- Full per-portfolio Figs 7.4-7.13 → W17/W18
- Per-seed bootstrap CI on λ traces → W17/W18
- Coherence (Eq 7.14) + POCID (Eq 7.13) + wealth trace (Eq 7.12) → W17 (M6/M7/M8 in BACKLOG)

Closes BACKLOG: **M3 + M4** (partial; trace-export scope only).

## Test plan
- [x] 4 new W16-4 tests green
- [x] 56/56 full W15/W16 suite
- [x] PR body echoes Eq 7.16 + Eq 6.4 per BACKLOG §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)