### PR TITLE
W18-1: cross-validation harness scaffold + FIRST C++ bug surfaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,16 @@ python_refactor/experiments/metrics/
 python_refactor/experiments/results/*
 # W17-1: result-of-truth artifacts (committed for test dependencies)
 !python_refactor/experiments/results/h4-eda/
+
+# W18-1 cross-validation: legacy-cpp/build/ is the harness scaffold dir.
+# Override the broad `build/` rule from VS boilerplate above so we can
+# commit the Makefile + README-BUILD-ADAPTER.md + drivers/*.cpp sources,
+# then ignore per-platform artifacts within it.
+!legacy-cpp/build/
+!legacy-cpp/build/**
+legacy-cpp/build/objs/
+legacy-cpp/build/src_patched/
+legacy-cpp/build/headers_patched/
+legacy-cpp/build/eigen-*/
+legacy-cpp/build/eigen-*.tar.gz
+legacy-cpp/build/drivers/*_driver

--- a/legacy-cpp/build/Makefile
+++ b/legacy-cpp/build/Makefile
@@ -1,0 +1,96 @@
+# W18-1 Cross-validation harness — C++ legacy build adapter
+#
+# Builds the C++ ASMOO reference implementation on Apple silicon /
+# Apple clang 17 / C++14 / Eigen 3.4. Patches are PURELY mechanical
+# build adapters (see README-BUILD-ADAPTER.md); they do NOT change
+# algorithm semantics.
+#
+# Usage:
+#   make all          # build all .o + drivers
+#   make eigen        # download + extract Eigen 3.4.0 if missing
+#   make patches      # apply build adapters to legacy-cpp/source + headers
+#   make objs         # compile all source files to objs/
+#   make driver-NAME  # build cross-check driver: drivers/NAME_driver
+#   make clean        # remove build artifacts (keep eigen download)
+#   make distclean    # remove everything except this Makefile
+
+CXX            = g++
+CXXFLAGS       = -std=c++14 -DEIGEN_DONT_VECTORIZE -O2 -Wno-deprecated-declarations
+EIGEN_VERSION  = 3.4.0
+EIGEN_DIR      = eigen-$(EIGEN_VERSION)
+EIGEN_URL      = https://gitlab.com/libeigen/eigen/-/archive/$(EIGEN_VERSION)/eigen-$(EIGEN_VERSION).tar.gz
+BOOST_INC      = /opt/homebrew/include
+INCLUDES       = -I./headers_patched -I$(BOOST_INC) -I./$(EIGEN_DIR)
+
+SOURCES        = aprendizado_operadores kalman_filter mvtnorm nsga2 \
+                  operadores_cruzamento operadores_mutacao operadores_selecao \
+                  portfolio statistics utils
+OBJS           = $(addprefix objs/, $(addsuffix .o, $(SOURCES)))
+
+DRIVER_SRCS    = $(wildcard drivers/*_driver.cpp)
+DRIVER_BINS    = $(patsubst drivers/%.cpp, drivers/%, $(DRIVER_SRCS))
+
+
+.PHONY: all eigen patches objs drivers clean distclean
+
+all: objs drivers
+
+eigen: $(EIGEN_DIR)/Eigen/Dense
+
+$(EIGEN_DIR)/Eigen/Dense:
+	@echo "[W18-1] Downloading Eigen $(EIGEN_VERSION)..."
+	@if [ ! -f $(EIGEN_DIR).tar.gz ]; then \
+		curl -fsSL $(EIGEN_URL) -o $(EIGEN_DIR).tar.gz; \
+	fi
+	@tar xzf $(EIGEN_DIR).tar.gz
+	@echo "[W18-1] Eigen $(EIGEN_VERSION) installed at ./$(EIGEN_DIR)"
+
+# W18-1 ADAPTER 1+2: Eigen include path + double->uint narrowing.
+# Creates src_patched/ and headers_patched/ from frozen legacy source.
+patches: src_patched/.timestamp headers_patched/.timestamp
+
+src_patched/.timestamp: ../source/*.cpp
+	@echo "[W18-1] Patching ../source -> src_patched (Eigen include + narrowing)..."
+	@rm -rf src_patched
+	@cp -r ../source src_patched
+	@find src_patched -name "*.cpp" | xargs sed -i '' \
+		-e 's|<Eigen/Eigen/|<Eigen/|g' \
+		-e 's|"../headers/|"|g' \
+		-e 's|2\.0\*portfolio::window_size|2u*portfolio::window_size|g'
+	@touch src_patched/.timestamp
+
+headers_patched/.timestamp: ../headers/*.h
+	@echo "[W18-1] Patching ../headers -> headers_patched..."
+	@rm -rf headers_patched
+	@cp -r ../headers headers_patched
+	@find headers_patched -name "*.h" | xargs sed -i '' \
+		-e 's|<Eigen/Eigen/|<Eigen/|g' \
+		-e 's|"../headers/|"|g' \
+		-e 's|2\.0\*portfolio::window_size|2u*portfolio::window_size|g'
+	@touch headers_patched/.timestamp
+
+objs: eigen patches $(OBJS)
+
+objs/%.o: src_patched/%.cpp | objs_dir
+	@echo "[W18-1] CXX $<"
+	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+objs_dir:
+	@mkdir -p objs
+
+# Per-check driver builds. Each cross-check ships a single
+# drivers/NAME_driver.cpp; the rule links it against the legacy .o set.
+drivers: $(DRIVER_BINS)
+
+drivers/%: drivers/%.cpp objs
+	@echo "[W18-1] LD $@"
+	@$(CXX) $(CXXFLAGS) $(INCLUDES) $< $(OBJS) -o $@
+
+clean:
+	@echo "[W18-1] cleaning build artifacts (keeping eigen download)..."
+	@rm -rf objs/ src_patched/ headers_patched/
+	@rm -f drivers/*_driver
+	@rm -f drivers/*.o
+
+distclean: clean
+	@rm -rf $(EIGEN_DIR) $(EIGEN_DIR).tar.gz

--- a/legacy-cpp/build/README-BUILD-ADAPTER.md
+++ b/legacy-cpp/build/README-BUILD-ADAPTER.md
@@ -1,0 +1,131 @@
+# legacy-cpp/build — W18-1 build adapter
+
+This directory provides a reproducible build of the frozen C++ legacy
+implementation (`legacy-cpp/source/` + `legacy-cpp/headers/`) on a
+modern toolchain (Apple silicon, Apple clang 17, C++14, Eigen 3.4).
+
+The C++ source is read-only — we never modify `legacy-cpp/source/` or
+`legacy-cpp/headers/` directly. Instead, this Makefile creates a
+patched copy in `src_patched/` and `headers_patched/` and applies
+four PURELY MECHANICAL build adapters before compilation.
+
+## Operator caveat (verbatim)
+
+> "There is the possibility of the C++ reference implementation also
+>  being wrong, so do not merely treat it as the oracle."
+
+The build adapters below are documented mechanical patches required
+ONLY for the modern toolchain to ingest 2013-era code. None of them
+changes algorithm semantics. The cross-validation harness (W18-2..)
+applies mutual-skepticism comparison — both sides report; neither is
+privileged.
+
+## The four build adapters
+
+### 1. Eigen include path
+
+| Legacy | Adapter |
+|---|---|
+| `#include <Eigen/Eigen/Dense>` | `#include <Eigen/Dense>` |
+
+The legacy code vendored Eigen at a non-standard path (`Eigen/Eigen/Dense`
+inside the vendored copy). Modern Eigen installs expose `Eigen/Dense`
+at the standard top-level include.
+
+Sed pattern: `s|<Eigen/Eigen/|<Eigen/|g`
+
+### 2. Double → unsigned int narrowing
+
+| Legacy | Adapter |
+|---|---|
+| `mat(t - (tr_period - 2.0*portfolio::window_size), i)` | `mat(t - (tr_period - 2u*portfolio::window_size), i)` |
+
+Eigen 3.4 (with C++14) refuses implicit `double → Index` conversions
+for matrix-element accessors. The legacy code uses `2.0 *
+portfolio::window_size` (double) as a matrix index in 17 sites; the
+adapter changes the constant to `2u` (unsigned int) so the resulting
+expression matches Eigen's `Index` type.
+
+Sed pattern: `s|2\.0\*portfolio::window_size|2u*portfolio::window_size|g`
+
+### 3. `-std=c++14` (NOT c++17)
+
+The legacy code uses `std::random_shuffle` which was deprecated in
+C++14 and **removed** in C++17. We compile with `-std=c++14` to
+preserve the symbol. If a future port wants C++17, the call sites
+need to migrate to `std::shuffle` with an explicit RNG.
+
+Sed pattern: none (compiler flag only).
+
+### 4. `-DEIGEN_DONT_VECTORIZE`
+
+Apple silicon (M-series) NEON vectorization in Eigen 3.4 has known
+edge cases. Disabling vectorization gives stable, predictable
+floating-point output across runs — critical for cross-validation
+parity (any vectorization-driven reordering would muddy comparisons
+even when the algorithm is identical).
+
+If a future investigation needs vectorized C++ output for speed,
+remove this flag and document any resulting parity drift.
+
+## Build
+
+```bash
+cd legacy-cpp/build
+
+# One-time: download Eigen 3.4.0 (≈ 2 MB tarball; cached)
+make eigen
+
+# Apply build adapters to source + headers (idempotent)
+make patches
+
+# Compile all 10 source files to objs/*.o
+make objs
+
+# Build per-check cross-validation drivers (W18-2+)
+make drivers
+```
+
+## Build receipt (2026-05-17, Apple M-series + clang 17)
+
+Verified: all 10 source files compile to .o:
+
+```
+aprendizado_operadores.o  kalman_filter.o      mvtnorm.o
+nsga2.o                   operadores_cruzamento.o  operadores_mutacao.o
+operadores_selecao.o      portfolio.o          statistics.o
+utils.o
+```
+
+## Adding a new cross-check driver
+
+Per the W18-1 driver pattern, each cross-check ships:
+
+```
+legacy-cpp/build/drivers/<check>_driver.cpp      # C++ harness
+python_refactor/scripts/cross_validation/run_<check>.py  # Python harness
+python_refactor/scripts/cross_validation/<check>_fixture.csv  # Shared input
+docs/CROSS-VALIDATION-<CHECK>.md                  # Receipt
+```
+
+The C++ driver:
+1. Reads input fixture from stdin (CSV)
+2. Constructs the relevant data structures (portfolio, KF state, etc.)
+3. Calls the function under test (e.g., `portfolio::compute_risk`)
+4. Emits the result to stdout as CSV with stable header
+
+The Python driver mirrors this exactly so the comparison framework
+can diff the two CSV outputs.
+
+## Cross-platform notes
+
+This Makefile is tested on:
+- **macOS 14+ (Apple silicon)** with Apple clang 17 + Eigen 3.4 + Boost (via Homebrew)
+
+For other platforms (Linux, x86_64, etc.) the includes may differ:
+- Linux: replace `BOOST_INC = /opt/homebrew/include` with `/usr/include`
+- Older gcc: may not need `-DEIGEN_DONT_VECTORIZE`
+
+The build is deliberately stripped-down — no CMake, no autoconf —
+because the adapter is a single-shot bring-up tool for cross-validation,
+not a long-lived build system. Frozen C++ stays frozen.

--- a/python_refactor/scripts/cross_validation/__init__.py
+++ b/python_refactor/scripts/cross_validation/__init__.py
@@ -1,0 +1,31 @@
+"""
+W18-1 cross-validation framework.
+
+Mutual-skepticism comparison: same input fixture fed to BOTH the C++
+legacy reference (compiled via legacy-cpp/build/Makefile) and the
+Python port; outputs compared with abs+rel tolerance + scale ratio.
+
+Per operator directive: "There is the possibility of the C++ reference
+implementation also being wrong, so do not merely treat it as the
+oracle." → comparison flags ANY discrepancy without privileging either
+side.
+
+Per-check usage pattern:
+
+1. Generate fixture (deterministic given seed):
+       from scripts.cross_validation.fixtures import build_risk_fixture
+       fixture_csv = build_risk_fixture(seed=42)
+
+2. Run C++ driver:
+       legacy-cpp/build/drivers/risk_driver < fixture.csv > cpp_out.csv
+
+3. Run Python equivalent:
+       python -m scripts.cross_validation.run_risk < fixture.csv > py_out.csv
+
+4. Compare:
+       from scripts.cross_validation.compare import compare_csvs
+       report = compare_csvs(cpp_path, py_path, atol=1e-9, rtol=1e-9)
+
+The output `report` is a structured dict + markdown receipt suitable
+for the docs/CROSS-VALIDATION-<CHECK>.md format.
+"""

--- a/python_refactor/scripts/cross_validation/compare.py
+++ b/python_refactor/scripts/cross_validation/compare.py
@@ -1,0 +1,196 @@
+"""
+W18-1 cross-validation: comparison framework.
+
+Per operator directive: "There is the possibility of the C++ reference
+implementation also being wrong, so do not merely treat it as the
+oracle." → comparison flags ANY discrepancy without privileging either
+side.
+
+Usage:
+    report = compare_csvs(cpp_path, py_path, atol=1e-9, rtol=1e-9)
+    # report is dict with:
+    #   verdict: AGREE | DISAGREE
+    #   n_compared: int
+    #   per_column: {col: {abs_max, rel_max, n_violations, scale_ratio}}
+    #   markdown: str (suitable for docs/CROSS-VALIDATION-<CHECK>.md)
+"""
+from __future__ import annotations
+
+import csv
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+def compare_csvs(
+    cpp_path: Path | str,
+    py_path: Path | str,
+    *,
+    atol: float = 1e-9,
+    rtol: float = 1e-9,
+    columns: list[str] | None = None,
+    label_cpp: str = "C++ legacy",
+    label_py: str = "Python port",
+) -> dict[str, Any]:
+    """Compare two cross-validation CSVs.
+
+    Args:
+        cpp_path: C++ driver output CSV
+        py_path: Python driver output CSV
+        atol: absolute tolerance for `np.isclose`
+        rtol: relative tolerance
+        columns: optional explicit column list (else compare all
+            numeric columns that exist in BOTH files)
+        label_cpp: label for the C++ side in the report
+        label_py: label for the Python side in the report
+
+    Returns:
+        Structured report dict + markdown receipt
+    """
+    cpp_df = pd.read_csv(cpp_path)
+    py_df = pd.read_csv(py_path)
+
+    if columns is None:
+        cpp_numeric = set(cpp_df.select_dtypes(include=[np.number]).columns)
+        py_numeric = set(py_df.select_dtypes(include=[np.number]).columns)
+        columns = sorted(cpp_numeric & py_numeric)
+
+    if len(cpp_df) != len(py_df):
+        return _emit_report(
+            verdict="DISAGREE",
+            mismatch_reason=(
+                f"row count differs: {label_cpp} has {len(cpp_df)} rows, "
+                f"{label_py} has {len(py_df)} rows"
+            ),
+            atol=atol, rtol=rtol, columns=columns,
+            label_cpp=label_cpp, label_py=label_py,
+            cpp_df=cpp_df, py_df=py_df,
+        )
+
+    per_column: dict[str, dict[str, float]] = {}
+    any_violation = False
+    for col in columns:
+        cpp_v = cpp_df[col].to_numpy(dtype=float)
+        py_v = py_df[col].to_numpy(dtype=float)
+        abs_diff = np.abs(cpp_v - py_v)
+        # Avoid divide-by-zero in rel-diff
+        denom = np.maximum(np.abs(cpp_v), np.abs(py_v))
+        denom = np.where(denom == 0, 1.0, denom)
+        rel_diff = abs_diff / denom
+
+        violations = ~np.isclose(cpp_v, py_v, atol=atol, rtol=rtol, equal_nan=True)
+        n_viol = int(violations.sum())
+        if n_viol > 0:
+            any_violation = True
+
+        cpp_nonzero_mean = np.mean(np.abs(cpp_v[np.abs(cpp_v) > 1e-30])) if np.any(np.abs(cpp_v) > 1e-30) else 0.0
+        py_nonzero_mean = np.mean(np.abs(py_v[np.abs(py_v) > 1e-30])) if np.any(np.abs(py_v) > 1e-30) else 0.0
+        scale_ratio = (cpp_nonzero_mean / py_nonzero_mean) if py_nonzero_mean > 0 else float("nan")
+
+        per_column[col] = {
+            "abs_max": float(np.max(abs_diff)),
+            "rel_max": float(np.max(rel_diff)),
+            "n_violations": n_viol,
+            "scale_ratio_cpp_over_py": float(scale_ratio),
+            "cpp_mean_abs": float(cpp_nonzero_mean),
+            "py_mean_abs": float(py_nonzero_mean),
+        }
+
+    verdict = "DISAGREE" if any_violation else "AGREE"
+    return _emit_report(
+        verdict=verdict,
+        mismatch_reason=None,
+        atol=atol, rtol=rtol, columns=columns,
+        label_cpp=label_cpp, label_py=label_py,
+        cpp_df=cpp_df, py_df=py_df,
+        per_column=per_column,
+    )
+
+
+def _emit_report(
+    verdict: str,
+    mismatch_reason: str | None,
+    atol: float, rtol: float, columns: list[str],
+    label_cpp: str, label_py: str,
+    cpp_df: pd.DataFrame, py_df: pd.DataFrame,
+    per_column: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Emit a structured report + markdown."""
+    md_lines = []
+    md_lines.append(f"# Cross-validation comparison — {label_cpp} vs {label_py}")
+    md_lines.append("")
+    md_lines.append(f"**Verdict**: `{verdict}`")
+    md_lines.append("")
+    md_lines.append(f"- Tolerance: `atol={atol:g}`, `rtol={rtol:g}`")
+    md_lines.append(f"- Rows: `{label_cpp}` = {len(cpp_df)}, `{label_py}` = {len(py_df)}")
+    md_lines.append(f"- Columns compared: {len(columns)}")
+    md_lines.append("")
+
+    if mismatch_reason is not None:
+        md_lines.append(f"## Structural mismatch")
+        md_lines.append("")
+        md_lines.append(f"{mismatch_reason}")
+        md_lines.append("")
+        return {
+            "verdict": verdict,
+            "n_compared": 0,
+            "per_column": {},
+            "markdown": "\n".join(md_lines),
+        }
+
+    if per_column is None:
+        per_column = {}
+    md_lines.append("## Per-column results")
+    md_lines.append("")
+    md_lines.append(
+        "| Column | abs_max | rel_max | n_violations | "
+        f"scale_ratio ({label_cpp}/{label_py}) | "
+        f"{label_cpp} mean(|x|) | {label_py} mean(|x|) |"
+    )
+    md_lines.append("|---|---|---|---|---|---|---|")
+    for col, stats in per_column.items():
+        md_lines.append(
+            f"| `{col}` | {stats['abs_max']:.3g} | {stats['rel_max']:.3g} | "
+            f"{stats['n_violations']} | "
+            f"{stats['scale_ratio_cpp_over_py']:.4f} | "
+            f"{stats['cpp_mean_abs']:.3g} | {stats['py_mean_abs']:.3g} |"
+        )
+    md_lines.append("")
+
+    md_lines.append("## Mutual-skepticism reporting")
+    md_lines.append("")
+    md_lines.append(
+        "Per W18 directive, neither side is treated as oracle. "
+        "Discrepancies are flagged; resolution (which side is correct) "
+        "must reference the thesis equation cross-cited in the unit "
+        "contract's BACKLOG §6 grounding section."
+    )
+
+    return {
+        "verdict": verdict,
+        "n_compared": len(cpp_df),
+        "per_column": per_column,
+        "markdown": "\n".join(md_lines),
+    }
+
+
+if __name__ == "__main__":
+    import argparse, sys
+    parser = argparse.ArgumentParser(description="W18 cross-validation comparison")
+    parser.add_argument("cpp_path", help="C++ driver output CSV")
+    parser.add_argument("py_path", help="Python driver output CSV")
+    parser.add_argument("--atol", type=float, default=1e-9)
+    parser.add_argument("--rtol", type=float, default=1e-9)
+    parser.add_argument("--output", help="Markdown report output path (default stdout)")
+    args = parser.parse_args()
+
+    report = compare_csvs(args.cpp_path, args.py_path,
+                            atol=args.atol, rtol=args.rtol)
+    if args.output:
+        Path(args.output).write_text(report["markdown"])
+    else:
+        sys.stdout.write(report["markdown"] + "\n")
+    sys.exit(0 if report["verdict"] == "AGREE" else 1)

--- a/python_refactor/scripts/cross_validation/fixtures.py
+++ b/python_refactor/scripts/cross_validation/fixtures.py
@@ -1,0 +1,90 @@
+"""
+W18-1 cross-validation fixtures — deterministic input generators.
+
+Each fixture is fully specified by (seed, params) and reproducible.
+Output format is plain CSV with stable header so the C++ driver and
+the Python driver consume identical data.
+"""
+from __future__ import annotations
+
+import csv
+from io import StringIO
+from pathlib import Path
+
+import numpy as np
+
+
+def build_risk_fixture(
+    n_portfolios: int = 20,
+    n_assets: int = 87,
+    n_days: int = 50,
+    seed: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """W18-2 fixture: portfolios + returns matrix.
+
+    Returns (portfolios, returns) where:
+      portfolios: shape (n_portfolios, n_assets), rows sum to 1
+      returns:    shape (n_days, n_assets), daily returns ~ N(0.001, 0.01)
+
+    The portfolios are random non-negative rows normalized to unit sum
+    (Simplex points), the returns simulate small-cap daily returns
+    with mean 0.1% and std 1%.
+    """
+    rng = np.random.default_rng(seed)
+    portfolios = rng.dirichlet(np.ones(n_assets), size=n_portfolios)
+    returns = rng.normal(loc=0.001, scale=0.01, size=(n_days, n_assets))
+    return portfolios, returns
+
+
+def serialize_risk_fixture(portfolios: np.ndarray, returns: np.ndarray) -> str:
+    """Serialize fixture to CSV with header schema:
+    HEADER: n_portfolios,n_assets,n_days
+    PORTFOLIOS: one row per portfolio (n_assets cols)
+    RETURNS: one row per day (n_assets cols)
+    Sections separated by ###PORTFOLIOS / ###RETURNS markers.
+    """
+    out = StringIO()
+    n_p, n_a = portfolios.shape
+    n_d = returns.shape[0]
+    out.write(f"###META\n{n_p},{n_a},{n_d}\n")
+    out.write("###PORTFOLIOS\n")
+    np.savetxt(out, portfolios, delimiter=",", fmt="%.17g")
+    out.write("###RETURNS\n")
+    np.savetxt(out, returns, delimiter=",", fmt="%.17g")
+    return out.getvalue()
+
+
+def deserialize_risk_fixture(csv_text: str) -> tuple[np.ndarray, np.ndarray]:
+    """Inverse of serialize_risk_fixture."""
+    lines = csv_text.splitlines()
+    # Find section markers
+    i_meta = lines.index("###META")
+    n_p, n_a, n_d = (int(x) for x in lines[i_meta + 1].split(","))
+    i_port = lines.index("###PORTFOLIOS")
+    i_ret = lines.index("###RETURNS")
+    port_block = "\n".join(lines[i_port + 1 : i_ret])
+    ret_block = "\n".join(lines[i_ret + 1 :])
+    portfolios = np.loadtxt(StringIO(port_block), delimiter=",")
+    returns = np.loadtxt(StringIO(ret_block), delimiter=",")
+    if portfolios.ndim == 1:
+        portfolios = portfolios.reshape(1, -1)
+    if returns.ndim == 1:
+        returns = returns.reshape(1, -1)
+    return portfolios, returns
+
+
+def write_risk_fixture_to(path: Path | str, **kwargs) -> Path:
+    """Convenience: build + serialize + write fixture to path."""
+    portfolios, returns = build_risk_fixture(**kwargs)
+    csv_text = serialize_risk_fixture(portfolios, returns)
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(csv_text)
+    return p
+
+
+if __name__ == "__main__":
+    # CLI: emit a default fixture to stdout
+    import sys
+    portfolios, returns = build_risk_fixture()
+    sys.stdout.write(serialize_risk_fixture(portfolios, returns))

--- a/python_refactor/tests/test_cross_validation_harness.py
+++ b/python_refactor/tests/test_cross_validation_harness.py
@@ -1,0 +1,150 @@
+"""
+W18-1 cross-validation harness regression tests.
+
+Tests the harness itself (fixtures + comparison framework), NOT any
+specific cross-check. The cross-checks (A risk, B ROI, F TIP, ...)
+get their own test files.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import via the scripts package
+import sys
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.cross_validation.fixtures import (
+    build_risk_fixture,
+    serialize_risk_fixture,
+    deserialize_risk_fixture,
+)
+from scripts.cross_validation.compare import compare_csvs
+
+
+class TestFixtureDeterminism:
+    """Same seed → same fixture."""
+
+    def test_same_seed_same_fixture(self):
+        p1, r1 = build_risk_fixture(seed=42)
+        p2, r2 = build_risk_fixture(seed=42)
+        np.testing.assert_array_equal(p1, p2)
+        np.testing.assert_array_equal(r1, r2)
+
+    def test_different_seeds_differ(self):
+        p1, _ = build_risk_fixture(seed=1)
+        p2, _ = build_risk_fixture(seed=2)
+        assert not np.array_equal(p1, p2)
+
+    def test_portfolios_on_simplex(self):
+        """Each portfolio row sums to ~1 (Dirichlet draw)."""
+        portfolios, _ = build_risk_fixture(seed=42, n_portfolios=5, n_assets=10)
+        sums = portfolios.sum(axis=1)
+        np.testing.assert_allclose(sums, np.ones(5), atol=1e-12)
+        assert np.all(portfolios >= 0.0)
+
+
+class TestSerializationRoundtrip:
+    """serialize → deserialize is identity."""
+
+    def test_roundtrip(self):
+        portfolios, returns = build_risk_fixture(seed=42, n_portfolios=3,
+                                                    n_assets=5, n_days=10)
+        text = serialize_risk_fixture(portfolios, returns)
+        p2, r2 = deserialize_risk_fixture(text)
+        np.testing.assert_allclose(portfolios, p2, atol=1e-15)
+        np.testing.assert_allclose(returns, r2, atol=1e-15)
+
+
+class TestCompareFramework:
+    """compare_csvs flags violations vs accepts identical inputs."""
+
+    def test_identical_csvs_agree(self, tmp_path: Path):
+        df = pd.DataFrame({"portfolio_idx": [0, 1, 2],
+                            "risk": [0.01, 0.02, 0.03]})
+        cpp_path = tmp_path / "cpp.csv"
+        py_path = tmp_path / "py.csv"
+        df.to_csv(cpp_path, index=False)
+        df.to_csv(py_path, index=False)
+
+        report = compare_csvs(cpp_path, py_path, atol=1e-12)
+        assert report["verdict"] == "AGREE"
+        assert report["n_compared"] == 3
+        assert report["per_column"]["risk"]["n_violations"] == 0
+
+    def test_diverging_csvs_disagree(self, tmp_path: Path):
+        cpp_df = pd.DataFrame({"portfolio_idx": [0, 1],
+                                "risk": [0.01, 0.02]})
+        py_df = pd.DataFrame({"portfolio_idx": [0, 1],
+                                "risk": [0.01, 0.025]})  # diverges row 1
+        cpp_path = tmp_path / "cpp.csv"
+        py_path = tmp_path / "py.csv"
+        cpp_df.to_csv(cpp_path, index=False)
+        py_df.to_csv(py_path, index=False)
+
+        report = compare_csvs(cpp_path, py_path, atol=1e-9)
+        assert report["verdict"] == "DISAGREE"
+        assert report["per_column"]["risk"]["n_violations"] == 1
+        assert report["per_column"]["risk"]["abs_max"] == pytest.approx(0.005)
+
+    def test_row_count_mismatch_flagged(self, tmp_path: Path):
+        cpp_df = pd.DataFrame({"risk": [0.01, 0.02]})
+        py_df = pd.DataFrame({"risk": [0.01, 0.02, 0.03]})
+        cpp_path = tmp_path / "cpp.csv"
+        py_path = tmp_path / "py.csv"
+        cpp_df.to_csv(cpp_path, index=False)
+        py_df.to_csv(py_path, index=False)
+
+        report = compare_csvs(cpp_path, py_path)
+        assert report["verdict"] == "DISAGREE"
+        assert "row count differs" in report["markdown"]
+
+    def test_scale_ratio_detected(self, tmp_path: Path):
+        """1000x scale difference shows in scale_ratio."""
+        cpp_df = pd.DataFrame({"risk": [0.001, 0.002, 0.003]})
+        py_df = pd.DataFrame({"risk": [1.0, 2.0, 3.0]})  # 1000x bigger
+        cpp_path = tmp_path / "cpp.csv"
+        py_path = tmp_path / "py.csv"
+        cpp_df.to_csv(cpp_path, index=False)
+        py_df.to_csv(py_path, index=False)
+
+        report = compare_csvs(cpp_path, py_path, atol=1e-9)
+        assert report["verdict"] == "DISAGREE"
+        scale = report["per_column"]["risk"]["scale_ratio_cpp_over_py"]
+        assert 0.0005 < scale < 0.0015  # ≈ 1/1000
+
+    def test_markdown_contains_mutual_skepticism_note(self, tmp_path: Path):
+        df = pd.DataFrame({"risk": [0.01]})
+        cpp_path = tmp_path / "cpp.csv"
+        py_path = tmp_path / "py.csv"
+        df.to_csv(cpp_path, index=False)
+        df.to_csv(py_path, index=False)
+        report = compare_csvs(cpp_path, py_path)
+        assert "Mutual-skepticism" in report["markdown"]
+        assert "neither side is treated as oracle" in report["markdown"]
+
+
+class TestCPPBuildPrerequisite:
+    """W18-1 prerequisite: C++ legacy must build (objs exist)."""
+
+    def test_cpp_objs_exist(self):
+        objs_dir = Path(__file__).resolve().parents[2] / "legacy-cpp" / "build" / "objs"
+        if not objs_dir.exists():
+            pytest.skip(
+                "C++ build not yet run; cd legacy-cpp/build && make objs"
+            )
+        expected = {
+            "aprendizado_operadores.o", "kalman_filter.o", "mvtnorm.o",
+            "nsga2.o", "operadores_cruzamento.o", "operadores_mutacao.o",
+            "operadores_selecao.o", "portfolio.o", "statistics.o", "utils.o",
+        }
+        actual = {p.name for p in objs_dir.glob("*.o")}
+        assert expected.issubset(actual), (
+            f"Missing C++ objects: {expected - actual}. "
+            "Run `cd legacy-cpp/build && make objs`."
+        )


### PR DESCRIPTION
## Summary

Closes W18 prerequisite for the 14 cross-checks (A-N) per operator directive. Ships C++ build adapter (4 mechanical patches, no algorithm changes) + Python comparison framework + 10 regression tests.

## ⚠ FIRST C++ bug surfaced by the harness

While compiling, observed C++ warning in \`portfolio.cpp:65\`:
\`\`\`
var += (v(i) - average, 2.0)*(v(i) - average, 2.0);
\`\`\`

This uses the C++ comma operator: \`(v(i) - average, 2.0)\` evaluates left side, discards it, returns 2.0. So \`var += 2.0 * 2.0 = 4.0\` per element — NOT the squared deviation the author intended (which would be \`std::pow(v(i) - average, 2.0)\`).

Location: \`portfolio::sample_autocorrelation\` (not the headline ASMS/SMS path), so it likely doesn't affect Δ(S2 − S0). **But it validates the operator's caveat**: "the C++ reference implementation also being wrong" must be assumed possible.

## C++ build adapter (legacy-cpp/build/Makefile)

4 mechanical patches for 2013-era code on 2026 Apple silicon:

| # | Adapter | Reason |
|---|---|---|
| 1 | \`<Eigen/Eigen/Dense>\` → \`<Eigen/Dense>\` | Modern Eigen install path |
| 2 | \`2.0*portfolio::window_size\` → \`2u*portfolio::window_size\` | Eigen 3.4 disallows double→Index narrowing |
| 3 | \`-std=c++14\` | Legacy uses std::random_shuffle (removed in C++17) |
| 4 | \`-DEIGEN_DONT_VECTORIZE\` | Apple silicon stability |

Patches applied in \`src_patched/\` + \`headers_patched/\`; original \`legacy-cpp/source\` + \`legacy-cpp/headers\` REMAIN read-only.

Receipt: all 10 source files compile to .o.

## Python compare framework

- \`scripts/cross_validation/fixtures.py\`: deterministic Dirichlet portfolios + Gaussian returns; serialize/deserialize
- \`scripts/cross_validation/compare.py\`: column-wise abs+rel tolerance with scale-ratio diagnostic; mutual-skepticism markdown report
- CLI: \`python -m scripts.cross_validation.compare cpp.csv py.csv --atol 1e-9\`

## Tests (10 shipped, all green)

- Fixture determinism (3)
- Roundtrip serialization (1)
- Compare framework: identical→AGREE; diverging→DISAGREE; row-count mismatch flagged; scale ratio detected; mutual-skepticism note (5)
- C++ build prerequisite (1, skips gracefully if not built)

## What W18-2/3/4 inherit

Per-check pattern:
\`\`\`
legacy-cpp/build/drivers/<check>_driver.cpp   # C++ harness binary
python_refactor/scripts/cross_validation/run_<check>.py
fixture (shared CSV input)
docs/CROSS-VALIDATION-<CHECK>.md  # receipt
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)