### PR TITLE
substrate: import 2015 ASMOO C++ paper-companion (legacy-cpp-v2/) — corrects W18 oracle

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -39,6 +39,8 @@ canonical template in §6.
 
 - **TH** = Azevedo PhD thesis (`docs/Azevedo_CarlosRenatoBelo_D.pdf`). Page numbers refer to printed thesis pagination (PDF page = printed + 20 frontmatter offset).
 - **PAP** = Azevedo & Von Zuben IEEE TCYB 2015 paper (`docs/paper.pdf`).
+- **CPP2** = 2015-era paper-companion C++ reference at `legacy-cpp-v2/` (GitHub `crbazevedo/anticipatory-learning-asmoo` @ `6643c92`). **Cross-validation oracle for the Python port.** Has `dirichlet.cpp`, `asms_emoa.cpp`, English filenames. Use this for any CPP cross-reference.
+- **CPP1** = 2013-era thesis-companion C++ at `legacy-cpp/`. Historical provenance only — pre-dates the post-thesis refinement that added Dirichlet + ASMS-EMOA naming. **NOT a cross-validation oracle.**
 - **REF** = third-party reference (cited via thesis bibliography pp. 198+).
 - **STD** = standard implementation pattern (no direct paper grounding; cite community practice).
 

--- a/docs/THESIS-INDEX.md
+++ b/docs/THESIS-INDEX.md
@@ -27,6 +27,21 @@ condenses chapters 5–7 of this thesis. **When the two disagree, the
 thesis wins** — it has the unabridged derivations and the explicit
 experimental protocol.
 
+**Companion C++ codebases (added 2026-05-17 during W18 substrate update).**
+TWO C++ implementations are vendored:
+
+| Path | Era | Status |
+|---|---|---|
+| `../legacy-cpp/` | 2013, thesis-companion (pre-paper) | Historical provenance only; **NOT cross-validation oracle** |
+| `../legacy-cpp-v2/` | 2015, paper-companion release (GitHub `crbazevedo/anticipatory-learning-asmoo` @ `6643c92`) | **Cross-validation oracle for the Python port** |
+
+The Python port (`../python_refactor/`) was built against the 2015 v2
+code, which adds the explicit `dirichlet.cpp` module that the 2013
+version lacks. W18 cross-validation work initially used `legacy-cpp/`
+and surfaced false-positive structural divergences; PR (W18-substrate-import)
+imported `legacy-cpp-v2/` as the correct reference. See
+`../legacy-cpp-v2/README.md` for the full diff.
+
 ---
 
 ## §1 Authoritative chapter map (for codebase work)

--- a/legacy-cpp-v2/LICENSE
+++ b/legacy-cpp-v2/LICENSE
@@ -1,0 +1,340 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {description}
+    Copyright (C) {year}  {fullname}
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/legacy-cpp-v2/README.md
+++ b/legacy-cpp-v2/README.md
@@ -1,0 +1,87 @@
+# legacy-cpp-v2 — the 2015-era ASMOO C++ reference
+
+This directory preserves the **2015-era** C++ implementation that
+accompanies the IEEE TCYB 2015 paper. It is the **authoritative
+upstream reference** for the Python port (`../python_refactor/`).
+
+## Provenance
+
+- **Source**: `Downloads/crbazevedo-anticipatory-learning-asmoo-6643c92`
+  (GitHub repo `crbazevedo/anticipatory-learning-asmoo`, commit `6643c92`)
+- **Dated**: 10 March 2015 (file mtimes); ASMOO post-thesis revision
+- **License**: GPL (see `LICENSE`)
+- **Upstream README**: see `UPSTREAM-README.md`
+
+## Why this is the authoritative reference (not `../legacy-cpp/`)
+
+The repo previously vendored only `legacy-cpp/` — a 2013-era thesis-companion
+codebase. Cross-validation work in W18 / W19 (PRs #105-#112) initially
+treated `legacy-cpp/` as the oracle but found apparent structural divergences
+(missing Dirichlet module, old `nsga2.cpp` naming, etc.). The operator then
+flagged that the **post-thesis 2015 release** at the path above is the
+correct reference, and the Python port was built against it.
+
+Both versions are kept:
+
+| Tree | Era | Use |
+|---|---|---|
+| `legacy-cpp/` | 2013 (thesis-companion, pre-paper) | Historical provenance; do NOT use as oracle |
+| `legacy-cpp-v2/` (this) | 2015 (paper-companion, with Dirichlet) | **Cross-validation oracle for the Python port** |
+
+## What v2 adds vs v1
+
+1. **`dirichlet.cpp` + `dirichlet.h`** — explicit Dirichlet prediction module
+   that Python's `DirichletPredictor` mirrors (`dirichlet_mean_prediction_vec`,
+   `dirichlet_mean_map_update`, `dirichlet_variance`).
+2. **`asms_emoa.cpp`** (replaces `nsga2.cpp`) — refined algorithm with
+   ASMS-EMOA-specific orchestration.
+3. **English filenames** — `learning_operators` (was `aprendizado_operadores`),
+   `mutation_operators` (`operadores_mutacao`), `selection_operators`
+   (`operadores_selecao`), `crossover_operators` (`operadores_cruzamento`).
+4. **KF lifecycle reversed** — v2's `Kalman_filter()` calls
+   `Kalman_update()` BEFORE `Kalman_prediction()` (v1 had predict→update).
+   Also `Kalman_params` now exposes `error` (running residual norm)
+   and `window_size` (for the K-period λ^K consumption).
+5. **Portfolio refinement** — `samples_per_portfolio`, `current_period`,
+   `periodicity`, `brokerage_commission`, `sequence_mean_covar` —
+   structural support for paper §7 protocol.
+6. **`alpha = 1 - non_dominance_probability(w)`** (no `linear_entropy()`
+   wrap; v1 had `alpha = 1 - linear_entropy(nd_probability)`) — different
+   anticipative-rate formula.
+7. **`compute_efficiency` invokes `observe_state` (KF integration)** —
+   tighter coupling between portfolio evaluation and KF state tracking.
+
+## Layout
+
+```
+legacy-cpp-v2/
+├── source/                    11 .cpp files (3,350 LOC total)
+├── headers/                   11 .h files
+├── LICENSE                    GPL upstream
+├── UPSTREAM-README.md         Original repo README
+└── README.md                  THIS file
+```
+
+## Building
+
+W18-1's `legacy-cpp/build/Makefile` was written against `legacy-cpp/`
+sources. A `legacy-cpp-v2/build/` Makefile is planned for the
+post-substrate-update cross-checks (subsequent units after the import).
+
+## Cross-validation impact (re-assessment pending)
+
+After this substrate import, all prior cross-checks must be re-run
+against v2:
+
+| Check | W18/W19 verdict (vs v1) | Re-assessment needed |
+|---|---|---|
+| A risk (W18-2) | DISAGREE-PYTHON-WRONG (Python adds sqrt) | v2 also has `u^T Σ u` (no sqrt) — verdict should hold |
+| B ROI (W18-3) | AGREE | should still hold (same formula) |
+| C bivariate (W19-1) | AGREE | should still hold |
+| D KF Gaussians (W19-2) | AGREE | **MAY FLIP** — v2 reverses KF lifecycle (update→predict vs predict→update) |
+| E Dirichlet (W19-3) | (pending) | v2 HAS Dirichlet — full cross-check now possible |
+| F TIP (W18-4) | STRUCTURAL (Reading C) | v2 has same formula; verdict should hold |
+| G λ end-to-end (W19-4) | (pending) | v2 uses `1 - p` (not `1 - entropy(p)`); structural divergence vs Python |
+
+W18 / W19 synthesis docs will be updated with re-assessment receipts
+in subsequent units.

--- a/legacy-cpp-v2/UPSTREAM-README.md
+++ b/legacy-cpp-v2/UPSTREAM-README.md
@@ -1,0 +1,2 @@
+# anticipatory-learning-asmoo
+This repository contains code regarding anticipatory learning methods for online multiobjective optimization and miulti-criteria decision-making in stochastic and changing environments.

--- a/legacy-cpp-v2/headers/asms_emoa.h
+++ b/legacy-cpp-v2/headers/asms_emoa.h
@@ -1,0 +1,275 @@
+#ifndef ASMS_EMOA_H
+	#define ASMS_EMOA_H
+
+#include "portfolio.h"
+
+#include <vector>
+#include <ctime>
+#include <cstdlib>
+#include <string>
+
+typedef struct solution {
+
+	portfolio P;
+	double cd; // Crowding distance
+	double Delta_S; // Hypervolume contribution
+	unsigned int Pareto_front; // Which front belongs (e.g. F0, F1, ...)
+	unsigned int observed_Pareto_front; // Which front belongs in the out-of-sample scenario
+	double stability; // Stability degree
+	unsigned int rank_ROI; // Rank in population in terms of return
+	unsigned int rank_risk; // Rank in population in terms of risk
+	double alpha; // Confidence over prediction
+	double anticipation_rate; // Anticipation rate
+	bool anticipation; // Anticipatory learning step executed?
+	double prediction_error; // Prediction residual of the Kalman filter
+	double pred_hv; // Predicted hypervolume T steps ahead associated with the solution
+	std::pair<double,double> epsilon_feasibility; // Feasibility probability over both objectives
+
+	static double xover_rate, mut_rate, min_error, max_error;
+	static unsigned int tourn_size, num_fronts;
+	static std::vector<double> error_sequence;
+
+	static std::vector<std::vector<solution*> > historical_populations;
+	static std::vector<solution*> historical_anticipative_decisions;
+	static solution* predicted_anticipative_decision;
+
+	static double epsilon;
+	static std::pair<double,double> ref_point;
+
+	static void compute_efficiency(solution *w);
+
+	solution()
+	{
+		P.init();
+
+		cd = 0.0; Pareto_front = 0; observed_Pareto_front = 0; stability = 1.0; rank_ROI = 0.0; rank_risk = 0.0; Delta_S = 0.0;
+		alpha = 0.0; anticipation = false; prediction_error = 0.0; epsilon_feasibility = std::pair<double,double>(0.0,0.0);
+
+		compute_efficiency(this);
+
+	}
+
+	solution(solution *sol)
+	{
+
+		P = portfolio(sol->P);
+		cd = sol->cd; Pareto_front = observed_Pareto_front = sol->Pareto_front; stability = sol->stability; rank_ROI = sol->rank_ROI; rank_risk = sol->rank_risk; Delta_S = sol->Delta_S;
+		alpha = sol->alpha; anticipation = sol->anticipation; prediction_error = sol->prediction_error; anticipation_rate = sol->anticipation_rate;
+		epsilon_feasibility = sol->epsilon_feasibility;
+
+		if (P.ROI != P.ROI || P.risk != P.risk)
+		{
+			solution::compute_efficiency(sol);
+		}
+
+	}
+
+	solution(const Eigen::VectorXd investment)
+	{
+		cd = 0.0; Pareto_front = 0; observed_Pareto_front = 0; stability = 1.0; rank_ROI = 0.0; rank_risk = 0.0; Delta_S = 0.0;
+		alpha = 0.0; anticipation = false; prediction_error = 0.0;
+		P.investment = investment;
+		compute_efficiency(this);
+	}
+
+} sol;
+
+static double compute_max_cost()
+{
+	double max_transaction_value = portfolio::current_wealth/(2.0*portfolio::num_assets);
+	std::pair<double,double> fees = portfolio::BOVESPA_fees(max_transaction_value);
+	double cost = max_transaction_value*fees.first + fees.second;
+	return 2.0*cost*portfolio::num_assets;
+}
+
+static double get_max_cost (std::vector<sol*> &pop)
+{
+	double max = 0.0;
+	for (unsigned int i = 0; i < pop.size(); ++i)
+	{
+		std::pair<double,double> cost = portfolio::transaction_cost(portfolio::current_investment, pop[i]->P.investment);
+		if (cost.first > max)
+			max = cost.first;
+	}
+	return max;
+}
+
+static double get_min_cost (std::vector<sol*> &pop)
+{
+	double min = 0.0;
+	for (unsigned int i = 0; i < pop.size(); ++i)
+	{
+		std::pair<double,double> cost = portfolio::transaction_cost(portfolio::current_investment, pop[i]->P.investment);
+		if (cost.first < min)
+			min = cost.first;
+	}
+	return min;
+}
+
+
+
+sol* random_solution(unsigned int H, unsigned int N);
+
+inline bool cmp_cd (sol i, sol j) { return (i.cd>j.cd); }
+inline bool cmp_cd_ptr (sol* i, sol* j) { return (i->cd>j->cd); }
+inline bool cmp_acc_confidence_ptr (sol* i, sol* j)
+{
+	double acc_i = (solution::min_error > 0.0) ? 1.0 - 0.5*(i->prediction_error - solution::min_error)/(solution::max_error - solution::min_error) : 1.0;
+	double acc_j = (solution::min_error > 0.0) ? 1.0 - 0.5*(j->prediction_error - solution::min_error)/(solution::max_error - solution::min_error) : 1.0;
+
+	return acc_i*i->alpha < acc_j*j->alpha;
+}
+
+inline bool cmp_confidence_ptr (sol* i, sol* j){ return i->alpha < j->alpha; }
+inline bool cmp_error_ptr (sol* i, sol* j){ return i->prediction_error > j->prediction_error; }
+
+inline bool cmp_front (sol i, sol j) { return (i.Pareto_front<j.Pareto_front); }
+inline bool cmp_front_ptr (sol* i, sol* j) { return (i->Pareto_front<j->Pareto_front); }
+inline bool cmp_observed_front_ptr (sol* i, sol* j) { return (i->observed_Pareto_front<j->observed_Pareto_front); }
+
+inline bool cmp_ROI (sol i, sol j) { return (i.P.ROI > j.P.ROI); }
+inline bool cmp_ROI_ptr (sol* i, sol* j) { return (i->P.ROI > j->P.ROI); }
+inline bool cmp_ROI_observed_ptr (sol* i, sol* j) { return (i->P.ROI_observed > j->P.ROI_observed); }
+inline bool cmp_ROI_ptr_pair (std::pair<unsigned int,sol*> i, std::pair<unsigned int,sol*> j) { return (i.second->P.ROI > j.second->P.ROI); }
+inline bool cmp_risk (sol i, sol j) { return (i.P.risk < j.P.risk); }
+inline bool cmp_risk_ptr (sol* i, sol* j) { return (i->P.risk < j->P.risk); }
+inline bool cmp_risk_observed_ptr (sol* i, sol* j) { return (i->P.risk_observed < j->P.risk_observed); }
+inline bool cmp_risk_ptr_pair (std::pair<unsigned int,sol*> i, std::pair<unsigned int,sol*> j) { return (i.second->P.risk < j.second->P.risk); }
+
+std::pair<double,double> feasibility_p(sol * x);
+bool epsilon_feasible(sol * x);
+
+// Considera a classe e desempate por CD
+inline bool compare_front_CD (sol i, sol j)
+{
+	return !(i.Pareto_front > j.Pareto_front || (i.Pareto_front == j.Pareto_front && !cmp_cd(i,j)));
+}
+
+inline bool unconstrained_dominance (sol* p, sol* q) 
+{ 
+	if (p->P.ROI < q->P.ROI || p->P.risk > q->P.risk)
+		return false;
+	else if (p->P.ROI > q->P.ROI || p->P.risk < q->P.risk)
+		return true;
+	else 
+		return false;
+}
+
+inline bool Pareto_dominance (std::pair<double,double> p1, std::pair<double,double> p2)
+{
+	if (p1.first < p2.first || p1.second < p2.second)
+		return false;
+	else if (p1.first > p2.first || p1.second > p2.second)
+		return true;
+	else
+		return false;
+}
+
+inline bool constrained_dominance (sol* p, sol* q)
+{
+
+	bool p_feasible = (p->epsilon_feasibility == std::pair<double,double>(0.0,0.0)) ? epsilon_feasible(p) :
+		(p->epsilon_feasibility.first >= solution::epsilon) && (p->epsilon_feasibility.second >= solution::epsilon);
+
+	bool q_feasible = (q->epsilon_feasibility == std::pair<double,double>(0.0,0.0)) ? epsilon_feasible(q) :
+		(q->epsilon_feasibility.first >= solution::epsilon) && (q->epsilon_feasibility.second >= solution::epsilon);
+
+
+	if (p_feasible && !q_feasible)
+		return true;
+	else if (!p_feasible && q_feasible)
+		return false;
+	else if (!p_feasible && !q_feasible)
+		return Pareto_dominance(p->epsilon_feasibility,q->epsilon_feasibility);
+	else
+		return unconstrained_dominance (p,q);
+}
+
+inline bool unconstrained_observed_dominance (sol* p, sol* q)
+{
+	if (p->P.ROI_observed < q->P.ROI_observed || p->P.risk_observed > q->P.risk_observed)
+		return false;
+	else if (p->P.ROI_observed > q->P.ROI_observed || p->P.risk_observed < q->P.risk_observed)
+		return true;
+	else
+		return false;
+}
+
+inline bool constrained_observed_dominance (sol* p, sol* q)
+{
+	bool p_feasible = (p->epsilon_feasibility == std::pair<double,double>(0.0,0.0)) ? epsilon_feasible(p) :
+		(p->epsilon_feasibility.first >= solution::epsilon) && (p->epsilon_feasibility.second >= solution::epsilon);
+	bool q_feasible = (q->epsilon_feasibility == std::pair<double,double>(0.0,0.0)) ? epsilon_feasible(q) :
+		(q->epsilon_feasibility.first >= solution::epsilon) && (q->epsilon_feasibility.second >= solution::epsilon);
+
+	if (p_feasible && !q_feasible)
+		return true;
+	else if (!p_feasible && q_feasible)
+		return false;
+	else if (!p_feasible && !q_feasible)
+		return Pareto_dominance(p->epsilon_feasibility,q->epsilon_feasibility);
+	else
+		return unconstrained_observed_dominance (p,q);
+}
+
+inline bool stochastic_dominance (sol* p, sol* q)
+{
+	if (!unconstrained_dominance(p,q))
+			return false;
+
+	Eigen::MatrixXd Sigma_diff = (q->P.kalman_state.P - p->P.kalman_state.P);
+	Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(Sigma_diff);
+	if (eigensolver.info() != Eigen::Success) abort();
+	return (eigensolver.eigenvectors().sum() > 0); // TODO
+}
+
+inline bool card_constrained_dominance (sol* p, sol* q)
+{
+	if (p->P.cardinality > portfolio::max_cardinality
+			&& q->P.cardinality <= portfolio::max_cardinality)
+		return false;
+	else if (p->P.cardinality <= portfolio::max_cardinality
+			&& q->P.cardinality > portfolio::max_cardinality)
+		return true;
+	else if (p->P.cardinality > portfolio::max_cardinality
+			&& p->P.cardinality > portfolio::max_cardinality)
+		return (p->P.cardinality < q->P.cardinality);
+
+	if (p->P.ROI < q->P.ROI || p->P.risk > q->P.risk)
+		return false;
+	else if (p->P.ROI > q->P.ROI || p->P.risk < q->P.risk)
+		return true;
+	else
+		return false;
+}
+
+void ordena_objetivo(std::vector<sol>& P, int m);
+void crowding_distance(std::vector<sol*>& P, unsigned int classe);
+unsigned int fast_nondominated_sort(std::vector<sol*>& P);
+unsigned int observed_fast_nondominated_sort(std::vector<sol*> &P);
+
+void compute_stochastic_Delta_S(std::vector<sol*> &P, unsigned int num_classes, float R_1, float R_2);
+void compute_stochastic_Delta_S_class(std::vector<sol*> &minha_classe, float R_1, float R_2);
+void compute_Delta_S(std::vector<sol*> &P, unsigned int num_classes, float R_1, float R_2);
+void compute_Delta_S_class(std::vector<sol*> &minha_classe, float R_1, float R_2);
+
+void remove_worst_s_metric(std::vector<sol*> &P, double total_error, unsigned int class_index, float R_1, float R_2);
+
+void apply_mutation(sol* w);
+
+std::pair<double,double> anticipatory_learning_obj_space(std::vector<sol*> &P, unsigned int t);
+void anticipatory_learning_obj_space(sol* &w, sol* anticipative_portfolio, Eigen::VectorXd& current_w, double min_error, double max_error, double min_alpha, double max_alpha, unsigned int t);
+std::vector<sol*> anticipatory_learning_dec_space(const std::vector<sol*> w, unsigned int t);
+sol* anticipatory_learning_dec_space(const std::vector<sol*> pop, unsigned int i, unsigned int current_t);
+sol* anticipatory_learning_dec_space(std::vector<sol*> pop_hist, std::vector<sol*> pop_pred, unsigned int i, unsigned int current_t);
+sol* anticipatory_learning_dec_space(sol *w, unsigned int i, unsigned int current_t);
+sol* anticipatory_learning_dec_space(sol *w, unsigned int current_t);
+
+double non_dominance_probability(sol* w);
+double non_dominance_probability(sol* w1, sol* w2);
+
+void NSGA2_iteration(std::vector<sol*> &P, unsigned int t);
+void ASMS_EMOA_iteration(std::vector<sol*> &P, float R1, float R2, unsigned int t, bool anticipation);
+
+#endif
+

--- a/legacy-cpp-v2/headers/crossover_operators.h
+++ b/legacy-cpp-v2/headers/crossover_operators.h
@@ -1,0 +1,9 @@
+#ifndef CROSSOVER_OPERATORS_H
+#define CROSSOVER_OPERATORS_H
+
+#include "asms_emoa.h"
+#include "learning_operators.h"
+
+void uniform_crossover(sol *parent1, sol *parent2, sol *offspring1, sol *offspring2);
+
+#endif

--- a/legacy-cpp-v2/headers/dirichlet.h
+++ b/legacy-cpp-v2/headers/dirichlet.h
@@ -1,0 +1,28 @@
+/*
+ * dirichlet.h
+ *
+ *  Created on: 10/11/2013
+ *      Author: LBiC
+ */
+
+#ifndef DIRICHLET_H_
+#define DIRICHLET_H_
+
+#include <Eigen/Eigen/Dense>
+#include <boost/random.hpp>
+
+#include "asms_emoa.h"
+
+Eigen::VectorXd dirichlet_mean(const Eigen::VectorXd& alpha);
+Eigen::VectorXd dirichlet_variance(const Eigen::VectorXd& alpha);
+Eigen::VectorXd dirichlet_variance(const Eigen::VectorXd& proportions, double concentration);
+Eigen::VectorXd dirichlet_mean_map_estimate(const Eigen::VectorXd& alpha);
+
+// Inference
+sol* dirichlet_mean_prediction(sol* prev_w, sol* current_w, unsigned int current_t);
+Eigen::VectorXd dirichlet_mean_prediction_vec(Eigen::VectorXd& prev_proportions, Eigen::VectorXd& current_proportions, double anticipative_rate);
+Eigen::VectorXd dirichlet_mean_map_update(Eigen::VectorXd& p_old, Eigen::VectorXd& p_obs, double concentration);
+sol* dirichlet_mean_map_update(sol* w_predicted, sol* w_obs, unsigned int current_t);
+
+
+#endif /* DIRICHLET_H_ */

