### PR TITLE
W17-5-CARRY-1: MultiHorizon now uses Eq 7.16 (1/2)(λ^H + λ^K), trace emits

### DIFF
--- a/python_refactor/src/algorithms/multi_horizon_anticipatory.py
+++ b/python_refactor/src/algorithms/multi_horizon_anticipatory.py
@@ -155,46 +155,85 @@ class MultiHorizonAnticipatoryLearning(TIPIntegratedAnticipatoryLearning):
         
         return anticipatory_state
     
-    def calculate_multi_horizon_lambda_rates(self, solution: Solution, 
-                                           prediction_horizon: int) -> List[float]:
+    def calculate_multi_horizon_lambda_rates(self, solution: Solution,
+                                           prediction_horizon: int,
+                                           generation: int = -1,
+                                           solution_rank: int = -1,
+                                           current_time: int = -1) -> List[float]:
         """
         Calculate λ_{t+h} rates for multiple horizons.
-        
-        Based on Equation 6.6: λ_{t+h} = (1/(H-1)) [1 - H(p_{t,t+h})]
-        
+
+        W17-5-CARRY-1: now combines Eq 6.6 (λ^H per horizon) with
+        Eq 6.9 (λ^K from K-period KF residual buffer) per thesis Eq 7.16:
+            λ_{t+h} = (1/2) * (λ^H_{t+h} + λ^K_{t+h})
+
+        Pre-W17-5-CARRY-1 the multi-horizon path used Eq 6.6 alone
+        (entropy of TIP) — silently dropping the λ^K arm. As a result
+        the W17-2 record_kf_residual wiring populated the buffer but
+        the buffer was never consumed by the headline ASMS_mHDM_K3
+        scenario. The W17-5 smoke saw 48x wall-clock slowdown
+        attributable to the multi-horizon prediction loop, NOT to
+        λ^K consumption (which was silently zero).
+
+        This fix:
+          1. Computes λ^H per horizon via Eq 6.6 (TIP-entropy, as before)
+          2. Computes λ^K via the inherited _compute_lambda_k_with_branch
+             (Eq 6.9 normalized residual sum over K periods)
+          3. Returns the (1/2) average per Eq 7.16 per horizon
+          4. Appends a trace row per horizon for W17-5 assertions
+
         Args:
             solution: Current solution
             prediction_horizon: Prediction horizon H
-            
+            generation: Generation index (for trace)
+            solution_rank: Rank index (for trace)
+            current_time: Period index (for trace)
+
         Returns:
-            List of lambda rates for each horizon
+            List of combined Eq 7.16 lambda rates for each horizon
         """
         if prediction_horizon < 2:
-            # W3-1: was `return [0.0]` which violates the invariant
-            # len(predicted_states) == len(lambda_rates) used by
-            # apply_anticipatory_learning_rule (H<2 has 0 future
-            # horizons, so 0 predicted_states, so 0 lambda_rates).
             return []
-        
+
+        # ── λ^K is solution-invariant per period (depends on residual
+        # buffer, not on the per-horizon TIP). Compute once.
+        # W17-5-CARRY-1: use _compute_lambda_k_with_branch from base.
+        lambda_k, lambda_k_branch = self._compute_lambda_k_with_branch(
+            solution,
+            min_error=0.0, max_error=1.0,
+            min_alpha=0.0, max_alpha=1.0,
+            current_time=current_time,
+        )
+
         lambda_rates = []
-        
         for h in range(1, prediction_horizon):
-            # Calculate TIP for horizon h
+            # λ^H per Eq 6.6: TIP-entropy across horizon h
             tip = self._calculate_tip_for_horizon(solution, h)
-            
-            # Calculate binary entropy
             entropy = self.tip_calculator.binary_entropy(tip)
-            
-            # Calculate lambda rate based on Equation 6.6
             lambda_h = (1.0 / (prediction_horizon - 1)) * (1.0 - entropy)
-            
-            # Apply bounds to ensure stability
             lambda_h = max(0.0, min(0.5, lambda_h))
