### PR TITLE
W17-4: AMFC u*_{t-1} selector per thesis Eq 6.42 (W16-2-CARRY-1 + M5 partial)

### DIFF
--- a/python_refactor/experiments/oos_evaluator.py
+++ b/python_refactor/experiments/oos_evaluator.py
@@ -185,3 +185,69 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
         "efhv_std": float(samples_hv.std(ddof=1)) if n_samples >= 2 else 0.0,
         "efhv_samples": samples_hv,
     }
+
+
+def compute_per_portfolio_efhv(pareto_weights: list[np.ndarray],
+                                oos_returns: pd.DataFrame,
+                                n_samples: int = 1000,
+                                z_ref: tuple[float, float] = (0.2, 0.0),
+                                rng: np.random.Generator | None = None) -> np.ndarray:
+    """W17-4: per-portfolio expected single-point HV against z_ref.
+
+    Implements thesis §6.4 Eq 6.42 (AMFC selection) on the OOS side:
+    for each portfolio i in pareto_weights, return E[Hypv((u_i^T Σ̂ u_i,
+    μ̂^T u_i))] averaged over n_samples MC bootstrap scenarios.
+
+    The "single-point HV" against z_ref = (risk_max, return_min) is:
+        HV_i_e = max(0, μ̂_e^T u_i - z_ref[1]) * max(0, z_ref[0] - u_i^T Σ̂_e u_i)
+    i.e. the rectangular area dominated by the single point (var, return)
+    against the reference corner (risk_max, return_min). Per-portfolio
+    EFHV = mean over e.
+
+    The argmax-index of the returned array is the AMFC per Eq 6.42.
+    walk_forward.run_walk_forward uses this argmax as u*_{t-1} for the
+    next rolling period (W16-2-CARRY-1 closure: replaces "first
+    Pareto-front portfolio" proxy).
+
+    Returns:
+        np.ndarray of length len(pareto_weights), each entry is the
+        portfolio's expected single-point HV (≥ 0). All-zero indicates
+        a degenerate period (all portfolios dominate-or-are-dominated
+        by z_ref); caller should fall back to weights[0].
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    arr = (oos_returns.values if isinstance(oos_returns, pd.DataFrame)
+            else np.asarray(oos_returns, dtype=float))
+    if arr.ndim != 2 or arr.shape[0] < 2:
+        raise ValueError(f"oos_returns must be 2D with ≥ 2 rows; got shape {arr.shape}")
+    n_days, n_assets = arr.shape
+
+    weights_arr = [np.asarray(w, dtype=float) for w in pareto_weights]
+    n_portfolios = len(weights_arr)
+    if n_portfolios == 0:
+        return np.zeros(0, dtype=float)
+    for i, w in enumerate(weights_arr):
+        if w.shape != (n_assets,):
+            raise ValueError(
+                f"weights[{i}] shape {w.shape} mismatches oos_returns "
+                f"n_assets={n_assets}"
+            )
+
+    risk_ref, return_ref = z_ref[0], z_ref[1]
+    # Accumulate per-portfolio HV samples across MC bootstrap.
+    per_portfolio_hv = np.zeros(n_portfolios, dtype=float)
+    for e in range(n_samples):
+        idx = rng.integers(0, n_days, n_days)
+        sample = arr[idx]
+        mu = sample.mean(axis=0)
+        cov = np.cov(sample, rowvar=False, ddof=1)
+        for i, w in enumerate(weights_arr):
+            var = float(w @ cov @ w)
+            ret = float(mu @ w)
+            # Single-point HV against z_ref = (risk_max, return_min).
+            # Dominance corner: portfolio dominates the reference iff
+            # ret > return_ref AND var < risk_ref.
+            hv = max(0.0, ret - return_ref) * max(0.0, risk_ref - var)
+            per_portfolio_hv[i] += hv
+    return per_portfolio_hv / float(n_samples)

--- a/python_refactor/experiments/walk_forward.py
+++ b/python_refactor/experiments/walk_forward.py
@@ -77,6 +77,29 @@ def enumerate_periods(n_days: int, train_window_days: int = 378,
 # Per-period training + OOS eval
 # ---------------------------------------------------------------------------
 
+def _select_amfc_index(per_portfolio_efhv: np.ndarray) -> int:
+    """W17-4: AMFC selector per thesis §6.4 Eq 6.42.
+
+    Pick the argmax over per-portfolio expected future HV. Ties
+    broken deterministically (smallest index wins). Fallback to
+    index 0 + warning if all per-portfolio EFHV are 0 / NaN.
+    """
+    if per_portfolio_efhv.size == 0:
+        return 0
+    finite_mask = np.isfinite(per_portfolio_efhv)
+    if not finite_mask.any() or per_portfolio_efhv[finite_mask].max() <= 0.0:
+        import logging
+        logging.getLogger(__name__).warning(
+            "W17-4: all per-portfolio EFHV are 0/NaN — fallback to index 0 "
+            "as u*_{t-1}. Possible degenerate period (Pareto front dominated "
+            "by z_ref or all weights produced negative-return / high-variance "
+            "predictions)."
+        )
+        return 0
+    # np.argmax breaks ties by smallest index (deterministic).
+    return int(np.argmax(per_portfolio_efhv))
+
+
 def _train_and_extract_pareto(scenario: str, seed: int,
                                train_returns: pd.DataFrame,
                                previous_weights: np.ndarray | None = None,
@@ -190,14 +213,23 @@ def run_walk_forward(scenario: str,
             n_samples=n_mc,
             rng=rng,
         )
-        # W16-2: persist the period's implemented portfolio as
-        # u*_{t-1} for the NEXT period's optimization. Convention:
-        # the first portfolio in the Pareto front (or argmax-EFHV
-        # if richer DM logic is available — W17 territory).
-        previous_weights = weights[0]
+        # W17-4 (closes W16-2-CARRY-1 + BACKLOG M5 partial): pick the
+        # AMFC per thesis §6.4 Eq 6.42 as u*_{t-1} for the NEXT period
+        # — argmax over per-portfolio expected single-point HV against
+        # z_ref. Replaces W16-2's "first Pareto-front portfolio" proxy.
+        from .oos_evaluator import compute_per_portfolio_efhv
+        per_portfolio_efhv = compute_per_portfolio_efhv(
+            pareto_weights=weights,
+            oos_returns=oos,
+            n_samples=n_mc,
+            rng=rng,
+        )
+        u_star_idx = _select_amfc_index(per_portfolio_efhv)
+        previous_weights = weights[u_star_idx]
         results.append({
             **p,
             "n_pareto": len(weights),
+            "u_star_idx": int(u_star_idx),
             "efhv_mean": efhv["efhv_mean"],
             "efhv_std": efhv["efhv_std"],
         })

--- a/python_refactor/tests/test_amfc_u_star_selector.py
+++ b/python_refactor/tests/test_amfc_u_star_selector.py
@@ -1,0 +1,117 @@
+"""
+W17-4: regression tests for AMFC u*_{t-1} selector per thesis Eq 6.42
+(W16-2-CARRY-1 + BACKLOG M5 partial closure).
+
+Thesis grounding (verbatim):
+
+§6.4 "Estimating the Anticipated Maximal Flexible Choice", Eq (6.42),
+p. 133:
+    "AMFC selects, from the available essential set of Pareto-flexible
+     decision candidates Û_t^{N*}, the portfolio u_t^{(i*)*} which is
+     predicted to lead to the maximum future expected hypervolume:
+     u_t^{(i*)*} = argmax_{u_t^{(i)*} ∈ Û_t^{N*}}
+                     E[Hypv(Ẑ_{t+1}^{(i)*})]"
+"""
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from experiments.walk_forward import _select_amfc_index
+from experiments.oos_evaluator import compute_per_portfolio_efhv
+
+
+class TestSelectAMFCIndex:
+    """_select_amfc_index picks argmax with deterministic tie-break."""
+
+    def test_picks_argmax(self):
+        """Clear winner → its index."""
+        efhv = np.array([0.001, 0.005, 0.003, 0.002])
+        assert _select_amfc_index(efhv) == 1
+
+    def test_tie_break_smallest_index(self):
+        """Ties → smallest index wins (deterministic via np.argmax)."""
+        efhv = np.array([0.005, 0.005, 0.003, 0.001])
+        assert _select_amfc_index(efhv) == 0
+
+    def test_all_zero_falls_back_to_zero_with_warning(self, caplog):
+        """All-zero EFHV → fallback index 0 + logged warning."""
+        efhv = np.zeros(4)
+        with caplog.at_level(logging.WARNING):
+            idx = _select_amfc_index(efhv)
+        assert idx == 0
+        assert any("W17-4" in r.message for r in caplog.records)
+
+    def test_all_nan_falls_back_to_zero(self):
+        """All-NaN EFHV → fallback index 0."""
+        efhv = np.array([float("nan")] * 3)
+        idx = _select_amfc_index(efhv)
+        assert idx == 0
+
+    def test_empty_array_returns_zero(self):
+        """Empty EFHV → 0 (degenerate; caller should already have weights[0])."""
+        efhv = np.zeros(0)
+        assert _select_amfc_index(efhv) == 0
+
+
+class TestComputePerPortfolioEFHV:
+    """compute_per_portfolio_efhv returns sensible per-portfolio array."""
+
+    def test_returns_length_matches_n_portfolios(self):
+        # Synthetic 2 portfolios x 3 assets; 50 days of returns
+        rng = np.random.default_rng(42)
+        oos = pd.DataFrame(
+            rng.normal(loc=0.001, scale=0.01, size=(50, 3)),
+            columns=[f"a{i}" for i in range(3)],
+        )
+        weights = [
+            np.array([0.5, 0.3, 0.2]),
+            np.array([0.2, 0.3, 0.5]),
+        ]
+        efhv = compute_per_portfolio_efhv(
+            pareto_weights=weights,
+            oos_returns=oos,
+            n_samples=20,
+            rng=rng,
+        )
+        assert efhv.shape == (2,)
+        assert all(np.isfinite(efhv))
+
+    def test_higher_return_portfolio_wins(self):
+        """Among 2 portfolios with same risk profile, higher-return wins."""
+        # Construct a returns DataFrame where asset 0 has much higher
+        # mean return than asset 1; both with similar variance.
+        n_days = 200
+        rng = np.random.default_rng(123)
+        col0 = rng.normal(loc=0.005, scale=0.01, size=n_days)
+        col1 = rng.normal(loc=0.0001, scale=0.01, size=n_days)
+        oos = pd.DataFrame({"a0": col0, "a1": col1})
+        # Two portfolios: 100% asset 0 (high return), 100% asset 1 (low return)
+        weights = [
+            np.array([1.0, 0.0]),  # high return
+            np.array([0.0, 1.0]),  # low return
+        ]
+        efhv = compute_per_portfolio_efhv(
+            pareto_weights=weights,
+            oos_returns=oos,
+            n_samples=200,
+            rng=rng,
+            z_ref=(0.2, 0.0),  # risk_max, return_min
+        )
+        # Higher-return portfolio gets larger HV (rectangle width)
+        assert efhv[0] > efhv[1], (
+            f"high-return portfolio should win: efhv[0]={efhv[0]}, "
+            f"efhv[1]={efhv[1]}"
+        )
+
+    def test_empty_weights_returns_empty(self):
+        oos = pd.DataFrame({"a0": [0.01, 0.02, 0.03], "a1": [0.0, 0.01, -0.01]})
+        efhv = compute_per_portfolio_efhv(
+            pareto_weights=[],
+            oos_returns=oos,
+            n_samples=10,
+        )
+        assert efhv.shape == (0,)


### PR DESCRIPTION
## Closes W16-2-CARRY-1 + BACKLOG M5 partial

Replace W16-2's "first Pareto-front portfolio" proxy with AMFC argmax per thesis §6.4 Eq 6.42.

## Thesis grounding (verbatim)

**§6.4 Eq (6.42), p. 133**:
> "AMFC selects, from the available essential set of Pareto-flexible decision candidates Û_t^{N*}, the portfolio u_t^{(i*)*} which is predicted to lead to the maximum future expected hypervolume: u_t^{(i*)*} = argmax_{u_t^{(i)*} ∈ Û_t^{N*}} E[Hypv(Ẑ_{t+1}^{(i)*})]"

## Implementation

- \`oos_evaluator.compute_per_portfolio_efhv\` — NEW; per-portfolio E[Hypv] via single-point HV against z_ref
- \`walk_forward._select_amfc_index\` — NEW; argmax with deterministic tie-break + all-zero/NaN fallback
- \`run_walk_forward\` — uses AMFC index for next-period \`previous_weights\`; emits \`u_star_idx\` per-period

## Why this matters for closing the gap

The W16-2 txn-cost penalty penalizes rebalancing from u*_{t-1}. With the arbitrary "first-portfolio" proxy, the penalty optimized for "minimum churn from an arbitrary portfolio" — not matching the AMFC implementation. With Eq 6.42 AMFC, the penalty signal matches reality.

## Tests (8 shipped, ≥ 3 required)

| Group | Tests |
|---|---|
| Selector (5) | argmax; tie-break smallest; all-zero+warning; all-NaN; empty |
| Per-portfolio EFHV (3) | length matches; higher-return wins; empty→empty |

All 8 green. 63/63 in the full W15+W16+W17 thesis-spec suite.

Closes: **W16-2-CARRY-1 + BACKLOG M5 partial**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)