--- a/legacy-cpp-v2/headers/kalman_filter.h
+++ b/legacy-cpp-v2/headers/kalman_filter.h
@@ -1,0 +1,37 @@
+/*
+ * kalman_filter.h
+ *
+ *  Created on: 03/03/2013
+ *      Author: LBiC
+ */
+
+#ifndef KALMAN_FILTER_H_
+#define KALMAN_FILTER_H_
+
+#include <Eigen/Eigen/Dense>
+
+struct Kalman_params
+{
+	static Eigen::MatrixXd F; // Next State Function
+	static Eigen::MatrixXd H; // Measurement Function
+	static Eigen::MatrixXd R; // Measurement Covariance Matrix
+
+	Eigen::VectorXd x; // State Vector
+	Eigen::VectorXd x_next; // Next state vector
+	Eigen::VectorXd u; // External control action
+	Eigen::MatrixXd P; // Error Covariance Matrix
+	Eigen::MatrixXd P_initial; // Error Covariance Matrix
+	Eigen::MatrixXd P_next; // Next covariance
+
+	double error;
+
+	static unsigned int window_size; // Window size for the KF estimation
+};
+
+
+void Kalman_prediction(Kalman_params& params);
+void Kalman_update(Kalman_params& params, Eigen::VectorXd measurement);
+void Kalman_filter(Kalman_params& params, Eigen::VectorXd measurement);
+
+
+#endif /* KALMAN_FILTER_H_ */

--- a/legacy-cpp-v2/headers/learning_operators.h
+++ b/legacy-cpp-v2/headers/learning_operators.h
@@ -1,0 +1,32 @@
+#ifndef learning_operators_h
+#define learning_operators_h
+
+#include <vector>
+#include <map>
+
+#include "asms_emoa.h"
+
+typedef void (*crossover_operator_ptr)(sol *, sol *, sol *, sol *);
+typedef void (*mutation_operator_ptr)(sol *, float);
+typedef std::map<unsigned int,float> operator_selector;
+
+struct xover_op
+{
+	static unsigned int num;
+	static crossover_operator_ptr _operator[1];
+	static operator_selector probability;
+	static operator_selector uniform_prob_op;
+};
+
+struct mutation_op
+{
+	static unsigned int num;
+	static mutation_operator_ptr _operator[4];
+	static operator_selector probability;
+	static operator_selector uniform_prob_op;
+};
+
+crossover_operator_ptr roulette_wheel_selection_crossover();
+mutation_operator_ptr roulette_wheel_selection_mutation();
+
+#endif

--- a/legacy-cpp-v2/headers/mutation_operators.h
+++ b/legacy-cpp-v2/headers/mutation_operators.h
@@ -1,0 +1,17 @@
+#ifndef MUTATION_OPERATORS_H
+#define MUTATION_OPERATORS_H
+
+#include "asms_emoa.h"
+#include "learning_operators.h"
+
+void reduce_investment(sol *offspring, unsigned int asset, float min, float max);
+void raise_investment(sol *offspring, unsigned int asset, float min, float max);
+void add_asset(sol *offspring, unsigned int asset);
+void remove_asset(sol *offspring, unsigned int asset);
+void modify_investment(sol *offspring, float p);
+void modify_portfolio(sol *offspring, float p);
+void raise_entropy(sol *offspring, float dummy);
+void lower_entropy(sol *offspring, float dummy);
+void prune_threshold(sol *offspring, float l);
+
+#endif