-            
-            lambda_rates.append(lambda_h)
-        
-        logger.debug(f"Calculated lambda rates for horizon {prediction_horizon}: {lambda_rates}")
-        
+
+            # W17-5-CARRY-1: combine per Eq 7.16 verbatim
+            #   λ_{t+h} = (1/2) * (λ^H_{t+h} + λ^K_{t+h})
+            lambda_combined = 0.5 * (lambda_h + lambda_k)
+
+            # Trace row per horizon (consumed by W16-4 flush_lambda_trace_csv)
+            self._lambda_trace_rows.append({
+                "period": current_time,
+                "generation": generation,
+                "solution_rank": solution_rank if solution_rank >= 0 else h,
+                "lambda_h": lambda_h,
+                "lambda_k": lambda_k,
+                "lambda": lambda_combined,
+                "tip": tip,
+                "lambda_k_branch": lambda_k_branch,
+            })
+
+            lambda_rates.append(lambda_combined)
+
+        logger.debug(f"MultiHorizon λ rates (Eq 7.16) for H={prediction_horizon}: "
+                     f"{lambda_rates} (λ^K={lambda_k:.6f}, branch={lambda_k_branch})")
+
         return lambda_rates
     
     def _calculate_tip_for_horizon(self, solution: Solution, horizon: int) -> float:
@@ -544,14 +583,19 @@ class MultiHorizonAnticipatoryLearning(TIPIntegratedAnticipatoryLearning):
             population: list of Solution objects to update in-place
             current_time: current time step
         """
-        for solution in population:
+        for sol_rank, solution in enumerate(population):
             # Build current state [ROI, risk] — paper Eq (11) canonical
             # ordering (W1-1 settled this).
             current_state = np.array([solution.P.ROI, solution.P.risk])
 
-            # Compute per-horizon λ rates (paper Eq 13).
+            # Compute per-horizon λ rates — W17-5-CARRY-1: now combines
+            # Eq 6.6 (λ^H per horizon) + Eq 6.9 (λ^K) per Eq 7.16, with
+            # trace row emission per horizon.
             lambda_rates = self.calculate_multi_horizon_lambda_rates(
                 solution, self.max_horizon,
+                generation=-1,  # generation not tracked here; rank disambiguates
+                solution_rank=sol_rank,
+                current_time=current_time,
             )
 
             # When max_horizon < 2 (no future horizons), the rule

--- a/python_refactor/src/experiments/experiment_manager.py
+++ b/python_refactor/src/experiments/experiment_manager.py
@@ -268,22 +268,28 @@ class ExperimentManager:
             # Run algorithm
             population = algorithm.run(data)
 
-            # W16-4: flush per-period λ + TIP trace CSV. Caller passes
-            # data["lambda_trace_csv_path"] (typically the walk-forward
-            # driver, once per period). Trace is APPENDED across periods.
+            # W16-4 + W17-5-CARRY-1: flush per-period λ + TIP trace CSV.
+            # Caller passes data["lambda_trace_csv_path"] (typically the
+            # walk-forward driver, once per period). Trace is APPENDED
+            # across periods.
             trace_csv_path = data.get("lambda_trace_csv_path")
-            if (trace_csv_path is not None
-                    and hasattr(algorithm, "anticipatory_learning")
-                    and algorithm.anticipatory_learning is not None
-                    and hasattr(algorithm.anticipatory_learning, "flush_lambda_trace_csv")):
-                try:
-                    algorithm.anticipatory_learning.flush_lambda_trace_csv(
-                        trace_csv_path, append=True,
-                    )
-                except Exception as exc:
-                    self.logger.warning(
-                        f"W16-4 λ trace flush failed (non-fatal): {exc}"
-                    )
+            if trace_csv_path is not None:
+                learner = getattr(algorithm, "anticipatory_learning", None)
+                if learner is not None and hasattr(learner, "flush_lambda_trace_csv"):
+                    import logging as _stdlib_logging
+                    _trace_logger = _stdlib_logging.getLogger(__name__)
+                    try:
+                        n_written = learner.flush_lambda_trace_csv(
+                            trace_csv_path, append=True,
+                        )
+                        _trace_logger.info(
+                            f"W16-4/W17-5-CARRY-1 λ trace flush: wrote "
+                            f"{n_written} rows to {trace_csv_path}"
+                        )
+                    except Exception as exc:
+                        _trace_logger.warning(
+                            f"W16-4 λ trace flush failed (non-fatal): {exc}"
+                        )
 
             execution_time = time.time() - start_time
             

--- a/python_refactor/tests/test_lambda_trace_integration.py
+++ b/python_refactor/tests/test_lambda_trace_integration.py
@@ -1,0 +1,155 @@
+"""
+W17-5-CARRY-1 closure: integration test for end-to-end λ trace CSV
+emit through ExperimentManager._run_algorithm.
+
+The W17-5 production smoke set --lambda-trace-csv-path but the
+CSV was not emitted. This test reproduces the path
+(ExperimentManager._run_algorithm with a real algorithm + learner
++ data["lambda_trace_csv_path"]) at unit scale to isolate the bug
+without paying the 600s walk-forward cost.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.experiments.experiment_manager import ExperimentManager
+from src.portfolio.portfolio import Portfolio
+
+
+@pytest.fixture(autouse=True)
+def _reset_portfolio_class_state():
+    prev_mean = Portfolio.mean_ROI
+    prev_cov = Portfolio.covariance
+    Portfolio.mean_ROI = None
+    Portfolio.covariance = None
+    try:
+        yield
+    finally:
+        Portfolio.mean_ROI = prev_mean
+        Portfolio.covariance = prev_cov
+
+
+def _build_minimal_data(tmp_path: Path,
+                          lambda_trace_csv_path: str | None = None) -> dict:
+    """Build a minimal data dict for ExperimentManager._run_algorithm."""
+    rng = np.random.default_rng(42)
+    n_days = 50
+    n_assets = 5
+    returns = rng.normal(loc=0.001, scale=0.01, size=(n_days, n_assets))
+    df = pd.DataFrame(returns, columns=[f"a{i}" for i in range(n_assets)])
+    data = {"assets": df, "market": pd.DataFrame(), "config": {}}
+    if lambda_trace_csv_path is not None:
+        data["lambda_trace_csv_path"] = str(lambda_trace_csv_path)
+    return data
+
+
+def _build_minimal_config(use_multi_horizon: bool = True) -> dict:
+    """Mirror SCENARIOS' ASMS_mHDM_K3 config shape."""
+    return {
+        "experiment_name": "trace_emit_smoke",
+        "algorithm": {
+            "name": "sms_emoa",
+            "parameters": {
+                "population_size": 10,
+                "generations": 3,
+                # Keep tiny so the test is fast
+            },
+        },
+        "learning": {
+            "enabled": True,
+            "use_multi_horizon": use_multi_horizon,
+            "parameters": {
+                "max_horizon": 2,
+                "monte_carlo_samples": 50,
+                "window_size": 3,  # K=3
+            },
+        },
+        "data": {},
+    }
+
+
+class TestLambdaTraceCSVEmitsInProduction:
+    """W17-5-CARRY-1: trace CSV must emit when path is set via data dict."""
+
+    def test_trace_csv_emitted_when_path_set(self, tmp_path: Path):
+        """End-to-end: _run_algorithm with lambda_trace_csv_path → CSV exists."""
+        csv_path = tmp_path / "lambda_tip_trace.csv"
+        suite_config = {
+            "experiment_name": "trace_emit_smoke",
+            "description": "W17-5-CARRY-1 reproducer",
+            "version": "W17-5-CARRY-1",
+            "timestamp": "2026-05-17T00:00:00Z",
+        }
+        mgr = ExperimentManager(suite_config)
+        config = _build_minimal_config(use_multi_horizon=True)
+        data = _build_minimal_data(tmp_path, lambda_trace_csv_path=str(csv_path))
+        result = mgr._run_algorithm(config, data)
+        # Algorithm ran (returned a result)
+        assert "pareto_front" in result
+        # CSV must exist
+        assert csv_path.exists(), (
+            f"lambda_tip_trace.csv was not emitted at {csv_path}; "
+            f"W17-5-CARRY-1 reproducer fails — flush silently no-ops"
+        )
+
+    def test_trace_csv_not_emitted_when_path_missing(self, tmp_path: Path):
+        """Default: no path → no CSV write attempted."""
+        suite_config = {
+            "experiment_name": "no_trace",
+            "description": "negative case",
+            "version": "W17-5-CARRY-1",
+            "timestamp": "2026-05-17T00:00:00Z",
+        }
+        mgr = ExperimentManager(suite_config)
+        config = _build_minimal_config(use_multi_horizon=True)
+        data = _build_minimal_data(tmp_path, lambda_trace_csv_path=None)
+        result = mgr._run_algorithm(config, data)
+        assert "pareto_front" in result
+        # No CSV files in tmp_path
+        csvs = list(tmp_path.glob("*.csv"))
+        assert not csvs, f"unexpected CSVs emitted: {csvs}"
+
+    def test_csv_contents_satisfy_trace_assertions(self, tmp_path: Path):
+        """W17-5-CARRY-1: assert the CSV content matches the W17-5 contract.
+
+          - λ^H ∈ [0, 1]
+          - λ^K ∈ [0, 1]
+          - λ ≈ 0.5 * (λ^H + λ^K) within 1e-9 (Eq 7.16)
+          - lambda_k_branch is one of {k0_zero, warmup_traditional, kperiod_sum}
+        """
+        import csv
+        csv_path = tmp_path / "trace.csv"
+        suite_config = {
+            "experiment_name": "trace_content_assertions",
+            "description": "W17-5-CARRY-1 contract test",
+            "version": "W17-5-CARRY-1",
+            "timestamp": "2026-05-17T00:00:00Z",
+        }
+        mgr = ExperimentManager(suite_config)
+        config = _build_minimal_config(use_multi_horizon=True)
+        data = _build_minimal_data(tmp_path, lambda_trace_csv_path=str(csv_path))
+        mgr._run_algorithm(config, data)
+        assert csv_path.exists()
+
+        with open(csv_path) as fh:
+            reader = csv.DictReader(fh)
+            rows = list(reader)
+        assert len(rows) >= 1, "expected at least 1 trace row"
+
+        for r in rows:
+            lh = float(r["lambda_h"])
+            lk = float(r["lambda_k"])
+            lam = float(r["lambda"])
+            branch = r["lambda_k_branch"]
+            assert 0.0 <= lh <= 1.0, f"λ^H out of range: {lh}"
+            assert 0.0 <= lk <= 1.0, f"λ^K out of range: {lk}"
+            assert lam == pytest.approx(0.5 * (lh + lk), abs=1e-9), (
+                f"Eq 7.16 violated: λ={lam}, expected 0.5*(λ^H + λ^K)={0.5*(lh+lk)}"
+            )
+            assert branch in {"k0_zero", "warmup_traditional", "kperiod_sum"}, (
+                f"unknown branch: {branch}"
+            )