--- a/legacy-cpp-v2/headers/mvtnorm.h
+++ b/legacy-cpp-v2/headers/mvtnorm.h
@@ -1,0 +1,57 @@
+#ifndef _MVT_H_
+#define _MVT_H_
+
+#ifdef __cplusplus
+extern"C" {
+
+
+extern void mvtdst_(int* n,
+                    int* nu,
+                    double* lower,
+                    double* upper,
+                    int* infin,
+                    double* correl,
+                    double* delta,
+                    int* maxpts,
+                    double* abseps,
+                    double* releps,
+                    double* error,
+                    double* value,
+                    int* inform);
+
+#endif
+
+  
+double pmvnorm(int* n,
+               int* nu,
+               double* lower,
+               double* upper,
+               int* infin,      //   if INFIN(I) < 0, Ith limits are (-infinity, infinity);
+                                //   if INFIN(I) = 0, Ith limits are (-infinity, UPPER(I)];
+                                //   if INFIN(I) = 1, Ith limits are [LOWER(I), infinity);
+                                //   if INFIN(I) = 2, Ith limits are [LOWER(I), UPPER(I)].
+               double* correl,  //   the correlation coefficient in row I column J of the 
+                                //     correlation matrixshould be stored in 
+                                //    CORREL( J + ((I-2)*(I-1))/2 ), for J < I.
+               double* delta,   // non-central parameter
+               int* maxpts,     // param
+               double* abseps,  // param
+               double* releps,  // param
+               double* error,   // estimated abs. error. with 99% confidence interval
+               double* value,      // results store here.
+               int* inform);    // inform message goes here
+
+double pmvnorm_P(int n,
+                 double* bound,
+                 double* correlationMatrix, // (2,1), (3,1), (3,2) .....
+                 double* error);
+double pmvnorm_Q(int n,
+                 double* bound,
+                 double* correlationMatrix, // (2,1), (3,1), (3,2) .....
+                 double* error);
+                     
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _MVT_H_ */

--- a/legacy-cpp-v2/headers/portfolio.h
+++ b/legacy-cpp-v2/headers/portfolio.h
@@ -1,0 +1,432 @@
+#ifndef PORTFOLIO_H
+	#define PORTFOLIO_H
+
+#include "utils.h"
+#include "kalman_filter.h"
+
+#include <string>
+#include <cmath>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <Eigen/Eigen/Dense>
+#include <boost/lexical_cast.hpp>
+#include <boost/random/mersenne_twister.hpp>
+
+#define SIGN(x) (x >= 0 ? 1 : -1)
+#define IS_POSITIVE(x) SIGN(x) == 1
+#define IS_NEGATIVE(x) SIGN(x) == -1
+#define IS_ZERO(x) (x == 0) ? 1 : 0
+
+
+using namespace boost;
+
+std::vector<std::pair<Eigen::VectorXd,Eigen::MatrixXd> > load_benchmark_data(const std::string& path);
+
+struct stats
+{
+	double roi, risk;
+	stats (double r1, double r2) { roi = r1; risk = r2; }
+	stats() { roi = risk = 0.0; }
+};
+
+struct stats_vec
+{
+	std::vector<stats> samples;
+	double mean_roi, mean_risk, var_roi, var_risk, covar;
+
+	stats_vec()
+	{
+		samples.resize(0);
+		mean_roi = mean_risk = var_roi = var_risk = covar = 0.0;
+	}
+
+	stats_vec(const std::vector<stats>& s, double m_roi, double m_risk, double v_roi, double v_risk, double c)
+	{
+		samples = s;
+		mean_roi = m_roi, mean_risk = m_risk, var_roi = v_roi, var_risk = v_risk, covar = c;
+	}
+};
+
+struct portfolio
+{
+	stats_vec S;
+	static unsigned int samples_per_portfolio;
+	static unsigned int min_cardinality;
+	static unsigned int max_cardinality;
+	static unsigned int current_period;
+	static unsigned int periodicity;
+	static unsigned int num_assets;
+	static unsigned int severity;
+	static unsigned int periods;
+	static double min_hold;
+	static double max_hold;
+	static double brokerage_commission;
+	static double brokerage_fee;
+	static double total_wealth;
+	static double current_wealth;
+	static double total_incurred_cost;
+	static double min_cost;
+	static double max_cost;
+	static double max_ROI;
+	static double max_risk;
+	static double min_ROI;
+	static double min_risk;
+
+
+	static double get_max_ROI(unsigned int t)
+	{
+		double max_max_ROI = 0.0;
+		for (unsigned int t = 0; t < portfolio::periods; ++t)
+		{
+			Eigen::VectorXd value = portfolio::sequence_mean_covar[t].first.colwise().maxCoeff();
+			double max_ROI = value(0);
+
+			if (max_ROI > max_max_ROI)
+				max_max_ROI = max_ROI;
+		}
+		return max_max_ROI;
+		//return max_ROI;
+	}
+
+	static double get_min_ROI(unsigned int t)
+	{
+		double min_min_ROI = 0.0;
+		for (unsigned int t = 0; t < portfolio::periods; ++t)
+		{
+			Eigen::VectorXd value = portfolio::sequence_mean_covar[t].first.colwise().minCoeff();
+			double min_ROI = value(0);
+			if (min_ROI < min_min_ROI)
+				min_min_ROI = min_ROI;
+		}
+		return min_min_ROI;
+	}
+
+	static double get_max_risk(unsigned int t)
+	{
+		double max_max_risk = 0.0;
+		for (unsigned int t = 0; t < portfolio::periods; ++t)
+		{
+			double max_risk = 0.0;
+			for (int i = 0; i < portfolio::sequence_mean_covar[t].second.rows(); ++i)
+				for (int j = 0; j < portfolio::sequence_mean_covar[t].second.cols(); ++j)
+					if (portfolio::sequence_mean_covar[t].second(i,j) > max_risk)
+						max_risk = portfolio::sequence_mean_covar[t].second(i,j);
+
+			if (max_risk > max_max_risk)
+				max_max_risk = max_risk;
+		}
+		return max_max_risk;
+	}
+
+	static double get_min_risk()
+	{
+		return 0.0;
+	}
+
+	static std::vector<std::pair<Eigen::VectorXd,Eigen::MatrixXd> > sequence_mean_covar;
+
+	static std::vector<std::pair<unsigned,double> > top_k_investments (const Eigen::VectorXd& investment, unsigned int k);
+
+	static double compute_risk(portfolio &P,const Eigen::MatrixXd &covariance);
+	static double compute_ROI(portfolio &P, const Eigen::VectorXd &mean_ROI);
+
+	static Eigen::VectorXd estimate_assets_mean_ROI(const Eigen::MatrixXd &return_data);
+	static void estimate_covariance(const Eigen::VectorXd &mean_ROI,
+				const Eigen::MatrixXd &return_data, Eigen::MatrixXd &covariance);
+
+	// For use in the Kalman Filter
+	static void observe_state(portfolio &w, unsigned int N, unsigned int initial_t, unsigned int current_t);
+	static void KF_prediction_obj_space(portfolio &w, unsigned int steps);
+
+	static std::vector<std::pair<Eigen::VectorXd,Eigen::MatrixXd> > get_mean_covar();
+
+	static Eigen::MatrixXd theoretical_covariance;
+	static Eigen::VectorXd theoretical_mean_ROI;
+
+	static Eigen::VectorXd current_investment;
+
+	Eigen::MatrixXd sample_covariance;
+	Eigen::VectorXd sample_mean_ROI;
+
+	double ROI, ROI_prediction, ROI_observed;
+	double risk, risk_prediction, risk_observed;
+	double cardinality;
+	double obs_error;
+	double cid_ROI;
+	double cid_risk;
+	double cid;
+	double current_cost;
+	double nominal_ROI;
+	double turnover_rate;
+
+	Kalman_params kalman_state;
+	Eigen::MatrixXd covar, error_covar, error_covar_prediction;
+	Eigen::VectorXd investment;
+
+
+	portfolio()
+	{
+		cardinality = .0;
+		ROI = risk = ROI_observed = risk_observed = .0;
+		ROI_prediction = risk_prediction = .0;
+		obs_error = .0; current_cost = .0; turnover_rate = .0;
+		nominal_ROI = .0; cid = cid_ROI = cid_risk = .0;
+	}
+
+	portfolio(portfolio& w)
+	{
+		cardinality = w.cardinality;
+		ROI = w.ROI;
+		ROI_observed = w.ROI_observed;
+		risk = w.risk;
+		risk_observed = w.risk_observed;
+		ROI_prediction = w.ROI_prediction;
+		risk_prediction = w.risk_prediction;
+		obs_error = w.obs_error;
+		current_cost = w.current_cost;
+		turnover_rate = w.turnover_rate;
+		nominal_ROI = w.nominal_ROI;
+		cid = w.cid;
+		cid_ROI = w.cid_ROI;
+		cid_risk = w.cid_risk;
+
+		kalman_state = w.kalman_state;
+		investment = w.investment;
+		covar = w.covar;
+		error_covar = w.error_covar;
+		error_covar_prediction = w.error_covar_prediction;
+	}
+
+	static void observed_error(portfolio &w, unsigned int t)
+	{
+		if (t == (periods-1))
+		{
+			w.obs_error = 0.0;
+			return;
+		}
+
+		// What will be actually observed in terms of ROI and Risk
+		Eigen::VectorXd mean_curr = portfolio::sequence_mean_covar[t].first;
+		Eigen::MatrixXd covar_curr = portfolio::sequence_mean_covar[t].second;
+		Eigen::VectorXd mean_next = portfolio::sequence_mean_covar[t+1].first;
+		Eigen::MatrixXd covar_next = portfolio::sequence_mean_covar[t+1].second;
+
+		double ROI_curr = compute_ROI(w, mean_curr);
+		double risk_curr = compute_risk(w, covar_curr);
+		double ROI_next = compute_ROI(w, mean_next);
+		double risk_next = compute_risk(w, covar_next);
+
+		std::pair<double,double> cost;
+
+		Eigen::VectorXd Zero_vec = Eigen::VectorXd::Zero(portfolio::num_assets);
+		if (t == 0) // Considers the entry cost in the share market (from nothing to something invested)
+			cost = portfolio::transaction_cost(Zero_vec, w.investment);
+		else
+			cost = portfolio::transaction_cost(portfolio::current_investment, w.investment);
+
+
+		double nominal_ROI = ROI_next*portfolio::current_wealth;
+		w.ROI_observed = (nominal_ROI - cost.first) / portfolio::current_wealth;
+		w.risk_observed = risk_next;
+
+		// Compute the mean absolute error (MAE)
+		double error_ROI = fabs(inverse_linear_transform(w.ROI_observed - w.ROI, min_ROI, max_ROI));
+		double error_risk = fabs(inverse_linear_transform(w.risk_observed - w.risk, portfolio::min_risk,max_risk));
+		w.obs_error = 0.5*(error_ROI + error_risk);
+
+		// Compute the 1-0 losses for change in direction
+		double prediction_direction_ROI = SIGN(w.kalman_state.x_next(0) - w.kalman_state.x(0));
+		double prediction_direction_risk = SIGN(w.kalman_state.x_next(1) - w.kalman_state.x(1));
+		double actual_direction_ROI = SIGN(ROI_next - ROI_curr);
+		double actual_direction_risk = SIGN(risk_next - risk_curr);
+
+		w.cid_ROI = IS_ZERO(actual_direction_ROI - prediction_direction_ROI);
+		w.cid_risk = IS_ZERO(actual_direction_risk - prediction_direction_risk);
+		w.cid = 0.5*(w.cid_ROI + w.cid_risk);
+
+		w.ROI_observed = linear_transform(w.ROI_observed,min_ROI,max_ROI);
+		w.risk_observed = linear_transform(w.risk_observed,min_ROI,max_ROI);
+	}
+
+
+	static double turnover(const Eigen::VectorXd& current_w, const Eigen::VectorXd& new_w)
+	{
+		double rate = 0.0;
+
+		for (int i = 0; i < new_w.rows(); ++i)
+			rate += fabs(current_w(i) - new_w(i));
+		return rate;
+	}
+
+
+	static void update_cost_and_wealth(portfolio &implemented_decision, unsigned int t)
+	{
+		if (t == (periods-1))
+		{
+			return;
+		}
+
+		// What will be actually observed in terms of ROI and Risk
+		Eigen::VectorXd mean = portfolio::sequence_mean_covar[t+1].first;
+		std::pair<double,double> cost;
+		if (t == 0) // Considers the entry cost in the share market (from nothing to something invested)
+		{
+			Eigen::VectorXd Zero_vec = Eigen::VectorXd::Zero(portfolio::num_assets);
+			cost = portfolio::transaction_cost(Zero_vec, implemented_decision.investment);
+			total_incurred_cost = cost.first;
+			implemented_decision.turnover_rate = cost.second;
+		}
+		else
+		{
+			cost = portfolio::transaction_cost(portfolio::current_investment, implemented_decision.investment);
+			implemented_decision.current_cost = cost.first;
+			implemented_decision.turnover_rate = cost.second;
+			total_incurred_cost += implemented_decision.current_cost;
+		}
+
+		portfolio::current_wealth = portfolio::current_wealth * (1.0 + compute_ROI(implemented_decision, mean)) - implemented_decision.current_cost;
+	}
+
+	static double card(portfolio& w)
+	{
+		w.cardinality = w.investment.count();
+		return w.cardinality;
+	}
+
+	static double normalized_Entropy(portfolio &P)
+	{
+		double ne = 0.0;
+
+		unsigned int card = P.investment.count();
+
+		if (card < 2)
+			return 1.0;
+
+		for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+			if (P.investment(i) > 0.0)
+				ne += P.investment(i) * log2(P.investment(i));
+		P.cardinality = card;
+		double e = -1.0/log2(P.cardinality)*ne;
+
+		if (!(e < 0.0 || e >= 0))
+			return 1.0;
+		return e;
+
+	}
+
+	static void compute_statistics(unsigned int t)
+	{
+		if (t >= periods)
+			return;
+
+		portfolio::theoretical_mean_ROI = portfolio::sequence_mean_covar[t].first;
+		portfolio::theoretical_covariance = portfolio::sequence_mean_covar[t].second;
+	}
+
+	static std::pair<double,double> BOVESPA_fees(double nominal_value)
+	{
+		std::pair<double,double> fees;
+
+		if (nominal_value <= 135.7)
+		{
+			fees.first = 0.0;
+			fees.second = 2.7;
+		}
+		else if (nominal_value > 135.7 && nominal_value <= 498.62)
+		{
+			fees.first = 0.02;
+			fees.second = 0.0;
+		}
+		else if (nominal_value > 498.62 && nominal_value <= 1514.69)
+		{
+			fees.first = 0.015;
+			fees.second = 2.49;
+		}
+		else if (nominal_value > 1514.69 && nominal_value <= 3029.38)
+		{
+			fees.first = 0.01;
+			fees.second = 10.06;
+		}
+		else if (nominal_value > 3029.38)
+		{
+			fees.first = 0.005;
+			fees.second = 25.21;
+		}
+
+		return fees;
+
+	}
+
+	static std::pair<double,double> transaction_cost(Eigen::VectorXd& w_current, Eigen::VectorXd& w_new)
+	{
+
+		if (w_current.rows() == 0 || w_new.rows() == 0 || w_new.sum() == 0.0)
+			return std::pair<double,double>(0.0, 0.0);
+
+		Eigen::VectorXd x = w_current - w_new;
+		double total_cost = 0.0;
+
+		for (int i = 0; i < x.rows(); ++i)
+		{
+			double value = x(i);
+			x(i) = fabs(value);
+
+			double nominal_value = value*current_wealth;
+
+			std::pair<double,double> fees = BOVESPA_fees(nominal_value);
+			double brokerage_commission = fees.first;
+			double brokerage_fee = fees.second;
+
+			total_cost += nominal_value*brokerage_commission + brokerage_fee;
+		}
+
+		return std::pair<double,double>(total_cost, turnover(w_current, w_new));
+	}
+
+	static void init_portfolio()
+	{
+		portfolio::compute_statistics(portfolio::current_period);
+	}
+
+	void init()
+	{
+
+		this->investment.resize(portfolio::num_assets);
+		std::vector<unsigned int> selected;
+
+		unsigned int n_assets = portfolio::min_cardinality + (rand() % (portfolio::max_cardinality - portfolio::min_cardinality));
+
+		std::vector<unsigned int> index;
+		for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+			index.push_back(i);
+
+		for (unsigned int i = 0; i < n_assets; ++i)
+		{
+			std::random_shuffle(index.begin(), index.end());
+			selected.push_back(index.back());
+			index.pop_back();
+		}
+
+		// Create random weights
+		Eigen::MatrixXd samples = Eigen::MatrixXd::Zero(n_assets,1);
+		Eigen::VectorXd alpha = Eigen::VectorXd::Ones(n_assets);
+		alpha *= 2.0;
+
+		boost::mt19937 rng;
+		Eigen::VectorXd weights = dirichlet_sample(alpha,rng);
+
+		for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+			investment(i) = 0.0;
+		for (unsigned int i = 0; i < n_assets; ++i)
+			investment(selected[i]) = weights(i);
+
+		apply_threshold(investment, portfolio::min_hold, portfolio::max_hold);
+		cardinality = investment.count(); ROI = 0.0; risk = 0.0;
+
+	}
+};
+
+
+
+#endif

--- a/legacy-cpp-v2/headers/selection_operators.h
+++ b/legacy-cpp-v2/headers/selection_operators.h
@@ -1,0 +1,11 @@
+#include <vector>
+
+#ifndef OPERADORES_H
+#define OPERADORES_H
+
+#include "../headers/asms_emoa.h"
+
+unsigned int tournament_selection_CD(std::vector<sol*>&, unsigned int);
+unsigned int tournament_Delta_S(std::vector<sol*>&, const std::pair<double,double>&, unsigned int);
+
+#endif

--- a/legacy-cpp-v2/headers/statistics.h
+++ b/legacy-cpp-v2/headers/statistics.h
@@ -1,0 +1,32 @@
+#ifndef STATISTICS_H
+	#define STATISTICS_H
+
+#include "asms_emoa.h"
+
+// Sorting functions and comparison operators
+void sort_per_objective(std::vector<sol*>&,unsigned);
+void sort_per_observed_objective(std::vector<sol*>&,unsigned);
+void sort_per_objective(std::vector<std::pair<unsigned int, sol*> >&,unsigned);
+// Diversity measures
+double spread(std::vector<sol*>&);
+double coverage(std::vector<sol*>& P);
+double turnover(const Eigen::VectorXd& current_w, const Eigen::VectorXd& new_w);
+Eigen::VectorXd concept_vector(std::vector<sol*>& P);
+double coherence(std::vector<sol*>& P);
+// Approximation metrics
+double hypervolume(std::vector<sol*>&, double, double);
+double observed_hypervolume(std::vector<sol*>&, unsigned int, double, double);
+// Robustness metrics
+void compute_ranks(std::vector<sol*>&);
+bool check_covar(Eigen::MatrixXd Sigma);
+
+// Draw a sample from a multivariate Gaussian distributions
+Eigen::MatrixXd multi_norm(Eigen::VectorXd mu, Eigen::MatrixXd Sigma, int num_samples);
+double normal_cdf(Eigen::VectorXd x, Eigen::MatrixXd Sigma);
+double entropy(double p);
+double linear_entropy(double p);
+
+// Operations with Gaussian distributions
+
+
+#endif

--- a/legacy-cpp-v2/headers/utils.h
+++ b/legacy-cpp-v2/headers/utils.h
@@ -1,0 +1,36 @@
+/*
+ * utils.h
+ *
+ *  Created on: 21/11/2012
+ *      Author: LBiC
+ */
+
+#ifndef UTILS_H_
+#define UTILS_H_
+
+#include <vector>
+#include <Eigen/Eigen/Dense>
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/random.hpp>
+using namespace boost::gregorian;
+
+Eigen::VectorXd sum(const std::vector<Eigen::VectorXd> &M);
+double mean(std::vector<double> &v);
+double mean(Eigen::VectorXd &v);
+double median(std::vector<double> &v);
+double median(Eigen::VectorXd &v);
+double break_down(std::vector<double>&v, double cutoff);
+double break_down(Eigen::VectorXd &v, double cutoff);
+double unbiased_IQD(Eigen::VectorXd& v);
+double variance(Eigen::VectorXd& v);
+bool sequential_date(date current_date, date next_date);
+float uniform_zero_one();
+void normalize(Eigen::VectorXd& v);
+void apply_threshold(Eigen::VectorXd &w, double l, double u);
+double linear_transform(double value, double min, double max);
+double inverse_linear_transform(double value, double min, double max);
+Eigen::VectorXd dirichlet_sample(const Eigen::VectorXd& proportions, double concentratrion, boost::mt19937& rng);
+Eigen::VectorXd dirichlet_sample(const Eigen::VectorXd& alpha, boost::mt19937& rng);
+
+
+#endif /* UTILS_H_ */

--- a/legacy-cpp-v2/source/asms_emoa.cpp
+++ b/legacy-cpp-v2/source/asms_emoa.cpp
@@ -1,0 +1,1201 @@
+#include "../headers/asms_emoa.h"
+#include "../headers/selection_operators.h"
+#include "../headers/mutation_operators.h"
+#include "../headers/crossover_operators.h"
+#include "../headers/learning_operators.h"
+#include "../headers/kalman_filter.h"
+#include "../headers/statistics.h"
+#include "../headers/portfolio.h"
+#include "../headers/dirichlet.h"
+
+#include <algorithm>
+#include <fstream>
+#include <istream>
+#include <ostream>
+#include <limits>
+#include <vector>
+#include <cmath>
+#include <map>
+
+#include <Eigen/Eigen/Cholesky>
+
+using namespace std;
+
+typedef std::pair<unsigned int, unsigned int> integer_pair;
+
+double solution::xover_rate, solution::mut_rate, solution::min_error, solution::max_error;
+std::vector<std::vector<solution*> > solution::historical_populations;
+std::vector<solution*> solution::historical_anticipative_decisions;
+unsigned int solution::tourn_size, solution::num_fronts;
+sol* solution::predicted_anticipative_decision;
+double solution::epsilon;
+std::pair<double,double> solution::ref_point;
+
+void solution::compute_efficiency(sol* w)
+{
+
+	unsigned int initial_t = (portfolio::current_period > Kalman_params::window_size)
+			? (portfolio::current_period - Kalman_params::window_size) : 0;
+
+	portfolio::observe_state(w->P, portfolio::samples_per_portfolio, initial_t, portfolio::current_period);
+
+	w->P.cardinality = portfolio::card(w->P);
+	w->prediction_error = w->P.kalman_state.error;
+	w->alpha = 1.0 - non_dominance_probability(w); // Quantifies confidence over prediction
+
+}
+
+std::pair<double,double> feasibility_p(sol * x)
+{
+
+	Eigen::MatrixXd covar(2,2);
+	covar << x->P.covar(0,0), x->P.covar(0,1), x->P.covar(1,0), x->P.covar(1,1);
+
+	Eigen::LLT<Eigen::MatrixXd> lltOfA(covar); // Computes Cholesky decomposition
+	Eigen::MatrixXd U = lltOfA.matrixU();
+
+	Eigen::VectorXd zref_bottom(2), zref_bottom_ROI(1), zref_upper(2), zref_upper_risk(1), zpoint(2);
+	zpoint << x->P.ROI, x->P.risk;
+
+	zref_bottom << solution::ref_point.first, 0.0;
+	zref_bottom = U.inverse()*(zref_bottom - zpoint);
+	zref_bottom_ROI << zref_bottom(0);
+
+	zref_upper << 0.5, solution::ref_point.second;
+	zref_upper = U.inverse()*(zref_upper - zpoint);
+	zref_upper_risk << zref_upper(1);
+
+
+	double p1 = 1.0 - normal_cdf(zref_bottom_ROI,Eigen::MatrixXd::Identity(1,1));
+	double p2 = normal_cdf(zref_upper_risk,Eigen::MatrixXd::Identity(1,1));
+
+	return std::pair<double,double>(p1,p2);
+}
+
+bool epsilon_feasible(sol * x)
+{
+	x->epsilon_feasibility = feasibility_p(x);
+	return (x->epsilon_feasibility.first >= solution::epsilon)
+			&& (x->epsilon_feasibility.second >= solution::epsilon);
+}
+
+void assigns_crowding_distance_obj(std::vector<sol*> Pareto_front, int m)
+{
+
+	// Number of solutions
+	unsigned int l = Pareto_front.size();
+
+	if (Pareto_front.size() <= 2)
+		Pareto_front[0]->cd = 1.0f;
+
+	else if (m == 0) // Sorts by Return (ROI)
+	{
+
+		// Obtains the minimum and maximum values found in 'front_id'
+		// for the objective 'transportation_cost'. This is equivalent to
+		// finding extreme solutions within the front_id.
+
+		std::sort (Pareto_front.begin(), Pareto_front.end(), cmp_ROI_ptr);
+		float min_cost = Pareto_front.back()->P.ROI;
+		float max_cost = Pareto_front.front()->P.ROI;
+
+		// Assigns infinite crowding distance to extrema.
+		Pareto_front.front()->cd = (std::numeric_limits<float>::max()/2.0f)-1.0f;
+		Pareto_front.back()->cd = (std::numeric_limits<float>::max()/2.0f)-1.0f;
+
+		// Computes CD (with objectives normalized between 0 and 1) for the remaining solutions
+		for (unsigned int i = 1; i < l-1; ++i)
+		{
+			float norm_cost1 = (min_cost == max_cost) ?
+					1 : (Pareto_front[i+1]->P.ROI - min_cost)/(max_cost - min_cost);
+			float norm_cost2 = (min_cost == max_cost) ? 1 : (Pareto_front[i-1]->P.ROI - min_cost)/(max_cost - min_cost);
+
+			Pareto_front[i]->cd +=  norm_cost2 - norm_cost1;
+		}
+
+	} 
+	else if (m == 1) // Same thing as above, but sorting by risk
+	{
+
+		std::sort (Pareto_front.begin(), Pareto_front.end(), cmp_risk_ptr);
+		float min_cost = Pareto_front.front()->P.risk;
+		float max_cost = Pareto_front.back()->P.risk;
+
+		Pareto_front.front()->cd = (std::numeric_limits<float>::max()/2.0f)-2.0f;
+		Pareto_front.back()->cd = (std::numeric_limits<float>::max()/2.0f)-2.0f;
+
+		for (unsigned int i = 1; i < l-1; ++i)
+		{
+			float norm_cost1 = (min_cost == max_cost) ? 1 : (Pareto_front[i+1]->P.risk - min_cost)/(max_cost - min_cost);
+			float norm_cost2 = (min_cost == max_cost) ? 1 : (Pareto_front[i-1]->P.risk - min_cost)/(max_cost - min_cost);
+
+			Pareto_front[i]->cd +=  (norm_cost1 - norm_cost2);
+		}
+	}
+
+}
+
+// Requires population P to be sorted by front_id
+void crowding_distance(std::vector<sol*> &P, unsigned int front_id)
+{
+
+	unsigned int i = 0, start = 0, end;
+
+	std::vector<sol*> Pareto_front;
+
+	while (i < P.size() && P[i]->Pareto_front != front_id)
+		++i;
+
+	start = i;
+
+	while (i < P.size() && P[i]->Pareto_front == front_id)
+	{
+		Pareto_front.push_back(P[i]);
+		P[i]->cd = 0;
+		++i;
+	}
+
+	end = i - 1;
+
+	// For both objectives
+	assigns_crowding_distance_obj(Pareto_front, 0);
+	assigns_crowding_distance_obj(Pareto_front, 1);
+
+	std::sort(P.begin() + start, P.begin() + end, cmp_cd_ptr);
+}
+
+
+unsigned int fast_nondominated_sort(std::vector<sol*> &P)
+{
+	unsigned int num_fronts = 0;
+	std::vector<std::vector<unsigned int> > F;
+	std::vector<std::vector<unsigned int> > S(P.size());
+	std::vector<unsigned int> n(P.size());
+
+	std::vector<unsigned int>H ;
+
+	for (unsigned int p = 0; p < P.size(); ++p)
+	{
+		for (unsigned int q = 0; q < P.size(); ++q)
+			if (p != q)
+			{
+
+				if (constrained_dominance(P[p],P[q]))
+					S[p].push_back(q);
+				else if (constrained_dominance(P[q],P[p]))
+					++n[p];
+			}
+
+		if (n[p] == 0)
+		{
+			H.push_back(p);
+			P[H.back()]->Pareto_front = 0;
+		}
+	}
+	// Obtains the first front (non-dominated solutions)
+	F.push_back(H);
+
+	num_fronts++;
+
+	unsigned int i = 0;
+
+	while (!F[i].empty())
+	{
+		std::vector<unsigned int> H;
+
+		for (unsigned int p = 0; p < F[i].size(); ++p)
+		{
+			for (unsigned int q = 0; q < S[F[i][p]].size(); ++q)
+			{
+				--n[S[F[i][p]][q]];
+				if (n[S[F[i][p]][q]] == 0)
+				{
+					H.push_back(S[F[i][p]][q]);
+					P[H.back()]->Pareto_front = i + 1;
+
+				}
+			}
+		}
+		F.push_back(H);
+		++i; ++num_fronts;
+	}
+
+	std::sort(P.begin(), P.end(), cmp_front_ptr);
+
+	return num_fronts-1;
+}
+
+unsigned int observed_fast_nondominated_sort(std::vector<sol*> &P)
+{
+	unsigned int num_fronts = 0;
+	std::vector<std::vector<unsigned int> > F;
+	std::vector<std::vector<unsigned int> > S(P.size());
+	std::vector<unsigned int> n(P.size());
+
+	std::vector<unsigned int>H ;
+
+	for (unsigned int p = 0; p < P.size(); ++p)
+	{
+		for (unsigned int q = 0; q < P.size(); ++q)
+			if (p != q)
+			{
+				if (constrained_observed_dominance(P[p],P[q]))
+
+					S[p].push_back(q);
+				else if (constrained_observed_dominance(P[q],P[p]))
+					++n[p];
+			}
+
+		if (n[p] == 0)
+		{
+			H.push_back(p);
+			P[H.back()]->observed_Pareto_front = 0;
+		}
+	}
+
+	F.push_back(H);
+
+	num_fronts++;
+
+	unsigned int i = 0;
+
+	while (!F[i].empty())
+	{
+		std::vector<unsigned int> H;
+
+		for (unsigned int p = 0; p < F[i].size(); ++p)
+		{
+			for (unsigned int q = 0; q < S[F[i][p]].size(); ++q)
+			{
+				--n[S[F[i][p]][q]];
+				if (n[S[F[i][p]][q]] == 0)
+				{
+					H.push_back(S[F[i][p]][q]);
+					P[H.back()]->observed_Pareto_front = i + 1;
+
+				}
+			}
+		}
+		F.push_back(H);
+		++i; ++num_fronts;
+	}
+
+	std::sort(P.begin(),P.end(),cmp_observed_front_ptr);
+
+	return num_fronts-1;
+}
+
+void compute_Delta_S_front_id(std::vector<sol*> &Pareto_front, float R_1, float R_2)
+{
+
+	if (Pareto_front.size() == 1)
+	{
+		Pareto_front[0]->Delta_S = (Pareto_front[0]->P.ROI - R_1)*(R_2 - Pareto_front[0]->P.risk);
+		return;
+	}
+
+	sort_per_objective(Pareto_front,0);
+
+	unsigned int i = 0;
+	double delta_Si = (Pareto_front[i]->P.ROI - Pareto_front[i+1]->P.ROI) *
+						  (R_2 - Pareto_front[i]->P.risk);
+
+	delta_Si *= Pareto_front[i]->stability;
+	Pareto_front[i]->Delta_S = delta_Si;
+
+	i = 1;
+
+	while (i < Pareto_front.size() - 1)
+	{
+		delta_Si = (Pareto_front[i]->P.ROI - Pareto_front[i+1]->P.ROI) *
+					(Pareto_front[i-1]->P.risk - Pareto_front[i]->P.risk);
+
+		delta_Si *= Pareto_front[i]->stability;
+
+		Pareto_front[i]->Delta_S = delta_Si;
+		++i;
+	}
+
+	delta_Si = (Pareto_front[i]->P.ROI - R_1) *
+				   (Pareto_front[i-1]->P.risk - Pareto_front[i]->P.risk);
+	delta_Si *= Pareto_front[i]->stability;
+	Pareto_front[i]->Delta_S = delta_Si;
+}
+
+struct stochastic_params
+{
+	double cov, var_ROI, var_risk, corr, var_ratio;
+	double conditional_mean_ROI, conditional_var_ROI;
+	double conditional_mean_risk, conditional_var_risk;
+
+	stochastic_params(sol* w)
+	{
+
+		cov = w->P.covar(0,1);
+		var_ROI = w->P.covar(0,0);
+		var_risk = w->P.covar(1,1);
+		corr = cov / (sqrt(var_ROI)*sqrt(var_risk));
+		var_ratio = sqrt(var_ROI)/sqrt(var_risk);
+
+		conditional_mean_ROI = w->P.ROI;
+		conditional_var_ROI = (1.0 - corr*corr)*var_ROI;
+
+		conditional_mean_risk = w->P.risk;
+		conditional_var_risk = (1.0 - corr*corr)*var_risk;
+	}
+};
+
+double mean_delta_product(sol* w_0, sol* w_1, sol* w_2)
+{
+
+	stochastic_params sw_0(w_0);
+	stochastic_params sw_1(w_1);
+	stochastic_params sw_2(w_2);
+
+	double covar = 0.0; unsigned int N = w_0->P.S.samples.size();
+	for (unsigned int j = 0; j < N; ++j)
+		covar += (w_1->P.S.samples[j].roi - w_1->P.S.mean_roi)*(w_0->P.S.samples[j].risk - w_0->P.S.mean_risk);
+	covar /= (N-1);
+
+	double term1 = sw_1.conditional_mean_ROI*sw_0.conditional_mean_risk + covar;
+	double term2 = sw_1.conditional_mean_ROI*sw_1.conditional_mean_risk + w_1->P.S.covar;
+
+	covar = 0.0;
+	for (unsigned int j = 0; j < N; ++j)
+		covar += (w_2->P.S.samples[j].roi - w_2->P.S.mean_roi)*(w_0->P.S.samples[j].risk - w_0->P.S.mean_risk);
+	covar /= (N-1);
+
+	double term3 = sw_2.conditional_mean_ROI*sw_0.conditional_mean_risk + covar;
+
+	covar = 0.0;
+	for (unsigned int j = 0; j < N; ++j)
+		covar += (w_2->P.S.samples[j].roi - w_2->P.S.mean_roi)*(w_1->P.S.samples[j].risk - w_1->P.S.mean_risk);
+	covar /= (N-1);
+
+	double term4 = sw_2.conditional_mean_ROI*sw_1.conditional_mean_risk + covar;
+
+	return term1 - term2 - term3 + term4;
+}
+
+void compute_stochastic_Delta_S_front_id(std::vector<sol*> &Pareto_front, float R_1, float R_2)
+{
+
+	if (Pareto_front.size() == 1)
+	{
+		stochastic_params sw_1(Pareto_front[0]);
+
+		//deltaS = (a - b)*(c - d) = ac - ad - bc + bd
+		// ac = term1, ad = term2, bc = term3, bd = term4
+		// E[xy] = E[x]E[y] + cov(x,y)
+
+		// deltaS = (sw_1.conditional_mean_ROI - R_1)*(R_2 - sw_1.conditional_mean_risk)
+		double term1 = sw_1.conditional_mean_ROI*R_2 + 0.0;
+		double term2 = sw_1.conditional_mean_ROI*sw_1.conditional_mean_risk + Pareto_front[0]->P.S.covar;
+		double term3 = R_1*R_2 + 0.0;
+		double term4 = R_1*sw_1.conditional_mean_risk + 0.0;
+
+		Pareto_front[0]->Delta_S = term1 - term2 - term3 + term4;
+
+		return;
+	}
+
+	sort_per_objective(Pareto_front,0);
+
+	unsigned int i = 0;
+
+	stochastic_params sw_1(Pareto_front[i]);
+	stochastic_params sw_2(Pareto_front[i+1]);
+
+	//deltaS = (a - b)*(c - d) = ac - ad - bc + bd
+	// ac = term1, ad = term2, bc = term3, bd = term4
+	// E[xy] = E[x]E[y] + cov(x,y)
+
+	// deltaS = (sw_1.conditional_mean_ROI - sw_2.conditional_mean_ROI)*(R_2 - sw_1.conditional_mean_risk)
+	double term1 = sw_1.conditional_mean_ROI*R_2 + 0.0;
+	double term2 = sw_1.conditional_mean_ROI*sw_1.conditional_mean_risk + Pareto_front[i]->P.S.covar;
+	double term3 = sw_2.conditional_mean_ROI*R_2 + 0.0;
+
+	double covar = 0.0; unsigned int N = Pareto_front[i]->P.S.samples.size();
+	for (unsigned int j = 0; j < N; ++j)
+		covar += (Pareto_front[i+1]->P.S.samples[j].roi - Pareto_front[i+1]->P.S.mean_roi)*(Pareto_front[i]->P.S.samples[j].risk - Pareto_front[i]->P.S.mean_risk);
+	covar /= (N-1);
+
+	double term4 = sw_2.conditional_mean_ROI*sw_1.conditional_mean_risk + covar;
+
+	Pareto_front[i]->Delta_S = term1 - term2 - term3 + term4;
+
+
+	i = 1;
+
+	double delta_Si = 0.0;
+	while (i < Pareto_front.size() - 1)
+	{
+		delta_Si = mean_delta_product(Pareto_front[i-1], Pareto_front[i], Pareto_front[i+1]);
+		Pareto_front[i]->Delta_S = delta_Si;
+		++i;
+	}
+
+	stochastic_params sw_l(Pareto_front[i-1]);
+	stochastic_params sw_r(Pareto_front[i]);
+
+	covar = 0.0;
+	for (unsigned int j = 0; j < N; ++j)
+		covar += (Pareto_front[i]->P.S.samples[j].roi - Pareto_front[i]->P.S.mean_roi)*(Pareto_front[i-1]->P.S.samples[j].risk - Pareto_front[i-1]->P.S.mean_risk);
+	covar /= (N-1);
+
+	term1 = sw_r.conditional_mean_ROI*sw_l.conditional_mean_risk + covar;
+	term2 = sw_r.conditional_mean_ROI*sw_r.conditional_mean_risk + Pareto_front[i]->P.S.covar;
+	term3 = R_1*sw_l.conditional_mean_risk + 0.0;
+	term4 = R_1*sw_r.conditional_mean_risk + 0.0;
+
+	Pareto_front[i]->Delta_S = term1 - term2 - term3 + term4;
+
+}
+
+void compute_stochastic_Delta_S(std::vector<sol*> &P, unsigned int num_fronts, float R_1, float R_2)
+{
+	unsigned int i = 0;
+	for (unsigned int c = 0; c < num_fronts; ++c)
+	{
+		std::vector<sol*> front_id;
+
+		while (P[i]->Pareto_front != c)
+			++i;
+
+		while (i < P.size() && P[i]->Pareto_front == c)
+		{
+			front_id.push_back(P[i]);
+			++i;
+		}
+
+		if (c == num_fronts-1 && front_id.size() > 3)
+			compute_stochastic_Delta_S_front_id(front_id,R_1,R_2);
+
+	}
+}
+
+void compute_Delta_S(std::vector<sol*> &P, unsigned int num_fronts, float R_1, float R_2)
+{
+	unsigned int i = 0;
+	for (unsigned int c = 0; c < num_fronts; ++c)
+	{
+		std::vector<sol*> front_id;
+
+		while (P[i]->Pareto_front != c)
+			++i;
+
+		while (i < P.size() && P[i]->Pareto_front == c)
+		{
+			front_id.push_back(P[i]);
+			++i;
+		}
+
+		if (c == num_fronts-1 && front_id.size() > 3)
+			compute_Delta_S_front_id(front_id,R_1,R_2);
+	}
+}
+
+
+void remove_worst_s_metric(std::vector<sol*> &P, double total_error, unsigned int front_id_index, float R_1, float R_2)
+{
+	unsigned int i = 0, start = 0, end, worst;
+	std::vector<std::pair<unsigned int,sol*> > front_id;
+
+	while (P[i]->Pareto_front != front_id_index)
+	{
+		start++; i++;
+	} end = start;
+	while (i < P.size() && P[i]->Pareto_front == front_id_index)
+	{
+		front_id.push_back(std::pair<unsigned int,sol*>(i,P[i]));
+		end++; i++;
+	}
+
+	end -= 1;
+
+	sort_per_objective(front_id,0);
+
+	if (front_id.size() == 1)
+	{
+		delete *(P.begin() + front_id[0].first);
+		P.erase(P.begin() + front_id[0].first);
+		return;
+	}
+	else if (front_id.size() == 2)
+	{
+
+		double alpha1 = front_id[0].second->anticipation_rate;
+		double alpha2 = front_id[1].second->anticipation_rate;
+
+		if (alpha1 < alpha2)
+		{
+			delete *(P.begin() + front_id[0].first);
+			P.erase(P.begin() + front_id[0].first);
+			return;
+		}
+		else
+		{
+			delete *(P.begin() + front_id[1].first);
+			P.erase(P.begin() + front_id[1].first);
+			return;
+		}
+	}
+	else if (front_id.size() == 3)
+	{
+		delete *(P.begin() + front_id[1].first);
+		P.erase(P.begin() + front_id[1].first);
+		return;
+	}
+	else
+	{
+
+		worst = start; i = 0;
+
+		double worst_delta_Si = std::numeric_limits<double>::max(); i = 1;
+
+		while (i < front_id.size() - 1)
+		{
+			if (front_id[i].second->Delta_S < worst_delta_Si)
+			{
+				worst_delta_Si = front_id[i].second->Delta_S;
+				worst = front_id[i].first;
+			}
+			++i;
+		}
+
+		delete *(P.begin() + worst);
+		P.erase(P.begin() + worst);
+	}
+}
+
+double non_dominance_probability(sol* w)
+{
+	Eigen::MatrixXd covar(2,2);
+	covar << w->P.error_covar_prediction(0,0) + w->P.error_covar(0,0),
+			 w->P.error_covar_prediction(0,1) + w->P.error_covar(0,1),
+			 w->P.error_covar_prediction(1,0) + w->P.error_covar(1,0),
+			 w->P.error_covar_prediction(1,1) + w->P.error_covar(1,1);
+
+	Eigen::VectorXd delta1(2), delta2(2), u(2);
+
+	// Pr{ROI(t+1) > ROI(t) & Risk(t+1) > Risk(t)}
+	delta1 << w->P.ROI - w->P.ROI_prediction,
+			  w->P.risk - w->P.risk_prediction;
+
+	// Pr{ROI(t+1) < ROI(t) & Risk(t+1) < Risk(t)}
+	delta2 << w->P.ROI_prediction -  w->P.ROI,
+			  w->P.risk_prediction - w->P.risk;
+
+
+	// Point of interest for Pr {Delta < u = [0 0]^T}
+	u << 0.0, 0.0;
+
+	// Compute the change of variables to standardize the multivariate Gaussian
+	Eigen::LLT<Eigen::MatrixXd> lltOfA(covar); // compute Cholesky decomposition of A
+	Eigen::MatrixXd U = lltOfA.matrixU();
+
+	Eigen::VectorXd z1 = U.inverse()*(u - delta1);
+	Eigen::VectorXd z2 = U.inverse()*(u - delta2);
+
+	// Compute probability of w(t+1) being non-dominated w.r.t. w(t)
+	double p = normal_cdf(z1,Eigen::MatrixXd::Identity(2,2)) + normal_cdf(z2,Eigen::MatrixXd::Identity(2,2));
+
+	return p;
+}
+
+double non_dominance_probability(sol* w1, sol* w2)
+{
+	Eigen::MatrixXd covar(2,2);
+	covar << w1->P.error_covar(0,0) + w2->P.error_covar(0,0),
+			 w1->P.error_covar(0,1) + w2->P.error_covar(0,1),
+			 w1->P.error_covar(1,0) + w2->P.error_covar(1,0),
+			 w1->P.error_covar(1,1) + w2->P.error_covar(1,1);
+
+	Eigen::VectorXd delta1(2), delta2(2), u(2);
+
+	// Pr{ROI(t+1) > ROI(t) & Risk(t+1) > Risk(t)}
+	delta1 << w1->P.ROI - w2->P.ROI,
+			  w1->P.risk - w2->P.risk;
+
+	// Pr{ROI(t+1) < ROI(t) & Risk(t+1) < Risk(t)}
+	delta2 << w2->P.ROI -  w1->P.ROI,
+			  w2->P.risk - w1->P.risk;
+	// Point of interest for Pr {Delta < u = [0 0]^T}
+	u << 0.0, 0.0;
+
+	// Compute the change of variables to standardize the multivariate Gaussian
+	Eigen::LLT<Eigen::MatrixXd> lltOfA(covar); // compute Cholesky decomposition of A
+	Eigen::MatrixXd U = lltOfA.matrixU();
+
+	Eigen::VectorXd z1 = U.inverse()*(u - delta1);
+	Eigen::VectorXd z2 = U.inverse()*(u - delta2);
+
+	// Compute probability of w(t+1) being non-dominated w.r.t. w(t)
+	double p = normal_cdf(z1,Eigen::MatrixXd::Identity(2,2)) + normal_cdf(z2,Eigen::MatrixXd::Identity(2,2));
+		return p;
+}
+
+
+void anticipatory_learning_obj_space(sol* &w, sol* anticipative_portfolio, Eigen::VectorXd& current_w, double min_error, double max_error, double min_alpha, double max_alpha, unsigned int t)
+{
+
+	if (anticipative_portfolio == NULL)
+		anticipative_portfolio = w;
+
+	if (anticipative_portfolio->prediction_error < min_error)
+		min_error = anticipative_portfolio->prediction_error;
+	else if (anticipative_portfolio->prediction_error > max_error)
+		max_error = anticipative_portfolio->prediction_error;
+
+	if (anticipative_portfolio->alpha < min_alpha)
+		min_alpha = anticipative_portfolio->alpha;
+	else if (anticipative_portfolio->alpha > max_alpha)
+		max_alpha = anticipative_portfolio->alpha;
+
+	// Updates return and risk based on the anticipatory learning rule
+	double accuracy_factor = (min_error > 0.0 && (max_error - min_error) > 0.0)
+			? 1.0 - (anticipative_portfolio->prediction_error - min_error)/(max_error - min_error)
+					: 0.0;
+	double uncertainty_factor = anticipative_portfolio->alpha;
+
+	double rate_upb = (t == 0 || Kalman_params::window_size == 0) ? 0.0 : 0.5;
+	double rate_lwb = (t == 0 || Kalman_params::window_size == 0) ? 0.0 : 0.0;
+
+	w->anticipation_rate = rate_lwb + 0.5*uncertainty_factor*(rate_upb - rate_lwb) + 0.5*accuracy_factor*(rate_upb - rate_lwb);
+
+	Eigen::VectorXd x_state = Eigen::VectorXd::Zero(4);
+	x_state << anticipative_portfolio->P.ROI, anticipative_portfolio->P.risk, 0.0, 0.0;
+
+	Eigen::VectorXd x = x_state; Eigen::MatrixXd C = anticipative_portfolio->P.kalman_state.P;
+
+	if (Kalman_params::window_size > 0)
+	{
+		x = x_state + w->anticipation_rate*(anticipative_portfolio->P.kalman_state.x_next - x_state);
+
+		C = anticipative_portfolio->P.kalman_state.P
+				+ w->anticipation_rate*w->anticipation_rate*
+				(anticipative_portfolio->P.kalman_state.P_next
+						- anticipative_portfolio->P.kalman_state.P);
+	}
+
+	anticipative_portfolio->P.ROI = x(0);
+
+	if (anticipative_portfolio != NULL)
+	{
+		std::pair<double,double> cost_current = portfolio::transaction_cost(portfolio::current_investment, w->P.investment);
+		std::pair<double,double> cost_predicted = portfolio::transaction_cost(current_w, anticipative_portfolio->P.investment);
+
+		double adjusted_ROI = (portfolio::current_wealth + cost_current.first) / portfolio::current_wealth
+							* inverse_linear_transform(anticipative_portfolio->P.ROI,
+												portfolio::min_ROI,portfolio::max_ROI);
+
+		double nominal_ROI = (portfolio::current_wealth - cost_predicted.first)*adjusted_ROI;
+		anticipative_portfolio->P.ROI = linear_transform((nominal_ROI) / portfolio::current_wealth,portfolio::min_ROI,portfolio::max_ROI);
+	}
+
+	if (x(1) > 0.0)
+		anticipative_portfolio->P.risk = x(1);
+	else if (x(1) < 0.0 && anticipative_portfolio->P.kalman_state.x(1) > 0.0)
+		anticipative_portfolio->P.risk = anticipative_portfolio->P.kalman_state.x(1);
+	else if (x(1) < 0.0 && anticipative_portfolio->P.kalman_state.x(1) <= 0.0)
+		anticipative_portfolio->P.risk = 0.0; // Does not allow negative risk
+
+	anticipative_portfolio->P.covar = C;
+	w->P.covar = C;
+
+	w->P.kalman_state = anticipative_portfolio->P.kalman_state;
+	w->P.ROI = anticipative_portfolio->P.ROI;
+	w->P.risk = anticipative_portfolio->P.risk;
+
+	w->anticipation = true;
+	anticipative_portfolio->anticipation = true;
+}
+
+std::pair<double,double> anticipatory_learning_obj_space(std::vector<sol*> &P, unsigned int t)
+{
+
+	double min_error = std::numeric_limits<float>::max();
+	double max_error = 0.0;
+	double min_alpha = 1.0, max_alpha = 0.0;
+
+	for (unsigned int i = 0; i < P.size(); ++i)
+	{
+		unsigned int initial_t = (t > Kalman_params::window_size) ? (t - Kalman_params::window_size) : 0;
+
+
+		if (!P[i]->anticipation)
+			portfolio::observe_state(P[i]->P, portfolio::samples_per_portfolio, initial_t, t);
+		else
+			P[i]->prediction_error = 0.0;
+
+		// Corrects bounds, just in case (should not happen)
+		if (P[i]->alpha < min_alpha)
+			min_alpha = P[i]->alpha;
+		else if (P[i]->alpha > max_alpha)
+			max_alpha = P[i]->alpha;
+
+		if (P[i]->prediction_error < min_error)
+			min_error = P[i]->prediction_error;
+		else if (P[i]->prediction_error > max_error)
+			max_error = P[i]->prediction_error;
+
+	}
+
+	for (unsigned int i = 0; i < P.size(); ++i)
+		if (!P[i]->anticipation)
+		{
+			if (t > 0)
+			{
+				sol* anticipative_portfolio = anticipatory_learning_dec_space(P, i, t);
+
+				anticipative_portfolio->alpha = 1.0 - non_dominance_probability(anticipative_portfolio);
+				anticipatory_learning_obj_space(P[i], anticipative_portfolio, solution::predicted_anticipative_decision->P.investment, min_error, max_error, min_alpha, max_alpha, t);
+			}
+			else
+			{
+				P[i]->alpha = 1.0 - non_dominance_probability(P[i]);
+				anticipatory_learning_obj_space(P[i], NULL, portfolio::current_investment, min_error, max_error, min_alpha, max_alpha, t);
+			}
+		}
+
+	return std::pair<double,double>(min_error,max_error);
+}
+
+sol* anticipatory_learning_dec_space(std::vector<sol*> pop, unsigned int i, unsigned int current_t)
+{
+	if (current_t == 0 || Kalman_params::window_size == 0)
+		return pop[i];
+
+	unsigned int initial_t = (current_t > Kalman_params::window_size) ? (current_t - Kalman_params::window_size) : 0;
+
+	sol* w_updated = NULL, * w_current = NULL, * w_prediction = NULL;
+	sol* w_previous = new sol(solution::historical_populations[initial_t][i]);
+	for (unsigned int t = initial_t+1; t < current_t; ++t)
+	{
+		w_current = new sol(solution::historical_populations[t][i]);
+		double previous_concentration = w_previous->P.nominal_ROI;
+		double current_concentration = w_current->P.nominal_ROI;
+		double concentration = previous_concentration + current_concentration;
+
+		w_prediction = dirichlet_mean_prediction(w_previous, w_current, t);
+		delete w_previous; delete w_current;
+		w_updated = w_prediction;
+
+		if (t == current_t-1)
+			w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						pop[i]->P.investment, concentration);
+		else
+		{
+			if (t+1 < current_t)
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						solution::historical_populations[t+1][i]->P.investment, concentration);
+			else
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+										pop[i]->P.investment, concentration);
+		}
+		w_previous = w_updated;
+	}
+
+	w_current = pop[i];
+	w_prediction = dirichlet_mean_prediction(w_previous, w_current, current_t);
+	return w_prediction;
+}
+
+sol* anticipatory_learning_dec_space(std::vector<sol*> pop_current, std::vector<sol*> pop_pred, unsigned int i, unsigned int current_t)
+{
+	if (current_t == 0 || Kalman_params::window_size == 0)
+		return pop_pred[i];
+
+	unsigned int initial_t = (current_t > Kalman_params::window_size) ? (current_t - Kalman_params::window_size) : 0;
+
+	sol* w_updated = NULL, * w_current = NULL, * w_prediction = NULL;
+	sol* w_previous = (initial_t+1 == current_t) ? new sol(pop_current[i]) : new sol(solution::historical_populations[initial_t+1][i]);
+	for (unsigned int t = initial_t+1; t < current_t; ++t)
+	{
+		w_current = (t == current_t-1) ? new sol(pop_current[i]) : new sol(solution::historical_populations[t+1][i]);
+		double previous_concentration = w_previous->P.nominal_ROI;
+		double current_concentration = w_current->P.nominal_ROI;
+		double concentration = previous_concentration + current_concentration;
+
+		w_prediction = dirichlet_mean_prediction(w_previous, w_current, t);
+		delete w_previous; delete w_current;
+		w_updated = w_prediction;
+
+		if (t == current_t-1)
+			w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+					pop_current[i]->P.investment, concentration);
+		else
+		{
+			if (t+1 < current_t)
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						solution::historical_populations[t+1][i]->P.investment, concentration);
+			else
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+							pop_current[i]->P.investment, concentration);
+		}
+		w_previous = w_updated;
+	}
+
+	w_current = pop_pred[i];
+	w_prediction = dirichlet_mean_prediction(w_previous, w_current, current_t);
+	return w_prediction;
+
+}
+
+sol* anticipatory_learning_dec_space(sol *w, unsigned int current_t)
+{
+	if (current_t == 0 || Kalman_params::window_size == 0)
+		return w;
+
+	sol* anticipative_portfolio;
+	unsigned int initial_t = (current_t > Kalman_params::window_size) ? (current_t - Kalman_params::window_size) : 0;
+	sol* w_updated = NULL, * w_current = NULL, * w_prediction = NULL;
+
+	sol* w_previous = new sol(solution::historical_anticipative_decisions[initial_t]);
+;
+	for (unsigned int t = initial_t+1; t < current_t; ++t)
+	{
+		w_current = new sol(solution::historical_anticipative_decisions[t]);
+		w_prediction = dirichlet_mean_prediction(w_previous, w_current, t);
+		delete w_previous; delete w_current;
+		w_updated = w_prediction;
+
+		double previous_concentration = w_previous->P.nominal_ROI;
+		double current_concentration = w_current->P.nominal_ROI;
+		double concentration = previous_concentration + current_concentration;
+
+		if (t == current_t-1)
+			w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						w->P.investment, concentration);
+		else
+		{
+			if (t+1 < current_t)
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						solution::historical_anticipative_decisions[t+1]->P.investment, concentration);
+			else
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+										w->P.investment, concentration);
+		}
+
+		w_previous = w_updated;
+	}
+
+	w_current = w;
+	w_prediction = dirichlet_mean_prediction(w_previous, w_current, current_t);
+
+	anticipative_portfolio = w_prediction;
+	return anticipative_portfolio;
+}
+
+sol* anticipatory_learning_dec_space(sol *w, unsigned int i, unsigned int current_t)
+{
+	if (current_t == 0 || Kalman_params::window_size == 0)
+		return w;
+
+	unsigned int initial_t = (current_t > Kalman_params::window_size) ? (current_t - Kalman_params::window_size) : 0;
+
+	sol* w_updated = NULL, * w_current = NULL, * w_prediction = NULL;
+	sol* w_previous = new sol(solution::historical_populations[initial_t][i]);
+
+	for (unsigned int t = initial_t+1; t < current_t; ++t)
+	{
+		w_current = new sol(solution::historical_populations[t][i]);
+
+		double previous_concentration = w_previous->P.nominal_ROI;
+		double current_concentration = w_current->P.nominal_ROI;
+		double concentration = previous_concentration + current_concentration;
+
+		w_prediction = dirichlet_mean_prediction(w_previous, w_current, t);
+		delete w_current; delete w_previous;
+		w_updated = w_prediction;
+
+		if (t == current_t-1)
+			w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						w->P.investment, concentration);
+		else
+		{
+			if (t+1 < current_t)
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+						solution::historical_populations[t+1][i]->P.investment, concentration);
+			else
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+										w->P.investment, concentration);
+		}
+		w_previous = w_updated;
+	}
+
+	w_current = w;
+	w_prediction = dirichlet_mean_prediction(w_previous, w_current, current_t);
+	return w_prediction;
+}
+
+
+std::vector<sol*> anticipatory_learning_dec_space(const std::vector<sol*> pop, unsigned int current_t)
+{
+	if (current_t == 0 || Kalman_params::window_size == 0)
+		return pop;
+
+	std::vector<sol*> anticipative_population(pop.size());
+
+	for (unsigned int i = 0; i < pop.size(); ++i)
+	{
+		unsigned int initial_t = (current_t > Kalman_params::window_size) ? (current_t - Kalman_params::window_size) : 0;
+
+		sol* w_updated = NULL, * w_current = NULL, * w_prediction = NULL;
+		sol*  w_previous = new sol(solution::historical_populations[initial_t][i]);
+
+		for (unsigned int t = initial_t+1; t < current_t; ++t)
+		{
+
+			w_current = new sol(solution::historical_populations[t][i]);
+			double previous_concentration = w_previous->P.nominal_ROI;
+			double current_concentration = w_current->P.nominal_ROI;
+			double concentration = previous_concentration + current_concentration;
+
+			w_prediction = dirichlet_mean_prediction(w_previous, w_current, t);
+			delete w_current; delete w_previous;
+			w_updated = w_prediction;
+
+			if (t == current_t-1)
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+							pop[i]->P.investment, concentration);
+			else
+				w_updated->P.investment = dirichlet_mean_map_update(w_prediction->P.investment,
+							solution::historical_populations[t+1][i]->P.investment, concentration);
+
+			w_previous = w_updated;
+		}
+
+		w_current = pop[i];
+		w_prediction = dirichlet_mean_prediction(w_previous, w_current, current_t);
+		anticipative_population[i] = w_prediction;
+	}
+
+	return anticipative_population;
+}
+
+void apply_mutation(sol* w)
+{
+	unsigned min_weight;
+	while (portfolio::card(w->P) > portfolio::max_cardinality)
+	{
+		min_weight = 0;
+		for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+			if (w->P.investment(i) > 0)
+			{
+				min_weight = i;
+				break;
+			}
+
+		for (unsigned int i = min_weight+1; i < portfolio::num_assets; ++i)
+			if (w->P.investment(i) > 0 && w->P.investment(i) < w->P.investment(min_weight))
+				min_weight = i;
+
+		remove_asset(w, min_weight);
+	}
+
+	bool low_card = false; std::vector<unsigned int> indices;
+	while (portfolio::card(w->P) < 2)
+	{
+
+		if (!low_card)
+			for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+				if (w->P.investment(i) == 0)
+						indices.push_back(i);
+
+			std::random_shuffle(indices.begin(), indices.end());
+
+			for (unsigned int i = 0; i < 2 - portfolio::card(w->P); ++i)
+			{
+				add_asset(w,indices.back());
+				indices.pop_back();
+			}
+			low_card = true;
+		}
+}
+
+void ASMS_EMOA_iteration(std::vector<sol*> &P, float R1, float R2, unsigned int t, bool anticipation)
+{
+	xover_op::probability = xover_op::uniform_prob_op;
+	mutation_op::probability = mutation_op::uniform_prob_op;
+
+	double total_error = 0.0;
+
+	std::pair<double,double> error;
+
+
+	if (anticipation == true)
+		error = anticipatory_learning_obj_space(P, t);
+
+	unsigned int num_fronts = fast_nondominated_sort(P);
+
+	if (anticipation == true)
+		compute_stochastic_Delta_S(P,num_fronts, R1, R2);
+	else
+		compute_Delta_S(P,num_fronts, R1, R2);
+
+	unsigned int parent1 = tournament_Delta_S(P, error, solution::tourn_size);
+	unsigned int parent2;
+
+	sol * offspring1;
+	if (uniform_zero_one() < solution::xover_rate)
+	{
+		do
+		{
+			parent2 = tournament_Delta_S(P, error, solution::tourn_size);
+		} while (parent1 == parent2);
+
+		offspring1 = new sol(); sol * offspring2 = new sol();
+
+		crossover_operator_ptr xover_op = roulette_wheel_selection_crossover();
+		xover_op(P[parent1], P[parent2], offspring1, offspring2);
+		delete offspring2;
+	}
+	else
+		offspring1 = new sol(P[parent1]);
+
+	mutation_operator_ptr mutation_op = roulette_wheel_selection_mutation();
+
+	double rate = solution::mut_rate;
+	mutation_op(offspring1, rate);
+	apply_mutation(offspring1);
+
+	if (t >= 0 && anticipation == true)
+	{
+		unsigned int initial_t = (t > Kalman_params::window_size) ? (t - Kalman_params::window_size) : 0;
+
+		portfolio::observe_state(offspring1->P, 20, initial_t, t);
+		offspring1->alpha = 1.0 - non_dominance_probability(offspring1);
+
+		double min_error = std::numeric_limits<float>::max();
+		double max_error = 0.0;
+		double min_alpha = 1.0, max_alpha = 0.0;
+
+		for (unsigned int i = 0; i < P.size(); ++i)
+		{
+			if (P[i]->alpha < min_alpha)
+				min_alpha = P[i]->alpha;
+			else if (P[i]->alpha > max_alpha)
+				max_alpha = P[i]->alpha;
+
+			if (P[i]->prediction_error < min_error)
+				min_error = P[i]->prediction_error;
+			else if (P[i]->prediction_error > max_error)
+				max_error = P[i]->prediction_error;
+		}
+
+		if (offspring1->alpha < min_alpha)
+			min_alpha = offspring1->alpha;
+		else if (offspring1->alpha > max_alpha)
+			max_alpha = offspring1->alpha;
+
+		if (offspring1->prediction_error < min_error)
+			min_error = offspring1->prediction_error;
+		else if (offspring1->prediction_error > max_error)
+			max_error = offspring1->prediction_error;
+
+		solution::num_fronts = num_fronts;
+		if (t > 0)
+		{
+			unsigned ROI_rank = 0;
+			for (unsigned int i = 0; i < P.size(); ++i)
+				if (offspring1->P.ROI > P[i]->P.ROI)
+				{
+					ROI_rank = i;
+					break;
+				}
+			 if (ROI_rank == P.size())
+				 ROI_rank -= 1;
+
+			sol * anticipative_offspring = anticipatory_learning_dec_space(offspring1, ROI_rank, t);
+			anticipatory_learning_obj_space(offspring1, anticipative_offspring, solution::predicted_anticipative_decision->P.investment, min_error, max_error, min_alpha, max_alpha, t);
+		}
+		else
+			anticipatory_learning_obj_space(offspring1, NULL, portfolio::current_investment, min_error, max_error, min_alpha, max_alpha, t);
+	}
+	else if (t > 0)
+		solution::compute_efficiency(offspring1);
+	else
+	{
+		offspring1->prediction_error = 0.0;
+		solution::compute_efficiency(offspring1);
+	}
+
+	solution::num_fronts = num_fronts;
+	P.push_back(offspring1);
+	num_fronts = fast_nondominated_sort(P);
+
+	if (t >= 0 && anticipation == true)
+		compute_stochastic_Delta_S(P,num_fronts, R1, R2);
+	else
+		compute_Delta_S(P,num_fronts, R1, R2);
+
+	remove_worst_s_metric(P, total_error, num_fronts-1, R1, R2);
+
+	for (unsigned int p = 0; p < P.size(); ++p)
+		portfolio::observed_error(P[p]->P, portfolio::current_period);
+}
+
+void NSGA2_iteration(std::vector<sol*> &P, unsigned int t)
+{
+
+	xover_op::probability = xover_op::uniform_prob_op;
+	mutation_op::probability = mutation_op::uniform_prob_op;
+
+	unsigned int num_fronts = fast_nondominated_sort(P);
+	
+	for (unsigned int i = 0; i < num_fronts; ++i)
+		crowding_distance(P, i);
+
+
+	unsigned int novap_size = 2*P.size();
+
+	while (P.size() < novap_size)
+	{
+		unsigned int parent1 = tournament_selection_CD(P, solution::tourn_size);
+		unsigned int parent2;
+
+		mutation_operator_ptr mut_operator = roulette_wheel_selection_mutation();
+
+		sol * offspring1, * offspring2;
+		if (uniform_zero_one() < solution::xover_rate)
+		{
+
+			do
+			{
+				parent2 = tournament_selection_CD(P, solution::tourn_size);
+			} while (parent1 == parent2);
+
+			offspring1 = new sol(); offspring2 = new sol();
+
+			crossover_operator_ptr xover_operator = roulette_wheel_selection_crossover();
+			xover_operator(P[parent1], P[parent2], offspring1, offspring2);
+
+			mut_operator = roulette_wheel_selection_mutation();
+			mut_operator(offspring2, solution::mut_rate);
+
+		}
+		else
+			offspring1 = P[parent1];
+
+		mut_operator = roulette_wheel_selection_mutation();
+		mut_operator(offspring1, solution::mut_rate);
+
+		solution::compute_efficiency(offspring1);
+		solution::compute_efficiency(offspring2);
+
+		P.push_back(offspring1);
+		P.push_back(offspring2);
+	}
+
+	num_fronts = fast_nondominated_sort(P);
+	for (unsigned int i = 0; i < num_fronts; ++i)
+		crowding_distance(P, i);
+
+	std::vector<sol*>::iterator it = P.begin() + P.size()/2;
+	for (; it != P.end(); ++it)
+		delete *it;
+
+	P.erase(P.begin() + P.size()/2, P.end());
+
+}

--- a/legacy-cpp-v2/source/crossover_operators.cpp
+++ b/legacy-cpp-v2/source/crossover_operators.cpp
@@ -1,0 +1,98 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <math.h>
+
+#include "../headers/utils.h"
+#include "../headers/mutation_operators.h"
+#include "../headers/crossover_operators.h"
+#include "../headers/learning_operators.h"
+
+// Pointers array for functions implementing crossover operators
+unsigned int xover_op::num = 1;
+crossover_operator_ptr xover_op::_operator[1] = {&uniform_crossover};
+
+void uniform_crossover(sol *parent1, sol *parent2, sol *offspring1, sol *offspring2)
+{
+	std::vector<unsigned int> index;
+	for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+	{
+		offspring1->P.investment(i) = offspring2->P.investment(i) = 0.0;
+		if (parent1->P.investment(i) > 0.0 || parent2->P.investment(i) > 0.0)
+			index.push_back(i);
+	}
+
+	unsigned int card1 = 0, card2 = 0;
+
+	std::random_shuffle(index.begin(),index.end());
+	for (unsigned int i = 0; i < index.size(); ++i)
+	{
+		if (portfolio::card(offspring1->P) < portfolio::max_cardinality)
+		{
+			if (uniform_zero_one() < .5)
+			{
+				offspring1->P.investment(index[i]) = parent1->P.investment(index[i]);
+				offspring2->P.investment(index[i]) = parent2->P.investment(index[i]);
+				if (offspring1->P.investment(index[i]) > 0.0)
+					card1++;
+				if (offspring2->P.investment(index[i]) > 0.0)
+					card2++;
+			}
+			else
+			{
+				offspring1->P.investment(index[i]) = parent2->P.investment(index[i]);
+				offspring2->P.investment(index[i]) = parent1->P.investment(index[i]);
+				if (offspring1->P.investment(index[i]) > 0.0)
+					card1++;
+				if (offspring2->P.investment(index[i]) > 0.0)
+					card2++;
+			}
+		}
+		else
+			break;
+	}
+
+	offspring2->P.cardinality = card2;
+
+	bool card = false;
+
+	while (portfolio::card(offspring1->P) < portfolio::min_cardinality)
+	{
+		for (unsigned c = portfolio::card(offspring1->P); c < portfolio::min_cardinality; ++c)
+		{
+			add_asset(offspring1,rand()%portfolio::num_assets);
+			apply_threshold(offspring1->P.investment, portfolio::min_hold, portfolio::max_hold);
+			card = true;
+		}
+	}
+
+	while (portfolio::card(offspring2->P) < portfolio::min_cardinality)
+	{
+		for (unsigned c = portfolio::card(offspring2->P); c < portfolio::min_cardinality; ++c)
+		{
+			add_asset(offspring2,rand()%portfolio::num_assets);
+			apply_threshold(offspring2->P.investment, portfolio::min_hold, portfolio::max_hold);
+			card = true;
+		}
+	}
+
+	if (portfolio::card(offspring1->P) < portfolio::min_cardinality)
+	{
+		std::cout << offspring1->P.investment;
+		card = true;
+	}
+
+	if (portfolio::card(offspring2->P) < portfolio::min_cardinality)
+	{
+		std::cout << offspring1->P.investment;
+		card = true;
+	}
+
+	if (!card)
+	{
+		apply_threshold(offspring1->P.investment, portfolio::min_hold, portfolio::max_hold);
+		apply_threshold(offspring2->P.investment, portfolio::min_hold, portfolio::max_hold);
+	}
+
+
+}