### PR DESCRIPTION
## Major finding (deeper than original carry scope)

W17-5 retro speculated the trace silent no-op was a path-resolution issue. **The real cause is more important**:

\`MultiHorizonAnticipatoryLearning.calculate_multi_horizon_lambda_rates\` used **Eq 6.6 (TIP-entropy only)** — silently dropping the entire λ^K arm AND the (1/2) averaging from Eq 7.16. Pre-this-fix:

- W17-2's \`record_kf_residual\` correctly populated the K-period buffer in production (debug confirmed 30 trace rows ready)
- But the buffer was **NEVER consumed** because MultiHorizon's \`learn_population\` path bypassed \`compute_anticipatory_learning_rate\`
- So the published ASMS_mHDM_K3 scenario was using TIP-entropy-only rates, NOT the Eq 7.16 combined rates the thesis prescribes

This materially changes the W17-5 attribution: the 3.22pp regression from W16-5 to W17-5 is now suspect — W17-2's λ^K wiring was correct but never reached the headline scenario.

## Fix

- \`calculate_multi_horizon_lambda_rates\`: computes λ^K once per call (via inherited \`_compute_lambda_k_with_branch\`); per horizon returns \`0.5*(λ^H + λ^K)\` per Eq 7.16; appends trace row per horizon
- \`learn_population\`: passes generation/solution_rank/current_time context
- \`ExperimentManager._run_algorithm\`: stdlib logging (\`ExperimentLogger\` lacks generic \`info\`/\`warning\`; silently swallowed warnings hid the original issue)

## Tests (3 new + 65 regression all green)

\`tests/test_lambda_trace_integration.py\`:
- path set → CSV exists post-run
- path absent → no CSV
- CSV content satisfies W17-5 contract (λ^H/λ^K in [0,1]; λ = 0.5*(λ^H+λ^K) within 1e-9; valid branch)

## Carry-forward implications

- W17-5's -8.72% gap is reinterpretable: needs re-run with this fix
- The "48x wall-clock = λ^K firing" inference was wrong — slowdown is from multi-horizon prediction loop overhead
- W18 should re-run W17-5 with this fix BEFORE any ablation/30-seed work

Closes: **W17-5-CARRY-1 + the deeper Eq 7.16 gap in MultiHorizon path**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)