--- a/legacy-cpp-v2/source/dirichlet.cpp
+++ b/legacy-cpp-v2/source/dirichlet.cpp
@@ -1,0 +1,88 @@
+/*
+ * dirichlet.cpp
+ *
+ *  Created on: 10/11/2013
+ *      Author: LBiC
+ */
+#include "../headers/dirichlet.h"
+#include "../headers/portfolio.h"
+#include "../headers/statistics.h"
+#include "../headers/asms_emoa.h"
+
+#include <boost/random/gamma_distribution.hpp>
+
+#include <vector>
+
+Eigen::VectorXd dirichlet_mean(const Eigen::VectorXd& alpha)
+{
+	return alpha / alpha.sum();
+}
+
+Eigen::VectorXd dirichlet_variance(const Eigen::VectorXd& alpha)
+{
+	double factor = alpha.sum()*alpha.sum()*alpha.sum() + alpha.sum()*alpha.sum();
+	Eigen::VectorXd alpha_square = alpha.array().square();
+	return (alpha.sum()*alpha - alpha_square) / factor;
+}
+
+Eigen::VectorXd dirichlet_variance(const Eigen::VectorXd& proportions, double concentration)
+{
+	Eigen::VectorXd alpha = concentration*proportions;
+	return dirichlet_variance(alpha);
+}
+
+Eigen::VectorXd dirichlet_mean_map_estimate(const Eigen::VectorXd& alpha)
+{
+	return (alpha - Eigen::VectorXd::Ones(alpha.rows())) / (alpha.sum() - alpha.rows());
+}
+
+Eigen::VectorXd dirichlet_mean_prediction_vec(Eigen::VectorXd& prev_proportions, Eigen::VectorXd& current_proportions, double anticipative_rate)
+{
+	anticipative_rate = 0.5*anticipative_rate;
+	Eigen::VectorXd prediction = prev_proportions + anticipative_rate*(current_proportions - prev_proportions);
+	normalize(prediction);
+
+	for (int i = 0; i < prediction.rows(); ++i)
+		if (prediction(i) < 0.0)
+			prediction(i) = 0.0;
+		else if (prediction(i) > 1.0)
+			prediction(i) = 1.0;
+
+	return prediction / prediction.sum();
+}
+
+sol* dirichlet_mean_prediction(sol* prev_w, sol* current_w, unsigned int current_t)
+{
+	sol* predicted_w = new sol(current_w);
+	double anticipative_rate = 2.0 - non_dominance_probability(prev_w, current_w);
+	predicted_w->P.investment = dirichlet_mean_prediction_vec(prev_w->P.investment, current_w->P.investment, anticipative_rate);
+
+	unsigned int initial_t = (current_t > Kalman_params::window_size) ? (current_t - Kalman_params::window_size) : 0;
+	portfolio::observe_state(predicted_w->P, portfolio::samples_per_portfolio, initial_t, current_t);
+
+	if (current_t == portfolio::current_period)
+		portfolio::KF_prediction_obj_space(predicted_w->P, 1); // 2 steps ahead
+
+	return predicted_w;
+}
+
+Eigen::VectorXd dirichlet_mean_map_update(Eigen::VectorXd& p_predicted, Eigen::VectorXd& p_obs, double concentration)
+{
+	Eigen::VectorXd p_updated = Eigen::VectorXd::Zero(p_predicted.rows());
+	Eigen::VectorXd var = dirichlet_variance(p_predicted, concentration);
+
+	for (int i = 0; i < p_predicted.rows(); ++i)
+		if (p_predicted(i) == 0.0 || var(i) == 0.0)
+			p_updated(i) = 0.0;
+		else
+			p_updated(i) = p_predicted(i) + 1.0*var(i)*(p_obs(i) - p_predicted(i)) / (p_predicted(i)*(1 - p_predicted(i)));
+
+	return p_updated / p_updated.sum();
+}
+
+sol* dirichlet_mean_map_update(sol* w_predicted, sol* w_obs, unsigned int current_t)
+{
+	Eigen::VectorXd p_updated = dirichlet_mean_map_update(w_predicted->P.investment, w_obs->P.investment, 20);
+	sol* w_updated = new sol(w_obs); w_updated->P.investment = p_updated;
+	return w_updated;
+}

--- a/legacy-cpp-v2/source/kalman_filter.cpp
+++ b/legacy-cpp-v2/source/kalman_filter.cpp
@@ -1,0 +1,45 @@
+/*
+ * kalman_filter.cpp
+ *
+ *  Created on: 03/03/2013
+ *      Author: LBiC
+ */
+
+
+#include <iostream>
+#include "../headers/kalman_filter.h"
+
+Eigen::MatrixXd Kalman_params::F; // Next State Function
+Eigen::MatrixXd Kalman_params::H; // Measurement Function
+Eigen::MatrixXd Kalman_params::R; // Measurement Covariance Matrix
+
+unsigned int Kalman_params::window_size;
+
+void Kalman_prediction(Kalman_params& params)
+{
+	params.x_next = (params.F * params.x) + params.u;
+	params.P_next = params.F * params.P * params.F.transpose();
+}
+void Kalman_update(Kalman_params& params, Eigen::VectorXd measurement)
+{
+
+	Eigen::MatrixXd I = Eigen::MatrixXd::Identity(params.F.rows(),params.F.cols());
+	Eigen::MatrixXd Z = Eigen::MatrixXd::Zero(1,2);
+			        Z << measurement(0), measurement(1);
+	Eigen::VectorXd y = Z.transpose() - (params.H * params.x_next);
+	Eigen::MatrixXd S = params.H * params.P_next * params.H.transpose() + params.R;
+	Eigen::MatrixXd K = params.P_next * params.H.transpose() * S.inverse();
+	params.x = params.x_next + (K * y);
+	params.P = (I - (K * params.H)) * params.P_next;
+
+	params.error += y.norm();
+
+}
+void Kalman_filter(Kalman_params& params, Eigen::VectorXd measurement)
+{
+	Kalman_update(params, measurement);
+	Kalman_prediction(params);
+}
+
+
+

--- a/legacy-cpp-v2/source/learning_operators.cpp
+++ b/legacy-cpp-v2/source/learning_operators.cpp
@@ -1,0 +1,46 @@
+#include <map>
+#include <vector>
+#include <algorithm>
+
+#include "../headers/asms_emoa.h"
+#include "../headers/learning_operators.h"
+
+operator_selector xover_op::uniform_prob_op;
+operator_selector xover_op::probability;
+operator_selector mutation_op::uniform_prob_op;
+operator_selector mutation_op::probability;
+
+
+mutation_operator_ptr roulette_wheel_selection_mutation()
+{
+	float u = rand()/(float)RAND_MAX;
+
+	operator_selector::iterator i = mutation_op::probability.begin();
+	operator_selector::iterator end = mutation_op::probability.end();
+
+	float acc = i->second;
+	for (; i != end && acc < u; ++i, acc += i->second);
+
+	if (i == end)
+		--i;
+
+	return mutation_op::_operator[i->first];
+}
+
+crossover_operator_ptr roulette_wheel_selection_crossover()
+{
+	float u = rand()/(float)RAND_MAX;
+
+	operator_selector::iterator i = xover_op::probability.begin();
+	operator_selector::iterator end = xover_op::probability.end();
+
+	float acc = i->second;
+
+	for (; i != end && acc < u; ++i, acc += i->second);
+
+	if (i == end)
+		--i;
+
+	return xover_op::_operator[i->first];
+
+}

--- a/legacy-cpp-v2/source/main.cpp
+++ b/legacy-cpp-v2/source/main.cpp
@@ -1,0 +1,744 @@
+/*
+ * main.cpp
+ *
+ *  Created on: 21/11/2012
+ *  Last updated on 08/03/2015
+ *      Author: Carlos R. B. Azevedo
+ *      Laboratory of Bioinformatics and Bio-inspired Computing
+ *      School of Electrical Engineering
+ *      University of Campinas, Brazil
+ */
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstdlib>
+#include <string>
+#include <ctime>
+
+#include <boost/lexical_cast.hpp>
+#include "../headers/crossover_operators.h"
+#include "../headers/mutation_operators.h"
+#include "../headers/learning_operators.h"
+#include "../headers/statistics.h"
+#include "../headers/portfolio.h"
+#include "../headers/kalman_filter.h"
+#include "../headers/dirichlet.h"
+
+
+using namespace boost;
+
+// Global variables
+static unsigned int pop_size;
+static unsigned int max_iter;
+static unsigned int trials;
+static bool anticipation = false;
+static std::string algo, instance, DM;
+static std::vector<std::vector<Eigen::VectorXd> > investments;
+
+
+unsigned int exp_id;
+
+// Prototypes
+void save_portfolio(const portfolio &P, std::ostream &out);
+void save_portfolio_stochastic_obj(const portfolio &P, std::ostream &out);
+void save_results(unsigned int e, unsigned int seed_initial_pop,
+	unsigned int experiment_seed, std::vector<sol*> &P, unsigned int t);
+
+void run_algorithm(unsigned int e, unsigned int initial_pop_seed,
+	unsigned int experiment_seed, unsigned int pop_size, unsigned int generations);
+
+std::vector<std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > > write_statistics(std::vector<sol*> &P, std::ostream &out, unsigned int t);
+void print_pop(std::vector<sol*> &P, std::ostream &out);
+void print_pop(std::vector<sol*> &P, std::pair<unsigned int, double>, std::ostream &out);
+
+
+// Reads parameters from the command line and assign them to the corresponding global class variables
+bool load_params (int argc, char** argv)
+{
+	if (argc != 27)
+	{
+		std::cout << "Usage: " << argv[0] << " instance num_assets exp_id trials KF_window_size"
+							   << " algorithm dm_type pop_size mut_rate xover_rate tourn_size"
+							   << " max_iter min_cardinality max_cardinality min_hold max_hold"
+							   << " brokerage_commission brokerage_fee epsilon periods periodicity"
+							   << " severity z_ref1 z_ref2 total_wealth samples_per_simulation\n";
+		return false;
+	}
+
+	instance = std::string(argv[1]); // Which instance are we solving?
+	portfolio::num_assets = lexical_cast<unsigned int>(argv[2]); // Number of available assets
+	exp_id = lexical_cast<unsigned int>(argv[3]); // Are we resuming the experiments? From were should we start?
+	trials = lexical_cast<unsigned int>(argv[4]); // Number of experiments
+	Kalman_params::window_size = lexical_cast<unsigned int>(argv[5]); // How far should we look into the past?
+	algo = std::string(argv[6]); // Which algorithm are we using?
+	DM = std::string(argv[7]); // What is the decision-making strategy?
+	pop_size = lexical_cast<unsigned int>(argv[8]); // What is the population size
+	solution::mut_rate = lexical_cast<double>(argv[9]); // Mutation rate
+	solution::xover_rate = lexical_cast<double>(argv[10]); // Crossover rate
+	solution::tourn_size = lexical_cast<unsigned int>(argv[11]); // Selection tournament size
+	max_iter = lexical_cast<unsigned int>(argv[12]); // Maximum number of iterations
+	portfolio::min_cardinality = lexical_cast<unsigned int>(argv[13]);
+	portfolio::max_cardinality = lexical_cast<unsigned int>(argv[14]);
+	portfolio::min_hold = lexical_cast<double>(argv[15]);
+	portfolio::max_hold = lexical_cast<double>(argv[16]);
+	portfolio::brokerage_commission = lexical_cast<double>(argv[17]);
+	portfolio::brokerage_fee = lexical_cast<double>(argv[18]);
+	solution::epsilon = lexical_cast<double>(argv[19]);
+	portfolio::periods = lexical_cast<unsigned int>(argv[20]);
+	portfolio::periodicity = lexical_cast<unsigned int>(argv[21]);
+	portfolio::severity = lexical_cast<unsigned int>(argv[22]);
+	solution::ref_point.first = lexical_cast<double>(argv[23]);
+	solution::ref_point.second = lexical_cast<double>(argv[24]);
+	portfolio::total_wealth = lexical_cast<double>(argv[25]);
+	portfolio::samples_per_portfolio = lexical_cast<unsigned int>(argv[26]);
+
+	// We start investing the total amount and see how it goes.
+	portfolio::current_wealth = portfolio::total_wealth;
+
+
+	if (portfolio::max_cardinality > portfolio::num_assets)
+	{
+		std::cout << "Error: max_cardinality > num_assets\n";
+		return false;
+	}
+
+	if (portfolio::min_cardinality < 1)
+	{
+		std::cout << "Error: min_cardinality < 1\n";
+		return false;
+	}
+
+	if (algo.compare("asms") == 0)
+		anticipation = true;
+
+	std::string path = "../data/" + instance + "/" + instance + "-" + boost::lexical_cast<std::string>(portfolio::num_assets)
+			+ "-" + boost::lexical_cast<std::string>(portfolio::periods)
+			+ "-" + boost::lexical_cast<std::string>(portfolio::periodicity) + "-";
+	if (portfolio::severity != 10)
+		path += "0";
+	path += boost::lexical_cast<std::string>(portfolio::severity);
+
+	portfolio::sequence_mean_covar = load_benchmark_data(path);
+
+
+	portfolio::init_portfolio();
+
+	// We use uniform crossover with probability one
+	xover_op::uniform_prob_op[0] = 1.0f;
+
+	// We decide randomly which mutation operator to apply
+	mutation_op::uniform_prob_op[0] = .25f;
+	mutation_op::uniform_prob_op[1] = .25f;
+	mutation_op::uniform_prob_op[2] = .25f;
+	mutation_op::uniform_prob_op[3] = .25f;
+
+	// Standard KF parameters initalization
+	Kalman_params::F = Eigen::MatrixXd::Zero(4,4);
+	Kalman_params::F << 1.0, 0.0, 1.0, 0.0,
+						0.0, 1.0, 0.0, 1.0,
+						0.0, 0.0, 1.0, 0.0,
+						0.0, 0.0, 0.0, 1.0;
+	Kalman_params::H = Eigen::MatrixXd::Zero(2,4);
+	Kalman_params::H << 1.0, 0.0, 0.0, 0.0,
+						0.0, 1.0, 0.0, 0.0;
+
+	// Compute the min and max return over investment, risk, and cost among all available assets, relative to the current period.
+	portfolio::max_ROI = portfolio::get_max_ROI(portfolio::current_period);
+	portfolio::max_risk = portfolio::get_max_risk(portfolio::current_period);
+	portfolio::min_ROI = portfolio::get_min_ROI(portfolio::current_period);
+	portfolio::min_risk = 0.0;
+	portfolio::max_cost = compute_max_cost();
+
+	// We shall start from zero
+	portfolio::current_investment = Eigen::VectorXd::Zero(portfolio::num_assets);
+
+	double nominal_min_ROI = portfolio::min_ROI*portfolio::current_wealth;
+	portfolio::min_ROI = (nominal_min_ROI - portfolio::max_cost)/portfolio::current_wealth;
+
+	// Reference points properly transformed
+	solution::ref_point.first = linear_transform(solution::ref_point.first, portfolio::min_ROI, portfolio::max_ROI);
+	solution::ref_point.second = linear_transform(solution::ref_point.second, portfolio::min_risk, portfolio::max_risk);
+
+	return true;
+}
+
+int main (int argc, char** argv)
+{
+	srand((unsigned)time(0));
+
+	bool loaded = load_params(argc, argv);
+	if (!loaded)
+	{
+		std::cout << "Exiting...\n";
+		return 0;
+	}
+
+	investments.resize(portfolio::periods);
+	portfolio::current_wealth = portfolio::total_wealth;
+
+	// Running the experiments.
+	for (unsigned int e = exp_id; e <= (exp_id + trials) - 1; ++e)
+	{
+		unsigned int seed_initial_pop = (unsigned)time(0);
+		unsigned int seed_experiment = rand();
+
+
+		portfolio::init_portfolio();
+		for (unsigned int i = 0; i < solution::historical_populations.size(); ++i)
+			for (unsigned int j = 0; j < solution::historical_populations[i].size(); ++j)
+			{
+				delete solution::historical_populations[i][j];
+				solution::historical_populations[i][j] = NULL;
+			}
+
+		solution::historical_populations.clear();
+		solution::historical_populations.resize(0);
+		solution::historical_anticipative_decisions.clear();
+		solution::historical_anticipative_decisions.resize(0);
+
+		portfolio::current_investment = Eigen::VectorXd::Zero(portfolio::num_assets);
+		run_algorithm(e, seed_initial_pop, seed_experiment, pop_size, max_iter);
+	}
+
+	return 0;
+}
+
+void print_portfolio(sol* w, std::ostream &out)
+{
+	out << w->P.ROI << " "
+		<< w->P.risk << " "
+		<< w->P.ROI_observed << " "
+		<< w->P.risk_observed << " "
+		<< w->rank_ROI << " "
+		<< w->rank_risk << " "
+		<< w->epsilon_feasibility.first << " "
+		<< w->epsilon_feasibility.second << " "
+		<< w->prediction_error << " "
+		<< w->alpha << " "
+		<< w->P.current_cost << " "
+		<< w->P.nominal_ROI << " "
+		<< w->pred_hv << std::endl;
+}
+
+void print_pop(std::vector<sol*> &P, std::ostream &out)
+{
+	sort_per_objective(P,0);
+	for (unsigned int p = 0; p < P.size(); ++p)
+		print_portfolio(P[p], out);
+}
+
+void print_pop(std::vector<sol*> &P, std::pair<unsigned int, double> error, std::ostream &out)
+{
+
+	out << P[error.first]->P.ROI << " "
+		<< P[error.first]->P.risk << " "
+		<< P[error.first]->P.ROI_observed << " "
+		<< P[error.first]->P.risk_observed << " "
+		<< P[error.first]->rank_ROI << " "
+		<< P[error.first]->rank_risk << " "
+		<< P[error.first]->epsilon_feasibility.first << " "
+		<< P[error.first]->epsilon_feasibility.second << " "
+		<< error.second << " "
+		<< P[error.first]->alpha << " "
+		<< P[error.first]->P.current_cost << " "
+		<< P[error.first]->P.nominal_ROI << " "
+		<< P[error.first]->pred_hv	<< std::endl;
+	save_portfolio(P[error.first]->P,out);
+}
+
+
+std::vector<std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > > write_statistics(std::vector<sol*> &P, std::ostream &out, unsigned int t)
+{
+
+	float mean_Pareto_rank = 0.0f;
+	float mean_cd = 0.0f;
+	float mean_Delta_S = 0.0f;
+	float mean_return = 0.0f;
+	float mean_risk = 0.0f;
+	float mean_return_obs = 0.0f;
+	float mean_risk_obs = 0.0f;
+	float mean_cardinality = 0.0f;
+	float mean_entropy = 0.0f;
+	float mean_alpha = 0.0f;
+	float mean_anticipation_rate = 0.0f;
+	float mean_prediction_error = 0.0f;
+	float mean_cid_ROI = 0.0f;
+	float mean_cid_risk = 0.0f;
+	float mean_cid = 0.0f;
+	float mean_epsilon_feasibility_ROI = 0.0f;
+	float mean_epsilon_feasibility_risk = 0.0f;
+	float mean_current_cost = 0.0f;
+	float mean_nominal_ROI = 0.0f;
+	float mean_turnover = 0.0f;
+	float mean_pred_hv = 0.0f;
+
+
+	double min_error = 0.0, max_error = 0.0;
+	unsigned min_error_index = 0, max_error_index = 0;
+	double min_uncertainty = 0.0, max_uncertainty = 0.0;
+	unsigned min_uncertainty_index = 0, max_uncertainty_index = 0;
+
+	for (unsigned int p = 0; p < P.size(); ++p)
+	{
+		if (P[p]->cd < 99999999.9f)
+			mean_cd += P[p]->cd;
+
+		mean_Delta_S += P[p]->Delta_S;
+		mean_return += P[p]->P.ROI;
+		mean_risk += P[p]->P.risk;
+		mean_return_obs += P[p]->P.ROI_observed;
+		mean_risk_obs += P[p]->P.risk_observed;
+		mean_cardinality += P[p]->P.investment.count();
+		mean_entropy += portfolio::normalized_Entropy(P[p]->P);
+		mean_alpha += P[p]->alpha;
+		mean_anticipation_rate += P[p]->anticipation_rate;
+		mean_epsilon_feasibility_ROI += P[p]->epsilon_feasibility.first;
+		mean_epsilon_feasibility_risk += P[p]->epsilon_feasibility.second;
+		mean_current_cost += P[p]->P.current_cost;
+		mean_nominal_ROI += P[p]->P.nominal_ROI;
+		mean_turnover += P[p]->P.turnover_rate;
+		mean_pred_hv += P[p]->pred_hv;
+
+		double error = P[p]->P.obs_error;
+		double uncertainty = 1.0 - P[p]->alpha;
+
+		if (P[p]->Pareto_front == 0)
+		{
+			if (error < min_error)
+			{
+				min_error_index = p;
+				min_error = error;
+			}
+			else if (error > max_error)
+			{
+				max_error_index = p;
+				max_error = error;
+			}
+
+			if (uncertainty < min_uncertainty)
+			{
+				min_uncertainty_index = p;
+				min_uncertainty = uncertainty;
+			}
+			else if (uncertainty > max_uncertainty)
+			{
+				max_uncertainty_index = p;
+				max_uncertainty = uncertainty;
+			}
+		}
+
+		mean_prediction_error += error;
+		mean_cid_ROI += P[p]->P.cid_ROI;
+		mean_cid_risk += P[p]->P.cid_risk;
+		mean_cid += P[p]->P.cid;
+	}
+
+	mean_Pareto_rank = solution::num_fronts;
+	mean_Delta_S /= P.size();
+	mean_Pareto_rank /= P.size();
+	mean_cd /= P.size();
+	mean_return /= P.size();
+	mean_risk /= P.size();
+	mean_return_obs /= P.size();
+	mean_risk_obs /= P.size();
+	mean_cardinality /= P.size();
+	mean_entropy /= P.size();
+	mean_alpha /= P.size();
+	mean_anticipation_rate /= P.size();
+	mean_prediction_error /= P.size();
+	mean_cid_ROI += P.size();
+	mean_cid_risk += P.size();
+	mean_cid += P.size();
+	mean_epsilon_feasibility_ROI /= P.size();
+	mean_epsilon_feasibility_risk /= P.size();
+	mean_current_cost /= P.size();
+	mean_nominal_ROI /= P.size();
+	mean_turnover /= P.size();
+	mean_pred_hv /= P.size();
+
+
+	out << mean_Pareto_rank << " " << mean_cd	<< " " << mean_Delta_S << " " << mean_return << " " << mean_risk << " "
+		<< mean_return_obs << " " << mean_risk_obs << " " << spread(P) << " " << coverage(P) << " " << mean_cardinality << " " << mean_entropy << " "
+		<< coherence(P) << " " << mean_epsilon_feasibility_ROI << " " << mean_epsilon_feasibility_risk <<  " "
+		<< mean_alpha << " " << mean_anticipation_rate << " " << mean_prediction_error << " " << mean_cid_ROI << " " << mean_cid_risk << " " << mean_cid
+		<< " " << mean_current_cost << " " << portfolio::total_incurred_cost << " " << mean_turnover << " " << mean_nominal_ROI  << " "
+		<< portfolio::current_wealth << " " << hypervolume(P, solution::ref_point.first, solution::ref_point.second) << " " << mean_pred_hv;
+
+	if (!(P[0]->anticipation == false && P[0]->epsilon_feasibility.first == 0.0 && P[0]->epsilon_feasibility.second == 0.0))
+		out << " " << observed_hypervolume(P, 1000, solution::ref_point.first, solution::ref_point.second);
+	else out << " " << 0.0;
+	out << "\n";
+
+	std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > error_pair (std::pair<unsigned, unsigned>(min_error_index,max_error_index),std::pair<double, double>(min_error,max_error));
+	std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > uncertainty_pair (std::pair<unsigned, unsigned>(min_uncertainty_index,max_uncertainty_index),std::pair<double, double>(min_uncertainty,max_uncertainty));
+	std::vector<std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > > res;
+	res.push_back(error_pair);
+	res.push_back(uncertainty_pair);
+
+	return res;
+}
+
+void save_portfolio(const portfolio &P, std::ostream &out)
+{
+	for (unsigned int i = 0; i < portfolio::num_assets-1; ++i)
+			out << std::setiosflags(std::ios::fixed) << std::setprecision(2) << P.investment(i) << " ";
+	out << std::setiosflags(std::ios::fixed) << std::setprecision(2) << P.investment(portfolio::num_assets-1);
+	out << std::endl;
+}
+
+void save_portfolio_stochastic_obj(const portfolio &P, std::ostream &out)
+{
+	out << P.ROI << " " << P.risk
+		<< " " << P.covar(0,0) << " " << P.covar(1,1)
+		<< " " << P.covar(0,1);
+	out << std::endl;
+}
+
+void save_results(unsigned int e, unsigned int seed_initial_pop,
+	unsigned int experiment_seed, std::vector<sol*> &P, unsigned int t)
+{
+
+
+	// Filename for storing final population data
+	std::stringstream experiment_id; experiment_id << e;
+	std::stringstream card; card << portfolio::max_cardinality;
+	std::stringstream period; period << t;
+
+	std::string file_path = "exp_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+
+	std::ofstream arquivo(file_path.c_str(), std::ios::out);
+	arquivo << seed_initial_pop << " " << experiment_seed << std::endl;
+	std::vector<std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > > res = write_statistics(P, arquivo, t);
+	std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > error = res[0];
+	std::pair<std::pair<unsigned, unsigned>, std::pair<double, double> > uncertainty = res[1];
+	arquivo.close();
+
+	file_path = "pop_" + instance + "_card" + card.str() + "_" + algo + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+	arquivo.open(file_path.c_str(), std::ios::out);
+	print_pop(P, arquivo);
+	arquivo.close();
+
+	file_path = "lowest_error_port_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+	arquivo.open(file_path.c_str(), std::ios::out);
+	print_pop(P, std::pair<unsigned int, double>(error.first.first,error.second.first), arquivo);
+	arquivo.close();
+
+	file_path = "lowest_uncertainty_port_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+	arquivo.open(file_path.c_str(), std::ios::out);
+	print_pop(P, std::pair<unsigned int, double>(uncertainty.first.first,uncertainty.second.first), arquivo);
+	arquivo.close();
+
+	file_path = "highest_error_port_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+	arquivo.open(file_path.c_str(), std::ios::out);
+	print_pop(P, std::pair<unsigned int, double>(error.first.second,error.second.second), arquivo);
+	arquivo.close();
+
+	file_path = "highest_uncertainty_port_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+	arquivo.open(file_path.c_str(), std::ios::out);
+	print_pop(P, std::pair<unsigned int, double>(uncertainty.first.second,uncertainty.second.second), arquivo);
+	arquivo.close();
+
+}
+
+void run_algorithm(unsigned int e, unsigned int initial_pop_seed,
+	unsigned int experiment_seed, unsigned int pop_size, unsigned int generations)
+{
+	srand(initial_pop_seed);
+
+	portfolio::current_period = 0;
+	portfolio::total_incurred_cost = 0.0;
+	portfolio::current_wealth = portfolio::total_wealth;
+
+	xover_op::probability = xover_op::uniform_prob_op;
+	mutation_op::probability = mutation_op::uniform_prob_op;
+
+	std::vector<sol*> active_population;
+	for (unsigned int p = 0; p < pop_size; ++p)
+		active_population.push_back(new sol());
+
+	srand(experiment_seed);
+
+	std::stringstream experiment_id; experiment_id << e;
+	std::stringstream card; card << portfolio::max_cardinality;
+	std::string filename;
+
+	do
+	{
+
+		portfolio::max_ROI = portfolio::get_max_ROI(portfolio::current_period);
+		portfolio::max_risk = portfolio::get_max_risk(portfolio::current_period);
+		portfolio::min_ROI = portfolio::get_min_ROI(portfolio::current_period);
+		portfolio::min_risk = 0.0;
+
+		portfolio::max_cost = compute_max_cost();
+
+		solution::ref_point.first = linear_transform(0.0, portfolio::min_ROI, portfolio::max_ROI);
+		solution::ref_point.second = linear_transform(1.0, portfolio::min_risk, portfolio::max_risk);
+
+		double nominal_min_ROI = portfolio::min_ROI*portfolio::current_wealth;
+		double adjusted_min_ROI = nominal_min_ROI - portfolio::max_cost;
+		portfolio::min_ROI = adjusted_min_ROI/portfolio::current_wealth;
+
+		save_results(e, initial_pop_seed, experiment_seed, active_population, portfolio::current_period);
+
+		std::stringstream period; period << portfolio::current_period;
+
+		if (portfolio::current_period  > 0)
+		for (unsigned int p = 0; p < active_population.size(); ++p)
+			solution::compute_efficiency(active_population[p]);
+
+		unsigned int num_classes = fast_nondominated_sort(active_population);
+		for (unsigned int k = 0; k < num_classes; ++k)
+			crowding_distance(active_population, k);
+
+		filename = "saida-pop_" + instance + "_card" + card.str() + "_" + algo + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+		std::ofstream arquivo_geracao(filename.c_str(), std::ios::app);
+		print_pop(active_population, arquivo_geracao);
+		arquivo_geracao.close();
+
+		Eigen::VectorXd acc_investments(portfolio::num_assets);
+		for (unsigned int i = 0; i < active_population.size(); ++i)
+			acc_investments += active_population[i]->P.investment;
+		acc_investments /= active_population.size();
+
+		investments[portfolio::current_period].push_back(acc_investments); acc_investments = sum(investments[portfolio::current_period])/investments[portfolio::current_period].size();
+
+		unsigned int K = (portfolio::num_assets < 10) ? portfolio::num_assets : 10;
+		std::vector<std::pair<unsigned,double> > top_k = portfolio::top_k_investments(acc_investments, K);
+
+		filename = "top_k_" + instance + "_card" + card.str() + "_" + algo  + "e" + experiment_id.str() + ".dat";
+
+		std::ofstream file_top(filename.c_str(), std::ios::app);
+
+		for (unsigned k = 0; k < K-1; ++k)
+			file_top << top_k[k].first << " " << top_k[k].second << " ";
+		file_top << top_k[K-1].first << " " << top_k[K-1].second << std::endl;
+		file_top.close();
+
+		for (unsigned int p = 0; p < active_population.size(); ++p)
+			portfolio::observed_error(active_population[p]->P, portfolio::current_period);
+
+		filename = "stats_" + instance + "_card" + card.str() + "_" + algo + "_id" + experiment_id.str() + ".dat";
+		std::ofstream experiment_file(filename.c_str(), std::ios::app);
+		write_statistics(active_population, experiment_file, portfolio::current_period);
+		experiment_file.close();
+
+		for (unsigned int g = 1; g <= generations; ++g)
+		{
+
+			if (algo == "sms" || algo == "asms")
+			{
+				// ASMS-EMOA is a steady state algorithm
+				for (unsigned int s = 0; s < active_population.size(); ++s)
+					ASMS_EMOA_iteration(active_population, solution::ref_point.first, solution::ref_point.second, portfolio::current_period, anticipation);
+			}
+			else if (algo == "nsga2")
+				// NSGA-II is a generational algorithm
+				NSGA2_iteration(active_population, portfolio::current_period);
+
+			//if (g == generations)
+			for (unsigned int i = 0; i < active_population.size(); ++i)
+			{
+				active_population[i]->anticipation = false;
+				if (Kalman_params::window_size == 0)
+				{
+					active_population[i]->P.ROI_prediction = active_population[i]->P.ROI;
+					active_population[i]->P.risk_prediction = active_population[i]->P.risk;
+				}
+
+			}
+
+			filename = "stats_" + instance + "_card" + card.str() + "_" + algo + "_id" + experiment_id.str() + ".dat";
+			std::ofstream experiment_file(filename.c_str(), std::ios::app);
+			write_statistics(active_population, experiment_file, portfolio::current_period);
+			experiment_file.close();
+
+			float current_hypervolume = hypervolume(active_population, solution::ref_point.first, solution::ref_point.second);
+			float observed_hypv = observed_hypervolume(active_population, 1000, solution::ref_point.first, solution::ref_point.second);
+
+			std::cout << "current/observed hypervolume [" << e << "][" << portfolio::current_period << "][" << g << "]: ("
+					<< current_hypervolume << ", " << observed_hypv << ")" << std::endl;
+
+			compute_ranks(active_population);
+			sort_per_objective(active_population,0);
+			std::string file_path = "pop_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "t_" + period.str() + "_end.dat";
+			std::ofstream best_population_file(file_path.c_str(), std::ios::out);
+
+			for (unsigned int i = 0; i < active_population.size(); ++i)
+				save_portfolio_stochastic_obj(active_population[i]->P,best_population_file);
+			best_population_file.close();
+
+			std::stringstream generation_id; generation_id << g;
+			std::stringstream period; period << portfolio::current_period;
+			filename = "saida-pop_" + instance + "_card" + card.str() + "_" + algo + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+			std::ofstream arquivo_geracao(filename.c_str(), std::ios::app);
+			print_pop(active_population, arquivo_geracao);
+			arquivo_geracao.close();
+		}
+
+
+		// Pushing the population found at time t into the history
+		std::vector<sol*> previous_population;
+		for (unsigned int i = 0; i < active_population.size(); ++i)
+			previous_population.push_back(new sol(active_population[i]));
+		solution::historical_populations.push_back(previous_population);
+
+		// Sorts the population according to ROI
+		std::sort(solution::historical_populations.back().begin(),solution::historical_populations.back().end(),cmp_ROI_ptr);
+		std::sort(active_population.begin(),active_population.end(),cmp_ROI_ptr);
+
+
+		std::vector<double> pred_hypervolume(active_population.size());
+		double best_hyp_value = std::numeric_limits<float>::min();
+
+		unsigned int best_decision;
+		if (Kalman_params::window_size > 0 && DM.compare("flexibility") == 0)
+		{
+
+			// Identifies the best candidate decision maximizing the future hypervolume
+			best_decision = 0;
+
+			// Obtains the anticipative population
+			std::vector<sol*> anticipative_population;
+			if (portfolio::current_period > 0)
+				anticipative_population = anticipatory_learning_dec_space(active_population, portfolio::current_period);
+			else
+				anticipative_population = active_population;
+
+
+			double min_error = std::numeric_limits<float>::max();
+			double max_error = 0.0;
+			double min_alpha = 1.0, max_alpha = 0.0;
+
+			for (unsigned int j = 0; j < anticipative_population.size(); ++j)
+			{
+
+				portfolio::KF_prediction_obj_space(anticipative_population[j]->P, 1);
+
+				anticipative_population[j]->prediction_error = anticipative_population[j]->P.kalman_state.error;
+
+				if (anticipative_population[j]->alpha < min_alpha)
+					min_alpha = anticipative_population[j]->alpha;
+				else if (anticipative_population[j]->alpha > max_alpha)
+					max_alpha = anticipative_population[j]->alpha;
+
+				if (anticipative_population[j]->prediction_error < min_error)
+					min_error = anticipative_population[j]->prediction_error;
+				else if (anticipative_population[j]->prediction_error > max_error)
+					max_error = anticipative_population[j]->prediction_error;
+			}
+
+			for (unsigned int i = 0; i < active_population.size(); ++i)
+			{
+				Eigen::VectorXd candidate_decision = active_population[i]->P.investment;
+
+				for (unsigned int j = 0; j < anticipative_population.size(); ++j)
+					anticipatory_learning_obj_space(active_population[j], anticipative_population[j], candidate_decision, min_error, max_error, min_alpha, max_alpha, portfolio::current_period);
+
+
+				unsigned int num_classes = fast_nondominated_sort(anticipative_population);
+				for (unsigned int k = 0; k < num_classes; ++k)
+						crowding_distance(anticipative_population, k);
+
+				pred_hypervolume[i] = hypervolume(anticipative_population, solution::ref_point.first, solution::ref_point.second);
+				active_population[i]->pred_hv = pred_hypervolume[i];
+
+				std::cout << "pred_hv[" << i << "](" << pred_hypervolume[i] << ")x";
+				epsilon_feasible(active_population[i]);
+				double weighted_pred_hypv = pred_hypervolume[i];//*active_population[i]->epsilon_feasibility.first*active_population[i]->epsilon_feasibility.second;
+
+				std::cout << "(" << active_population[i]->epsilon_feasibility.first << ")x("
+						  << active_population[i]->epsilon_feasibility.second << ") = " << weighted_pred_hypv << std::endl;
+
+				if (weighted_pred_hypv > best_hyp_value)
+				{
+					best_hyp_value = weighted_pred_hypv;
+					best_decision = i;
+					filename = "saida-anticipative_pop_" + instance + "_card" + card.str() + "_" + algo + "_id" + experiment_id.str() + "_t" + period.str() + ".dat";
+					arquivo_geracao.open(filename.c_str(), std::ios::out);
+					print_pop(anticipative_population, arquivo_geracao);
+					arquivo_geracao.close();
+				}
+
+				std::sort(anticipative_population.begin(),anticipative_population.end(),cmp_ROI_ptr);
+			}
+		}
+		else if (DM.compare("median") == 0)
+		{
+			std::cout << "Median point decision maker\n";
+			// Median decision maker. This assumes the population is already
+			// sorted by the first objective function. We know that this is the case
+			// because we sorted the population before entering the DM scope code.
+			best_decision = active_population.size() % 2 == 0 ? active_population.size() / 2 : (active_population.size() + 1) / 2;
+			epsilon_feasible(active_population[best_decision]);
+		}
+		else if (DM.compare("random") == 0)
+		{
+			std::cout << "Random decision maker\n";
+			// Random decision maker
+			best_decision = floor(active_population.size()*uniform_zero_one());
+			epsilon_feasible(active_population[best_decision]);
+		}
+
+		std::cout << std::endl;
+
+		std::cout << "\nApplying best decision -> ";
+		std::cout << "P[" << best_decision << "]: pred_hypv=" << best_hyp_value;
+		// Updating incurred transaction cost and wealth
+		portfolio::update_cost_and_wealth(active_population[best_decision]->P, portfolio::current_period);
+		std::cout << ", ROI_observed=" << active_population[best_decision]->P.ROI_observed << ", nominal_ROI="
+				<< active_population[best_decision]->P.nominal_ROI << ", incurred_cost=" << active_population[best_decision]->P.current_cost
+				 << ", total_incurred_cost=" << portfolio::total_incurred_cost << ", current_wealth=" << portfolio::current_wealth << std::endl;
+
+		// "Applies" the best decision at the current investment environment
+		portfolio::current_investment = active_population[best_decision]->P.investment;
+		solution::historical_anticipative_decisions.push_back(new sol(active_population[best_decision]));
+
+		if (portfolio::current_period == 0)
+			solution::predicted_anticipative_decision = new sol(active_population[best_decision]);
+		else
+		{
+
+			delete solution::predicted_anticipative_decision;
+			solution::predicted_anticipative_decision = new sol(anticipatory_learning_dec_space(active_population[best_decision], portfolio::current_period));
+			unsigned int initial_t = (portfolio::current_period > Kalman_params::window_size) ? (portfolio::current_period - Kalman_params::window_size) : 0;
+			portfolio::observe_state(solution::predicted_anticipative_decision->P, 20, initial_t, portfolio::current_period + 1);
+		}
+
+		portfolio::current_period++;
+
+		// Saves the decision taken
+		std::string file_path = "decision_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "t_" + period.str() + "_obj.dat";
+		std::ofstream decision_file(file_path.c_str(), std::ios::out);
+		save_portfolio_stochastic_obj(active_population[best_decision]->P, decision_file); decision_file.close();
+
+		file_path = "decision_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "t_" + period.str() + "_stats.dat";
+		decision_file.open(file_path.c_str(), std::ios::out);
+		print_portfolio(active_population[best_decision], decision_file); decision_file.close();
+
+		file_path = "decision_" + instance + "_card" + card.str() + "_" + algo  + "_id" + experiment_id.str() + "t_" + period.str() + "_dec.dat";
+		decision_file.open(file_path.c_str(), std::ios::out);
+		save_portfolio(active_population[best_decision]->P, decision_file); decision_file.close();
+
+
+		if (portfolio::current_period == portfolio::periods-1)
+		{
+			std::cout << "Ending experiment...\n";
+			save_results(e, initial_pop_seed, experiment_seed, active_population, portfolio::current_period);
+
+			for (unsigned int p = 0; p < active_population.size(); ++p)
+			{
+				delete active_population[p];
+				active_population[p] = NULL;
+			}
+			active_population.clear();
+			return;
+		}
+
+		std::cout << "Re-starting...\n";
+		portfolio::compute_statistics(portfolio::current_period);
+
+	} while (true);
+
+}

--- a/legacy-cpp-v2/source/mutation_operators.cpp
+++ b/legacy-cpp-v2/source/mutation_operators.cpp
@@ -1,0 +1,169 @@
+#include <map>
+#include <ctime>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+#include <cstdlib>
+#include <iostream>
+#include <algorithm>
+
+#include "../headers/learning_operators.h"
+#include "../headers/mutation_operators.h"
+#include "../headers/asms_emoa.h"
+#include "../headers/utils.h"
+
+// Pointers array for functions implementing mutation operators
+unsigned int mutation_op::num = 4;
+mutation_operator_ptr mutation_op::_operator[4] = {&modify_investment, &modify_portfolio, &raise_entropy, &lower_entropy};
+
+/* Decreases investment
+ * Decreases allocation for a given asset.
+ */
+void reduce_investment(sol *offspring, unsigned int asset, float min, float max)
+{
+	float fator = min + uniform_zero_one()*(max - min);
+
+	if (offspring->P.investment(asset) > .0)
+		offspring->P.investment(asset) *= fator;
+	offspring->anticipation = false;
+	apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+}
+
+/* Raises investment
+ * Raises allocation for a given asset.
+ */
+void raise_investment(sol *offspring, unsigned int asset, float min, float max)
+{
+	float fator = 1.0 + (min + uniform_zero_one()*(max - min));
+
+	if (offspring->P.investment(asset) > .0)
+		offspring->P.investment(asset) *= fator;
+	offspring->anticipation = false;
+	apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+}
+
+/* Modify investment
+ *  Randomly modifies investment, according to a mutation rate p
+ */
+void modify_investment(sol *offspring, float p)
+{
+	for (int i = 0; i < offspring->P.investment.rows(); ++i)
+	{
+		if (offspring->P.investment(i) > 0.0)
+			if (uniform_zero_one() < p)
+			{
+				if (uniform_zero_one() < .5)
+					raise_investment(offspring,i, 0.05, 0.25);
+				else
+					reduce_investment(offspring,i, 0.05, 0.25);
+			}
+	}
+
+	offspring->anticipation = false;
+}
+
+void remove_asset(sol *offspring, unsigned int asset)
+{
+	offspring->P.investment(asset) = 0.0;
+	offspring->P.cardinality -= 1;
+	offspring->anticipation = false;
+	apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+}
+
+void add_asset(sol *offspring, unsigned int asset)
+{
+	float investimento_uniforme = 1.0/(portfolio::card(offspring->P) + 1);
+	float u = -.1 + uniform_zero_one()*.2;
+	offspring->P.investment(asset) = (1 + u)*investimento_uniforme;
+	offspring->P.cardinality += 1;
+	offspring->anticipation = false;
+	apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+}
+
+/* Modify investment
+ *  Randomly modifies the portfolio, according to a given mutation rate p.
+ */
+void modify_portfolio(sol *offspring, float p)
+{
+	unsigned card = offspring->P.investment.count();
+
+	offspring->P.cardinality = card;
+
+
+	for (int i = 0; i < offspring->P.investment.rows(); ++i)
+	{
+		if (uniform_zero_one() < p)
+		{
+			if (uniform_zero_one() < 0.5 && offspring->P.investment(i) > 0.0 && card > portfolio::min_cardinality)
+				remove_asset(offspring,i);
+			else if (card < portfolio::max_cardinality)
+				add_asset(offspring,i);
+		}
+	}
+
+	bool cardinality = false;
+	while (portfolio::card(offspring->P) < portfolio::min_cardinality)
+	{
+		for (unsigned c = portfolio::card(offspring->P); c < portfolio::min_cardinality; ++c)
+		{
+			add_asset(offspring,rand()%portfolio::num_assets);
+			if (static_cast<unsigned>(offspring->P.investment.count()) > portfolio::min_cardinality)
+				prune_threshold(offspring, portfolio::min_hold);
+			cardinality = true;
+		}
+
+	}
+
+	offspring->anticipation = false;
+
+	if (!cardinality)
+		apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+
+}
+
+void prune_threshold(sol *offspring, float l)
+{
+	normalize(offspring->P.investment);
+
+	bool removed = false;
+	for (int i = 0; i < offspring->P.investment.rows(); ++i)
+	{
+		unsigned int card = offspring->P.investment.count();
+		if (offspring->P.investment(i) < l && card > portfolio::min_cardinality)
+		{
+			remove_asset(offspring,i);
+			removed = true;
+		}
+	}
+
+	if (removed)
+		normalize(offspring->P.investment);
+	offspring->anticipation = false;
+
+}
+
+void raise_entropy(sol *offspring, float dummy)
+{
+	unsigned int max_elem = 0;
+	for (int i = 1; i < offspring->P.investment.rows(); ++i)
+		if (offspring->P.investment(i) > offspring->P.investment(max_elem))
+			max_elem = i;
+	reduce_investment(offspring,max_elem, 0.05, 0.25);
+	apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+
+	offspring->anticipation = false;
+}
+
+void lower_entropy(sol *offspring, float dummy)
+{
+	unsigned int max_elem = 0;
+	for (int i = 1; i < offspring->P.investment.rows(); ++i)
+		if (offspring->P.investment(i) > offspring->P.investment(max_elem))
+			max_elem = i;
+	raise_investment(offspring,max_elem, 0.05, 0.25);
+	apply_threshold(offspring->P.investment, portfolio::min_hold, portfolio::max_hold);
+
+	offspring->anticipation = false;
+}
+
+

--- a/legacy-cpp-v2/source/portfolio.cpp
+++ b/legacy-cpp-v2/source/portfolio.cpp
@@ -1,0 +1,333 @@
+#include "../headers/utils.h"
+#include "../headers/portfolio.h"
+#include "../headers/statistics.h"
+
+#include <list>
+#include <cmath>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <strstream>
+#include <algorithm>
+
+#include <boost/assign.hpp>
+#include <boost/foreach.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/range/algorithm/copy.hpp>
+#include <boost/range/adaptor/reversed.hpp>
+#include <boost/math/constants/constants.hpp>
+
+using namespace std;
+using namespace boost;
+
+Eigen::MatrixXd portfolio::theoretical_covariance;
+Eigen::VectorXd portfolio::theoretical_mean_ROI;
+std::vector<std::pair<Eigen::VectorXd,Eigen::MatrixXd> > portfolio::sequence_mean_covar;
+Eigen::VectorXd portfolio::current_investment;
+
+unsigned int portfolio::samples_per_portfolio;
+unsigned int portfolio::min_cardinality;
+unsigned int portfolio::max_cardinality;
+unsigned int portfolio::current_period;
+unsigned int portfolio::periodicity;
+unsigned int portfolio::num_assets;
+unsigned int portfolio::severity;
+unsigned int portfolio::periods;
+
+double portfolio::min_hold;
+double portfolio::max_hold;
+double portfolio::brokerage_commission;
+double portfolio::brokerage_fee;
+double portfolio::total_wealth;
+double portfolio::current_wealth;
+double portfolio::total_incurred_cost;
+double portfolio::max_ROI;
+double portfolio::max_risk;
+double portfolio::max_cost;
+double portfolio::min_ROI;
+double portfolio::min_risk;
+double portfolio::min_cost;
+
+
+std::vector<std::pair<unsigned,double> > portfolio::top_k_investments (const Eigen::VectorXd& investment, unsigned int K)
+{
+	std::list<std::pair<unsigned,double> > sequence;
+	std::list<std::pair<unsigned,double> >::iterator kth_element;
+
+	for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+	{
+		if (investment(i) > 0.0)
+		{
+			if (sequence.size() == 0)
+				sequence.push_back(std::pair<unsigned,double>(i,investment(i)));
+			else
+			{
+				std::list<std::pair<unsigned,double> >::iterator it = sequence.begin();
+				for (; it != sequence.end(); ++it)
+				{
+
+					if (investment(i) > it->second)
+					{
+						sequence.insert(it,std::pair<unsigned,double>(i,investment(i)));
+						break;
+					}
+				}
+				if (it == sequence.end())
+					sequence.push_back(std::pair<unsigned,double>(i,investment(i)));
+			}
+		}
+		else
+			sequence.push_back(std::pair<unsigned,double>(i,0.0));
+	}
+
+	std::list<std::pair<unsigned,double> >::iterator it = sequence.begin();
+	for (unsigned int k = 0; it != sequence.end(); ++it, ++k)
+		if (k == K)
+		{
+			kth_element = it;
+			break;
+		}
+
+	return std::vector<std::pair<unsigned,double> > (sequence.begin(), kth_element);
+}
+
+std::vector<std::pair<Eigen::VectorXd,Eigen::MatrixXd> > load_benchmark_data(const std::string& path)
+{
+	std::vector<std::pair<Eigen::VectorXd,Eigen::MatrixXd> > sequence;
+
+	std::string mean_path = path + "-means.dat";
+	std::string covar_path = path + "-covar.dat";
+	std::cout << mean_path << std::endl << covar_path << std::endl;
+	std::ifstream means_file(mean_path.c_str(), std::ios::in);
+	std::ifstream covar_file(covar_path.c_str(), std::ios::in);
+
+	for (unsigned int t = 0; t < portfolio::periods; ++t)
+	{
+		Eigen::VectorXd mean(portfolio::num_assets);
+		Eigen::MatrixXd covar(portfolio::num_assets,portfolio::num_assets);
+
+		for (unsigned int i = 0; i < portfolio::num_assets; ++i)
+		{
+			means_file >> mean(i);
+
+			for (unsigned int j = 0; j < portfolio::num_assets; ++j)
+				covar_file >> covar(i,j);
+		}
+
+		bool valid_covar = check_covar(covar);
+		if (!valid_covar)
+		{
+			std::cout << "Invalid covar!\n";
+			system("pause");
+		}
+
+		std::pair<Eigen::VectorXd,Eigen::MatrixXd> mc(mean,covar);
+		sequence.push_back(mc);
+	}
+
+	means_file.close();
+	covar_file.close();
+
+	return sequence;
+}
+
+Eigen::VectorXd portfolio::estimate_assets_mean_ROI(const Eigen::MatrixXd &returns_data)
+{
+	return returns_data.colwise().mean();
+}
+
+void portfolio::estimate_covariance(const Eigen::VectorXd &mean_ROI, const Eigen::MatrixXd &returns_data, Eigen::MatrixXd &covariance)
+{
+	covariance.resize(portfolio::num_assets,portfolio::num_assets);
+	covariance = (returns_data.rowwise() - mean_ROI.transpose()).transpose()*(returns_data.rowwise() - mean_ROI.transpose())/(returns_data.rows()-1.0);
+}
+
+double portfolio::compute_ROI(portfolio &P, const Eigen::VectorXd &mean_ROI)
+{
+	return //log(P.investment.transpose()*mean_ROI);
+			P.investment.transpose()*mean_ROI;
+}
+
+double portfolio::compute_risk(portfolio &P, const Eigen::MatrixXd &covariance)
+{
+	return P.investment.transpose()*covariance*P.investment;
+}
+
+void portfolio::observe_state(portfolio &w, unsigned int N, unsigned int initial_t, unsigned int current_t)
+{
+
+	normalize(w.investment);
+	double mean_ROI = 0.0, mean_risk = 0.0;
+
+	w.S.samples.clear();
+	w.S.samples.resize(0);
+
+	for (unsigned int t = initial_t; t <= current_t; ++t)
+	{
+		Eigen::VectorXd mean = portfolio::sequence_mean_covar[t].first;
+		Eigen::MatrixXd covar = portfolio::sequence_mean_covar[t].second;
+
+		std::vector<double> ROI(N), risk(N);
+
+		mean_ROI = 0.0, mean_risk = 0.0;
+		double var_ROI = 0.0, var_risk = 0.0, cov = 0.0;
+		std::vector<stats> stats_samples;
+
+		for (unsigned int i = 0; i < N; ++i)
+		{
+			do
+			{
+				Eigen::MatrixXd samples = multi_norm(mean, covar, 1000);
+				samples.transposeInPlace();
+				Eigen::VectorXd mean2 = estimate_assets_mean_ROI(samples);
+				Eigen::MatrixXd covar2;
+				estimate_covariance(mean2, samples, covar2);
+
+				double roi = compute_ROI(w, mean2);
+				double _risk = compute_risk(w, covar2);
+
+				ROI[i] = linear_transform(roi, min_ROI, max_ROI);
+				risk[i] = linear_transform(_risk, min_risk, max_risk);
+
+			} while (ROI[i] > 1.0 || ROI[i] < 0.0 || risk[i] < 0.0 || risk[i] > 1.0);
+
+			if (t == current_t)
+				stats_samples.push_back(stats(ROI[i],risk[i]));
+
+			mean_ROI += ROI[i];
+			mean_risk += risk[i];
+		}
+
+		mean_ROI /= N;
+		mean_risk /= N;
+
+		for (unsigned int i = 0; i < N; ++i)
+		{
+			var_ROI += (ROI[i] - mean_ROI)*(ROI[i] - mean_ROI);
+			var_risk += (risk[i] - mean_risk)*(risk[i] - mean_risk);
+			cov += (ROI[i] - mean_ROI)*(risk[i] - mean_risk);
+		}
+
+		var_ROI /= (N-1);
+		var_risk /= (N-1);
+		cov /= (N-1);
+
+		Eigen::VectorXd Zero_vec = Eigen::VectorXd::Zero(portfolio::num_assets);
+		std::pair<double,double> cost;
+		if (t == 0) // Considers the entry cost in the share market (from nothing to something invested)
+			cost = portfolio::transaction_cost(Zero_vec, w.investment);
+		else if (t < current_t && t > 0) // Considers the historical cost
+			cost = portfolio::transaction_cost(solution::historical_anticipative_decisions[t-1]->P.investment, w.investment);
+		else if (t == current_t && t > 0) // Considers the current incurring cost to change the portfolio
+		{
+			cost = portfolio::transaction_cost(portfolio::current_investment, w.investment);
+		}
+
+		w.current_cost = cost.first;
+		w.turnover_rate = cost.second;
+
+		// Computes the nominal expected return over investment for the current period
+		double nominal_ROI = inverse_linear_transform(mean_ROI,min_ROI,max_ROI)*portfolio::current_wealth;
+
+		// Updates the percentual expected return, considering the transaction cost
+		double mean_ROI_adjusted = (nominal_ROI - cost.first) / portfolio::current_wealth;
+		double nominal_ROI_adjusted = mean_ROI_adjusted*portfolio::current_wealth;
+		w.nominal_ROI = nominal_ROI_adjusted;
+
+		mean_ROI = linear_transform(mean_ROI_adjusted,portfolio::min_ROI, portfolio::max_ROI);
+
+		if (t == current_t)
+			w.S = stats_vec(stats_samples,mean_ROI,mean_risk,var_ROI,var_risk,cov);
+
+		if (t == initial_t)
+		{
+			// Initial state equals the average of the noisy observations
+			Eigen::VectorXd state(4);
+			state << mean_ROI, mean_risk, 0.0, 0.0;
+
+
+			w.kalman_state.x = state;
+			w.kalman_state.u = Eigen::VectorXd::Zero(4);
+			w.kalman_state.error = 0.0;
+
+			// Initial uncertainty over the state equates the computed variances
+			// Velocity uncertainty is set to an arbitrary high number
+			w.kalman_state.P = Eigen::MatrixXd::Zero(4,4);
+			w.kalman_state.P << var_ROI, cov, 0.0, 0.0,
+								cov, var_risk, 0.0, 0.0,
+								0.0, 0.0, var_ROI, 0.0,
+								0.0, 0.0, 0.0, var_risk;
+			w.kalman_state.P_initial = w.kalman_state.P;
+			Kalman_prediction(w.kalman_state);
+
+			w.ROI_prediction = w.kalman_state.x_next(0);
+			w.risk_prediction = w.kalman_state.x_next(1);
+			w.error_covar_prediction = w.kalman_state.P_next;
+			w.error_covar = w.kalman_state.P;
+			w.covar = w.kalman_state.P;
+
+			// Updates the measurement uncertainty
+			Kalman_params::R = Eigen::MatrixXd::Zero(2,2);
+			Kalman_params::R << var_ROI/N, cov/N,
+								cov/N, var_risk/N;
+		}
+
+
+		if (mean_ROI > 1.0 || mean_ROI < 0.0)
+		{
+			mean_ROI = linear_transform(compute_ROI(w, mean), min_ROI, max_ROI);
+			double nominal_ROI = inverse_linear_transform(mean_ROI,min_ROI,max_ROI)*portfolio::current_wealth;
+
+			// Updates the percentual expected return, considering the transaction cost
+			double mean_ROI_adjusted = (nominal_ROI - cost.first) / portfolio::current_wealth;
+			double nominal_ROI_adjusted = mean_ROI_adjusted*portfolio::current_wealth;
+			w.nominal_ROI = nominal_ROI_adjusted;
+
+			mean_ROI = mean_ROI_adjusted;
+		}
+
+
+		Eigen::VectorXd measurement(2);
+		measurement << mean_ROI, mean_risk;
+
+		if (current_t > initial_t)
+		{
+			Kalman_filter(w.kalman_state, measurement);
+
+			w.ROI_prediction = w.kalman_state.x_next(0);
+			w.risk_prediction = w.kalman_state.x_next(1);
+			w.error_covar_prediction = w.kalman_state.P_next;
+			w.error_covar = w.kalman_state.P;
+			w.covar = w.kalman_state.P;
+		}
+
+	}
+
+	// We finally arrive at the current time, t.
+	w.ROI = mean_ROI;
+	w.risk = mean_risk;
+
+	w.kalman_state.x(0) = w.ROI;
+	w.kalman_state.x(1) = w.risk;
+}
+
+void portfolio::KF_prediction_obj_space(portfolio &w, unsigned int steps_ahead)
+{
+
+	unsigned int current_step = 1;
+
+	while (current_step < steps_ahead)
+	{
+		if (current_step < steps_ahead)
+		{
+			w.ROI = w.ROI_prediction;
+			w.risk = w.risk_prediction;
+			w.kalman_state.x = w.kalman_state.x_next;
+			w.error_covar = w.error_covar_prediction;
+			w.kalman_state.P = w.kalman_state.P_next;
+			Kalman_prediction(w.kalman_state);
+		}
+		++current_step;
+	}
+
+}

--- a/legacy-cpp-v2/source/selection_operators.cpp
+++ b/legacy-cpp-v2/source/selection_operators.cpp
@@ -1,0 +1,51 @@
+#include "../headers/selection_operators.h"
+#include <cstdlib>
+
+unsigned int tournament_selection_CD(std::vector<sol*>& P, unsigned int K)
+{
+
+	unsigned int champion = (int)(((float)rand() / RAND_MAX)*(P.size() - 1));
+
+	for (unsigned int k = 1; k < K; ++k)
+	{
+		unsigned int challenger;
+
+		do
+		{
+			challenger = (int)(((float)rand() / RAND_MAX)*(P.size() - 1));
+		} while(challenger == champion);
+
+		if (P[challenger]->Pareto_front < P[champion]->Pareto_front)
+			champion = challenger;
+
+		else if (P[challenger]->Pareto_front == P[champion]->Pareto_front)
+			if (P[challenger]->cd > P[champion]->cd)
+				champion = challenger;
+	}
+
+	return champion;
+}
+
+unsigned int tournament_Delta_S(std::vector<sol*>& P, const std::pair<double,double>& error, unsigned int K)
+{
+	unsigned int champion = (int)(((float)rand() / RAND_MAX)*(P.size() - 1));
+
+	for (unsigned int k = 1; k < K; ++k)
+	{
+		unsigned int challenger;
+
+		do
+		{
+			challenger = (int)(((float)rand() / RAND_MAX)*(P.size() - 1));
+		} while(challenger == champion);
+
+
+		if (P[challenger]->Pareto_front < P[champion]->Pareto_front)
+			champion = challenger;
+		else if (P[challenger]->Pareto_front == P[champion]->Pareto_front)
+			if (P[challenger]->Delta_S > P[champion]->Delta_S)
+				champion = challenger;
+	}
+
+	return champion;
+}

--- a/legacy-cpp-v2/source/statistics.cpp
+++ b/legacy-cpp-v2/source/statistics.cpp
@@ -1,0 +1,403 @@
+#include "../headers/statistics.h"
+#include "../headers/asms_emoa.h"
+#include "../headers/mvtnorm.h"
+
+#include <cmath>
+#include <vector>
+#include <limits>
+#include <cmath>
+#include <iostream>
+#include <algorithm>
+#include <ctime>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+
+#define MIN(a,b) ((a)>(b)?(b):(a))
+#define MAX(a,b) ((a)>(b)?(a):(b))
+
+#if 0
+#include "../headers/rmg-master/wishart_distribution.hpp"
+#include "../headers/rmg-master/inverted_wishart_distribution.hpp"
+#include "../headers/rmg-master/matrix_variate_t_distribution.hpp"
+#include "../headers/rmg-master/inverted_matrix_variate_t_distribution.hpp"
+
+std::vector<Eigen::MatrixXd> wishart_matrix(const Eigen::MatrixXd& covar, unsigned int sample_size)
+{
+    using namespace boost::numeric::ublas;
+    boost::random::mt19937 rng;
+
+    symmetric_matrix<double> A(covar.rows()), B;
+    for (unsigned int i = 0; i < covar.rows(); ++i)
+    	for (unsigned int j = i; j < covar.rows(); ++i)
+    		A(i,j) = covar(i,j);
+
+    wishart_distribution<> IW(covar.rows(),A);
+    std::vector<Eigen::MatrixXd> sample;
+
+    for (unsigned int n = 0; n < sample_size; ++n)
+    {
+
+		B = IW(rng);
+		Eigen::MatrixXd covar_sample = Eigen::MatrixXd::Zero(covar.rows(),covar.rows());
+		for (unsigned int i = 0; i < covar.rows(); ++i)
+			for (unsigned int j = 0; j < covar.rows(); ++i)
+				covar_sample(i,j) = B(i,j);
+		sample.push_back(covar_sample);
+    }
+
+    return sample;
+}
+#endif
+
+
+bool check_covar(Eigen::MatrixXd Sigma)
+{
+	unsigned size = Sigma.rows();
+	Eigen::MatrixXd normTransform(size,size);
+
+	Eigen::LLT<Eigen::MatrixXd> cholSolver(Sigma);
+
+	// We can only use the cholesky decomposition if
+	// the covariance matrix is symmetric, pos-definite.
+	// But a covariance matrix might be pos-semi-definite.
+	// In that case, we'll go to an EigenSolver
+	if (cholSolver.info()==Eigen::Success) {
+	// Use cholesky solver
+
+	normTransform = cholSolver.matrixL();
+	} else {
+	// Use eigen solver
+
+	Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigenSolver(Sigma);
+	normTransform = eigenSolver.eigenvectors()
+				   * eigenSolver.eigenvalues().cwiseSqrt().asDiagonal();
+	}
+
+	for (unsigned int i = 0; i < size; ++i)
+		for (unsigned j = 0; j < size; ++j)
+			if (normTransform(i,j) != normTransform(i,j))
+			  return false;
+	return true;
+}
+
+// Sort the candidates set using the values of a
+// specific objective function
+void sort_per_objective(std::vector<sol*>& candidates_set, unsigned obj_id)
+{
+	if (obj_id == 0)
+		std::sort(candidates_set.begin(),candidates_set.end(),cmp_ROI_ptr);
+	else if (obj_id == 1)
+		std::sort(candidates_set.begin(),candidates_set.end(),cmp_risk_ptr);
+}
+
+void sort_per_observed_objective(std::vector<sol*>& candidates_set, unsigned obj_id)
+{
+	if (obj_id == 0)
+		std::sort(candidates_set.begin(),candidates_set.end(),cmp_ROI_observed_ptr);
+	else if (obj_id == 1)
+		std::sort(candidates_set.begin(),candidates_set.end(),cmp_risk_observed_ptr);
+}
+
+void sort_per_objective(std::vector<std::pair<unsigned int, sol*> >& candidates_set, unsigned obj_id)
+{
+	if (obj_id == 0)
+		std::sort(candidates_set.begin(),candidates_set.end(),cmp_ROI_ptr_pair);
+	else if (obj_id == 1)
+		std::sort(candidates_set.begin(),candidates_set.end(),cmp_risk_ptr_pair);
+}
+
+void compute_ranks(std::vector<sol*> &P)
+{
+	unsigned int i = 0;
+	std::vector<sol*> front;
+	while (i < P.size())
+	{
+		front.push_back(P[i]);
+		++i;
+	}
+
+	sort_per_objective(front,0);
+
+	for (unsigned int i = 0; i < front.size(); ++i)
+		front[i]->rank_ROI = i;
+
+	sort_per_objective(front,1);
+
+	for (unsigned int i = 0; i < front.size(); ++i)
+		front[i]->rank_risk = i;
+}
+
+double spread(std::vector<sol*>& P)
+{
+	double average = 0.0;
+	unsigned i = 1;
+	std::vector<double> distances;
+
+	while(i < P.size() && P[i]->Pareto_front == 0)
+	{
+		double sum = 0.0;
+		for (unsigned j = 0; j < 2; ++j)
+		{
+			double diff;
+			if (j == 0)
+				diff = P[i-1]->P.ROI_observed - P[i]->P.ROI_observed;
+			else
+				diff = P[i-1]->P.risk_observed - P[i]->P.risk_observed;
+
+			diff = diff*diff;
+			sum += diff;
+		}
+		double d = sqrt(sum);
+		distances.push_back(d);
+		average += d;
+		i++;
+	}
+	unsigned pareto_size = i;
+	average /= pareto_size;
+	
+	double sum = 0.0;
+	for (i = 0; i < distances.size(); ++i)
+		sum += fabs(distances[i] - average);
+
+	return sum /= pareto_size;
+}
+
+double coverage(std::vector<sol*>& P)
+{
+
+	double min_risk, min_ROI, max_risk, max_ROI;
+
+	min_risk = std::numeric_limits<double>::max();
+	max_risk = std::numeric_limits<double>::min();
+	min_ROI = min_risk; max_ROI = max_risk;
+
+	for (unsigned i = 0; i < P.size(); ++i)
+		if(P[i]->Pareto_front == 0)
+		{
+			if (P[i]->P.risk_observed < min_risk)
+				min_risk = P[i]->P.risk_observed;
+			else if (P[i]->P.risk_observed > max_risk)
+				max_risk = P[i]->P.risk_observed;
+
+			if (P[i]->P.ROI_observed < min_ROI)
+				min_ROI = P[i]->P.ROI_observed;
+			else if (P[i]->P.ROI_observed > max_ROI)
+				max_ROI = P[i]->P.ROI_observed;
+		}
+
+
+	double d_ROI = MIN(max_ROI, 1.0) - MAX(min_ROI, solution::ref_point.first);
+	double d_risk = MIN(max_risk, solution::ref_point.second) - MAX(min_risk, 0.0);
+	double sum = d_risk*d_risk+d_ROI*d_ROI;
+
+	double c = sqrt(sum / 2.0);
+
+	if (c != c)
+		return 0.0;
+
+	return c;
+}
+
+double observed_hypervolume(std::vector<sol*>& P, unsigned int samples, double rx, double ry)
+{
+	double out_of_sample_future_hypv = 0.0;
+	
+	std::vector<std::pair<double,double> > original_values;
+
+	for (unsigned i = 0; i < P.size(); ++i)
+		original_values.push_back(std::pair<double,double>(P[i]->P.ROI_observed,P[i]->P.risk_observed));
+
+	for (unsigned int e = 0; e < samples; ++e)
+	{
+
+		for (unsigned i = 0; i < P.size(); ++i)
+		{
+			original_values.push_back(std::pair<double,double>(P[i]->P.ROI_observed,P[i]->P.risk_observed));
+			Eigen::MatrixXd objective_values = multi_norm(P[i]->P.kalman_state.x, P[i]->P.covar, 1);
+			P[i]->P.ROI_observed = objective_values(0,0);
+			P[i]->P.risk_observed = objective_values(0,1);
+		}
+	
+		observed_fast_nondominated_sort(P);
+
+		std::vector<sol*> pareto;
+		for (unsigned i = 0; i < P.size(); ++i)
+			if (P[i]->observed_Pareto_front == 0)
+				pareto.push_back(P[i]);
+
+		sort_per_observed_objective(pareto,0);
+
+		double volume = 0.0;
+
+		for (int i = pareto.size() - 1; i > 0; --i)
+		{
+			double v = (pareto[i-1]->P.risk_observed - pareto[i]->P.risk_observed);
+			v = v * (pareto[i]->P.ROI_observed - rx);
+			volume += v;
+		}
+
+		double v = (ry - pareto[0]->P.risk_observed);
+		v = v * (pareto[0]->P.ROI_observed - rx);
+		volume += v;
+		
+		out_of_sample_future_hypv += volume;		
+		++e;
+		
+	}
+
+	// Restore solutions original mean objective values
+	for (unsigned i = 0; i < P.size(); ++i)
+	{
+		P[i]->P.ROI_observed = original_values[i].first;
+		P[i]->P.risk_observed = original_values[i].second;
+	}
+
+	// Restore original sorting and class divisions
+	observed_fast_nondominated_sort(P);
+
+	return (1.0/samples)*out_of_sample_future_hypv;
+}
+
+
+double hypervolume(std::vector<sol*>& P, double rx, double ry)
+{
+	std::vector<sol*> pareto;
+	for (unsigned i = 0; i < P.size(); ++i)
+		if (P[i]->Pareto_front == 0)
+			pareto.push_back(P[i]);
+
+	sort_per_objective(pareto,0);
+
+	double volume = 0.0;
+
+	for (int i = pareto.size() - 1; i > 0; --i) 
+	{
+		double v = (pareto[i-1]->P.risk - pareto[i]->P.risk);
+		v = v * (pareto[i]->P.ROI - rx);
+		volume += v;
+	}
+
+	double v = (ry - pareto[0]->P.risk);
+	v = v * (pareto[0]->P.ROI - rx);
+	volume += v;
+
+	return volume;	
+}
+
+/*
+  We need a functor that can pretend it's const,
+  but to be a good random number generator
+  it needs mutable state.
+*/
+namespace Eigen {
+namespace internal {
+template<typename Scalar>
+struct scalar_normal_dist_op
+{
+  static boost::mt19937 rng;    // The uniform pseudo-random algorithm
+  mutable boost::normal_distribution<Scalar> norm;  // The Gaussian combinator
+
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_normal_dist_op)
+
+  template<typename Index>
+  inline const Scalar operator() (Index, Index = 0) const { return norm(rng); }
+};
+
+template<typename Scalar> boost::mt19937 scalar_normal_dist_op<Scalar>::rng;
+
+template<typename Scalar>
+struct functor_traits<scalar_normal_dist_op<Scalar> >
+{ enum { Cost = 50 * NumTraits<Scalar>::MulCost, PacketAccess = false, IsRepeatable = false }; };
+} // end namespace internal
+} // end namespace Eigen
+
+/*
+  Draw nn samples from a size-dimensional normal distribution
+  with a specified mean and covariance
+*/
+Eigen::MatrixXd multi_norm(Eigen::VectorXd mu, Eigen::MatrixXd Sigma, int num_samples)
+{
+  int size = mu.rows(); // Dimensionality (rows)
+  int nn=num_samples;     // How many samples (columns) to draw
+  Eigen::internal::scalar_normal_dist_op<double> randN; // Gaussian functor
+  Eigen::internal::scalar_normal_dist_op<double>::rng.seed(rand()); // Seed the rng
+
+  Eigen::MatrixXd normTransform(size,size);
+  Eigen::LLT<Eigen::MatrixXd> cholSolver(Sigma);
+
+  // We can only use the cholesky decomposition if
+  // the covariance matrix is symmetric, pos-definite.
+  // But a covariance matrix might be pos-semi-definite.
+  // In that case, we'll go to an EigenSolver
+  if (cholSolver.info()==Eigen::Success) {
+    // Use cholesky solver
+	  //std::cout << "Use cholesky solver...\n";
+    normTransform = cholSolver.matrixL();
+  } else {
+    // Use eigen solver
+	  //std::cout << " Use eigen solver...\n";
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigenSolver(Sigma);
+    normTransform = eigenSolver.eigenvectors()
+                   * eigenSolver.eigenvalues().cwiseSqrt().asDiagonal();
+  }
+
+  Eigen::MatrixXd samples = (normTransform
+                           * Eigen::MatrixXd::NullaryExpr(size,nn,randN)).colwise()
+                           + mu;
+  return samples;
+}
+
+double normal_cdf(Eigen::VectorXd z, Eigen::MatrixXd Sigma)
+{
+	unsigned int d = z.rows();
+	unsigned int off_diagonal_elems = Sigma.rows()*(Sigma.rows()-1)/2;
+
+	double * covar = new double[off_diagonal_elems];
+	for (unsigned int i = 0; i < off_diagonal_elems; ++i)
+		covar[i] = 0.0;
+
+	double * upper = new double[d];
+	for (unsigned int i = 0; i < d; ++i)
+		upper[i] = z(i);
+
+	double error;
+	double p = pmvnorm_P(d, upper, covar, &error);
+
+	delete []covar;
+	delete []upper;
+
+	return p;
+}
+
+double entropy(double p)
+{
+	if (p == 0.0 || p == 1.0)
+		return 0.0;
+	return - (p*log2(p) + (1.0 - p)*log2(1.0 - p));
+}
+
+double linear_entropy(double p)
+{
+	if (p <= .5)
+		return 2.0*p;
+	return 2.0*(1.0 - p);
+}
+
+Eigen::VectorXd concept_vector(std::vector<sol*>& P)
+{
+	Eigen::VectorXd c = Eigen::VectorXd::Zero(P[0]->P.investment.rows());
+	for (unsigned int i = 0; i < P.size(); ++i)
+		c += P[i]->P.investment;
+	c /= P.size();
+	return c/c.norm();
+}
+
+double coherence(std::vector<sol*>& P)
+{
+	Eigen::VectorXd c = concept_vector(P);
+	double coherence = 0.0;
+	for (unsigned int i = 0; i < P.size(); ++i)
+		coherence += P[i]->P.investment.transpose()*c;
+	return coherence/P.size();
+}

--- a/legacy-cpp-v2/source/utils.cpp
+++ b/legacy-cpp-v2/source/utils.cpp
@@ -1,0 +1,172 @@
+/*
+ * utils.cpp
+ *
+ *  Created on: 21/11/2012
+ *      Author: LBiC
+ */
+
+#include "../headers/utils.h"
+#include <algorithm>
+
+double linear_transform(double value, double min, double max)
+{
+	double scaled_value = (value - min)/(max - min);
+	return scaled_value;
+}
+
+double inverse_linear_transform(double value, double min, double max)
+{
+	return value*(max-min)+min;
+}
+
+Eigen::VectorXd sum(const std::vector<Eigen::VectorXd> &M)
+{
+	Eigen::VectorXd v(M[0].rows());
+
+	for (unsigned int i = 0; i < M.size(); ++i)
+		v += M[i];
+
+	return v;
+}
+
+void normalize(Eigen::VectorXd& v)
+{
+	v = (1.0/ v.sum())*v;
+}
+
+float uniform_zero_one()
+{
+	return (float)rand() / RAND_MAX;
+}
+
+bool sequential_date(date current_date, date next_date)
+{
+	if (current_date.day_of_week().as_enum() == Monday)
+		return next_date.day_of_week().as_enum() == Tuesday;
+	if (current_date.day_of_week().as_enum() == Tuesday)
+		return next_date.day_of_week().as_enum() == Wednesday;
+	if (current_date.day_of_week().as_enum() == Wednesday)
+		return next_date.day_of_week().as_enum() == Thursday;
+	if (current_date.day_of_week().as_enum() == Thursday)
+		return next_date.day_of_week().as_enum() == Friday;
+	if (current_date.day_of_week().as_enum() == Friday)
+		return next_date.day_of_week().as_enum() == Monday;
+	return true;
+}
+
+double mean(std::vector<double> &v)
+{
+	double m = 0.0;
+	for (unsigned int i = 0; i < v.size(); ++i)
+		m += v[i];
+	return m / v.size();
+}
+
+double mean(Eigen::VectorXd &v)
+{
+	return v.mean();
+}
+
+double median(std::vector<double> &v)
+{
+
+	if (v.size() % 2 != 0)
+	{
+		size_t n = v.size() / 2;
+		std::nth_element(v.begin(), v.begin()+n, v.end());
+		return v[n];
+	}
+	else
+	{
+		size_t n1 = (v.size()-1) / 2;
+		size_t n2 = (v.size()-1) / 2 + 1;
+		std::nth_element(v.begin(), v.begin()+n1, v.end());
+		std::nth_element(v.begin(), v.begin()+n2, v.end());
+
+		return (v[n1] + v[n2]) / 2.0;
+	}
+}
+
+double median(Eigen::VectorXd &v)
+{
+
+	if (v.count() == 0)
+		return 0.0;
+
+	std::vector<double> v2;
+	v2.resize(v.rows());
+
+	for (int i = 0; i < v.rows(); ++i)
+		v2[i] = v(i);
+
+	return median(v2);
+}
+
+double break_down(std::vector<double>&v, double cutoff)
+{
+	size_t n = v.size()*cutoff;
+	std::nth_element(v.begin(), v.begin()+n, v.end());
+	return v[n];
+}
+
+double break_down(Eigen::VectorXd &v, double cutoff)
+{
+	std::vector<double> v2;
+		v2.resize(v.rows());
+		for (int i = 0; i < v.rows(); ++i)
+			v2[i] = v(i);
+	return break_down(v2,cutoff);
+}
+
+double unbiased_IQD(Eigen::VectorXd& v)
+{
+
+	double Q1 = break_down(v, 0.25);
+	double Q3 = break_down(v, 0.75);
+	return .7413*(Q3 - Q1); // The constant is such that
+							// the IQD is unbiased when the
+							// columns are normally distributed.
+}
+
+double variance(Eigen::VectorXd& v)
+{
+	return 0.0;
+}
+
+void apply_threshold(Eigen::VectorXd &w, double l, double u)
+{
+	normalize(w);
+	for (int i = 0; i < w.rows(); ++i)
+	{
+		if (w(i) > 0.0 && w(i) < l)
+			w(i) = l;
+		else if (w(i) > u)
+			w(i) = u;
+		normalize(w);
+	}
+
+}
+
+Eigen::VectorXd dirichlet_sample(const Eigen::VectorXd& alpha, boost::mt19937& rng)
+{
+	Eigen::VectorXd sample(alpha.rows());
+
+	for (int i = 0; i < alpha.rows(); ++i)
+	{
+		boost::gamma_distribution<> pdf(alpha(i));
+		boost::variate_generator<boost::mt19937&, boost::gamma_distribution<> > generator(rng, pdf);
+		sample(i) = generator();
+	}
+
+	return sample / sample.sum();
+}
+
+Eigen::VectorXd dirichlet_sample(const Eigen::VectorXd& proportions, double concentratrion, boost::mt19937& rng)
+{
+	Eigen::VectorXd alpha(proportions.rows());
+
+	for (int i = 0; i < proportions.rows(); ++i)
+		alpha(i) = proportions(i)*concentratrion;
+
+	return dirichlet_sample(alpha, rng);
+}

--- a/legacy-cpp/README.md
+++ b/legacy-cpp/README.md
@@ -1,20 +1,42 @@
-# legacy-cpp — the original C++ ASMOO implementation
+# legacy-cpp — the 2013-era C++ ASMOO implementation (PRE-PAPER)
 
-This directory preserves the original C++ codebase ("ASMOO") that accompanied
-the PhD thesis *Learning to Anticipate Flexible Trade-off Choices in
-Multiobjective Combinatorial Optimization Under Catastrophic Information Losses*
-(Azevedo, 2014) and the IEEE Transactions on Cybernetics paper that distilled
-its main contributions:
+⚠️ **NOT the cross-validation oracle.** This directory preserves the
+**2013-era** C++ codebase that pre-dates the paper-companion release.
+For cross-validation use [`../legacy-cpp-v2/`](../legacy-cpp-v2/) — the
+**2015-era paper-companion release** that the Python port mirrors.
+
+This directory accompanies the PhD thesis *Learning to Anticipate
+Flexible Trade-off Choices in Multiobjective Combinatorial Optimization
+Under Catastrophic Information Losses* (Azevedo, 2014).
+
+The 2015 IEEE TCYB paper:
 
 > **Azevedo, C. R. B., & Von Zuben, F. J.** (2015). *Learning to Anticipate
 > Flexible Choices in Multiobjective Combinatorial Optimization Under
 > Catastrophic Information Losses.* IEEE Transactions on Cybernetics.
 
+was published with a refined post-thesis C++ codebase that's vendored at
+`../legacy-cpp-v2/`. THAT is the cross-validation reference. Use it.
+
 The actively-maintained, publication-track implementation is the Python
 package under `../python_refactor/`. **Use that for any new work.** This
-directory is kept for provenance and to enable cross-checking the
-Python implementation against the original C++ behaviour where that is
-ever in question.
+directory is kept for historical provenance only.
+
+## Differences vs `legacy-cpp-v2/`
+
+- This (2013) version LACKS `dirichlet.cpp` (the Dirichlet predictor
+  module). Python's `DirichletPredictor` was built against the 2015
+  v2 code where Dirichlet exists.
+- This version's `Kalman_filter()` calls `Kalman_prediction()` BEFORE
+  `Kalman_update()`. v2 reverses the order.
+- This version uses Portuguese filenames (`aprendizado_operadores`,
+  `operadores_*`). v2 uses English.
+- `nsga2.cpp` here → `asms_emoa.cpp` in v2.
+
+W18 cross-validation work initially used THIS directory as the oracle
+and found false-positive structural divergences (missing Dirichlet,
+"different" algorithms). PR #(forthcoming) imports `legacy-cpp-v2/`
+and re-runs cross-checks against the correct reference.
 
 ## Layout
 


### PR DESCRIPTION
## Summary

Operator-flagged correction: the Python port was built against the **2015 post-thesis C++ release** (\`crbazevedo/anticipatory-learning-asmoo\` @ commit \`6643c92\`), not the 2013 thesis-companion code that was vendored as \`legacy-cpp/\`. W18 cross-validation work therefore had the wrong oracle.

This PR imports the correct reference as \`legacy-cpp-v2/\` and updates all provenance docs. Re-assessments of prior cross-checks land in subsequent PRs.

## What v2 has that v1 lacked

- **\`dirichlet.cpp\` + \`dirichlet.h\`** — explicit Dirichlet predictor module (Python's \`DirichletPredictor\` mirrors it LINE-FOR-LINE)
- **\`asms_emoa.cpp\`** (replaces \`nsga2.cpp\`) — refined ASMS-EMOA orchestration
- **English filenames** (was Portuguese: \`aprendizado_operadores\` → \`learning_operators\`, etc.)
- **KF lifecycle REVERSED**: v2 = update→predict; v1 = predict→update. Python matches v1, not v2 → **W19-2 AGREE verdict may flip**
- **\`Kalman_params.error\`** (running residual norm) + **\`Kalman_params::window_size\`** (K-period λ^K support)
- **\`alpha = 1 - non_dominance_probability(w)\`** (v2 direct; v1 was entropy-wrapped) — different anticipative-rate formula
- **\`samples_per_portfolio\`**, **\`brokerage_commission\`**, **\`sequence_mean_covar\`**, **\`current_period\`** — paper §7 protocol infrastructure
- **NO \`robustness\` flag**, **NO \`median_ROI\`** in v2

## Cross-validation re-assessment matrix

| Check | W18/W19 verdict (vs v1) | Predicted vs v2 |
|---|---|---|
| A risk | DISAGREE-PYTHON-WRONG (sqrt) | v2 also no-sqrt; verdict should hold |
| B ROI | AGREE | hold |
| C bivariate | AGREE | hold |
| D KF | AGREE | **MAY FLIP** (lifecycle reversed) |
| E Dirichlet | (incorrectly "C++ has none") | v2 HAS it; full cross-check now possible |
| F TIP | STRUCTURAL | hold |
| G λ end-to-end | (pending) | THREE different formulas (v1, v2, Python) |

## Provenance docs updated

- \`legacy-cpp/README.md\` — clarified historical-only status; points to v2
- \`legacy-cpp-v2/README.md\` (NEW) — full provenance + diff vs v1
- \`docs/THESIS-INDEX.md\` §0 — dual-codebase table
- \`docs/BACKLOG.md\` — CPP2 (v2 oracle) + CPP1 (v1 historical) grounding labels

## Next units (subsequent PRs)

1. Re-assess W18-2 risk vs v2
2. Re-assess W19-1 bivariate vs v2
3. Re-assess W19-2 KF vs v2 (lifecycle order)
4. Ship W19-3 Dirichlet cross-check against v2 \`dirichlet.cpp\`
5. W19-4 anticipative-rate G with full v1/v2/Python comparison
6. Update W18 + W19 synthesis docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)