### PR TITLE
W21 replan: Reading-F test + cross-checks L/M/N + full ablation + publication-track decision

### DIFF
--- a/.dfg/plan.yaml
+++ b/.dfg/plan.yaml
@@ -1693,20 +1693,20 @@ waves:
       - id: W21-1
         slug: reading-f-experimental-test
         name: Reading-F experimental test (use_v2_stability_weighting flag + smoke)
-        purpose: "KEYSTONE. Closes W20-5-CARRY-1. Test whether v2's Δ_S stability multiplier closes the residual 4.04% gap from W20-1 (+7.82pp Reading-E recovery)."
+        purpose: "KEYSTONE. Closes W20-5-CARRY-1. Per W20-5 CORRECTION: Reading F is INVERTED — v2's stability is no-op (always 1.0); Python's depresses Δ_S. Flag forces Python stability=1.0 to match v2."
         files:
-          - python_refactor/src/algorithms/anticipatory_learning.py
-          - python_refactor/src/algorithms/expected_hypervolume.py
+          - python_refactor/src/algorithms/sms_emoa.py
+          - python_refactor/src/algorithms/solution.py
           - python_refactor/tests/test_use_v2_stability_weighting.py
           - python_refactor/experiments/validation_matrix.py
           - docs/READING-F-EXPERIMENTAL-TEST.md
         depends_on: []
         size: M
         acceptance_criteria:
-          - "use_v2_stability_weighting kwarg implemented; Δ_S × stability multiplier where stability = 1/(1 + (ROI_unseen-P.ROI)² + (risk_unseen-P.risk)²)"
-          - "W17-5 smoke re-run with v2-rate flag AND v2-stability flag enabled; Δ(S2 − S0) reported honestly"
-          - "Verdict: READING-F-CONFIRMED (combined gap < 0) / READING-F-PARTIAL / READING-F-REFUTED"
-          - "≥ 3 unit tests for the flag behavior"
+          - "use_v2_stability_weighting kwarg added to SMS-EMOA constructor; when True, solution.stability is forced to 1.0 (no-op multiplier matching v2's effective behavior) at the three Δ_S call sites in sms_emoa.py (538, 554, 599)"
+          - "W17-5 smoke re-run with v2-rate flag AND v2-stability flag both enabled; Δ(S2 − S0) reported honestly"
+          - "Verdict: READING-F-CONFIRMED (combined gap closes ≤ 0) / READING-F-PARTIAL / READING-F-REFUTED"
+          - "≥ 3 unit tests for the flag behavior (default off; flag on forces stability=1.0; combined with use_v2_anticipative_rate)"
 
       - id: W21-2
         slug: cross-check-l-nds

--- a/.dfg/plan.yaml
+++ b/.dfg/plan.yaml
@@ -1685,3 +1685,121 @@ waves:
         - "4 cross-checks (H, I, J, K) shipped with receipts"
         - "Retros at .dfg/retrospectives/W20/W20-N.md with ADR-004 keys"
       checkpoint_file: .dfg/checkpoints/W20-gate.md
+
+  - id: W21
+    name: Reading-F experimental test + cross-checks L/M/N + full ablation + 30-seed → final replication verdict
+    state: PLANNED
+    units:
+      - id: W21-1
+        slug: reading-f-experimental-test
+        name: Reading-F experimental test (use_v2_stability_weighting flag + smoke)
+        purpose: "KEYSTONE. Closes W20-5-CARRY-1. Test whether v2's Δ_S stability multiplier closes the residual 4.04% gap from W20-1 (+7.82pp Reading-E recovery)."
+        files:
+          - python_refactor/src/algorithms/anticipatory_learning.py
+          - python_refactor/src/algorithms/expected_hypervolume.py
+          - python_refactor/tests/test_use_v2_stability_weighting.py
+          - python_refactor/experiments/validation_matrix.py
+          - docs/READING-F-EXPERIMENTAL-TEST.md
+        depends_on: []
+        size: M
+        acceptance_criteria:
+          - "use_v2_stability_weighting kwarg implemented; Δ_S × stability multiplier where stability = 1/(1 + (ROI_unseen-P.ROI)² + (risk_unseen-P.risk)²)"
+          - "W17-5 smoke re-run with v2-rate flag AND v2-stability flag enabled; Δ(S2 − S0) reported honestly"
+          - "Verdict: READING-F-CONFIRMED (combined gap < 0) / READING-F-PARTIAL / READING-F-REFUTED"
+          - "≥ 3 unit tests for the flag behavior"
+
+      - id: W21-2
+        slug: cross-check-l-nds
+        name: Cross-check L — non-dominated sorting (NDS) algorithm
+        purpose: "Closes operator check L. Deterministic; likely AGREE."
+        files:
+          - legacy-cpp-v2/build/drivers/nds_driver.cpp
+          - python_refactor/scripts/cross_validation/run_nds.py
+          - python_refactor/tests/test_cross_check_nds.py
+          - docs/CROSS-VALIDATION-L-NDS.md
+        depends_on: []
+        size: S
+        acceptance_criteria:
+          - "C++ + Python drivers on identical Pareto-front fixture"
+          - "Front identity + ordering compared"
+          - "Verdict per W18 matrix"
+
+      - id: W21-3
+        slug: cross-check-m-mutation
+        name: Cross-check M — mutation operator (simplex / parent-correlation)
+        purpose: "Closes operator check M. W15-2 changed Python from per-element to dual-mode per thesis §7.2.3."
+        files:
+          - legacy-cpp-v2/build/drivers/mutation_driver.cpp
+          - python_refactor/scripts/cross_validation/run_mutation.py
+          - python_refactor/tests/test_cross_check_mutation.py
+          - docs/CROSS-VALIDATION-M-MUTATION.md
+        depends_on: []
+        size: S
+        acceptance_criteria:
+          - "C++ + Python mutation on shared (parent, RNG-seed) fixture"
+          - "Statistical comparison of offspring distribution"
+          - "Verdict per W18 matrix"
+
+      - id: W21-4
+        slug: cross-check-n-crossover
+        name: Cross-check N — SBX vs uniform crossover semantic divergence
+        purpose: "Closes operator check N. C++ uses SBX; Python switched to uniform in W15-2 per thesis §7.2.3 p.147. Confirm intentional."
+        files:
+          - legacy-cpp-v2/build/drivers/crossover_driver.cpp
+          - python_refactor/scripts/cross_validation/run_crossover.py
+          - python_refactor/tests/test_cross_check_crossover.py
+          - docs/CROSS-VALIDATION-N-CROSSOVER.md
+        depends_on: []
+        size: M
+        acceptance_criteria:
+          - "Both C++ SBX + Python uniform on shared (parents, RNG-seed) fixture"
+          - "Document semantic divergence with thesis citation"
+          - "Verdict: INTENTIONAL-PER-THESIS"
+
+      - id: W21-5
+        slug: full-ablation-30-seed
+        name: Full ablation table + 30-seed run → final replication verdict
+        purpose: "KEYSTONE. Synthesize all closed-divergences into a single ablation matrix on 30 seeds to determine which combination of fixes reverses S2 vs S0."
+        files:
+          - python_refactor/experiments/ablation_matrix.py
+          - python_refactor/experiments/results/w21-5-ablation/per_seed.json
+          - docs/W21-FULL-ABLATION-VERDICT.md
+        depends_on: [W21-1]
+        size: L
+        acceptance_criteria:
+          - "Ablation variants run (default × v2-rate × v2-stability × +sqrt-removed × +KF-lifecycle-aligned)"
+          - "30 seeds per variant"
+          - "Headline table: Δ(S2 − S0) per variant with std"
+          - "Final replication verdict: PAPER-REPLICATES / PARTIAL / REFUTED"
+
+      - id: W21-6
+        slug: synthesis-publication-decision
+        name: W21 synthesis + publication-track decision
+        purpose: "Aggregate W21-1..W21-5; consolidate the W7→W21 chain; surface publication-track decision to operator."
+        files:
+          - docs/W21-CROSS-VALIDATION-SYNTHESIS.md
+          - docs/PUBLICATION-TRACK-DECISION.md
+          - .dfg/retrospectives/W21/W21-6.md
+        depends_on: [W21-1, W21-2, W21-3, W21-4, W21-5]
+        size: S
+        acceptance_criteria:
+          - "Verdict matrix for L/M/N + Reading F + final ablation"
+          - "W7→W21 chain narrative"
+          - "Publication-track decision menu for operator"
+          - "ADR-004 retro"
+
+    parallel_groups:
+      - [W21-1, W21-2, W21-3, W21-4]
+      - [W21-5]
+      - [W21-6]
+
+    gate:
+      gate_type: wave-gate
+      criteria:
+        - "All 6 units MERGED with green pre-pr battery"
+        - "W21-1 Reading-F test reports verdict with honest data"
+        - "3 cross-checks (L, M, N) shipped with receipts"
+        - "W21-5 ablation reports final replication verdict on 30 seeds"
+        - "W21-6 surfaces publication-track decision menu"
+        - "Retros at .dfg/retrospectives/W21/W21-N.md with ADR-004 keys"
+      checkpoint_file: .dfg/checkpoints/W21-gate.md


### PR DESCRIPTION
## Summary

W21 closes the final 3 of 14 operator cross-checks (L NDS, M mutation, N crossover) + tests **Reading F** (the W20-5 stability-weighting hypothesis, **per honest correction at `docs/W20-5-CORRECTION-READING-F-INVERSION.md`**) + ships the **keystone ablation matrix** that determines the final replication verdict.

This is the W7→W21 chain's terminal wave. After W21, the cross-validation programme is structurally complete.

## ⚠️ Honest correction — Reading F is INVERTED

Per the W20-5 correction document (committed on `chore/w20-wave-close` as part of #120):

- v2 stability: declared in `legacy-cpp-v2/headers/asms_emoa.h:18`, initialized to `1.0` in 3 constructors, **NEVER REASSIGNED** anywhere in `legacy-cpp-v2/source/*.cpp`. The `delta_Si *= Pareto_front[i]->stability` lines at asms_emoa.cpp:{303,313,321} are behavioral no-ops.
- Python stability: non-trivial — `1/(1 + prediction_error)` (Portfolio.evaluate_stability) or `1/(1 + std(investment))` (sms_emoa.py:351) — both < 1.0, actively depress Δ_S.
- **Original W20-5 framing:** "v2 has stability multiplier, Python doesn't" — **WRONG.**
- **Corrected W20-5 framing:** "Both have multipliers; v2's is no-op (1.0); Python's depresses Δ_S below bare Gaussian expectation."
- **Original W21-1 plan:** add v2's stability formula to Python.
- **Corrected W21-1 plan:** force Python's stability to 1.0 (match v2's effective no-op).

Smaller code change. Same experimental design intent. The original W20-5 receipt at `docs/CROSS-VALIDATION-K-EXPECTED-HV.md` also contained a FABRICATED citation (claimed v2 formula at `portfolio.cpp:595` but that file contains zero occurrences of "stability"). The correction document supersedes the relevant sections; W20-5 receipt + W20-6 synthesis are preserved as honest history.

## 6 units

| Unit | Size | Subject |
|---|---|---|
| **W21-1 KEYSTONE** | M | Reading-F test — `use_v2_stability_weighting` flag (forces stability=1.0) + smoke (combined with W20-1 v2-rate) |
| W21-2 | S | Cross-check L — NDS algorithm (deterministic; likely AGREE) |
| W21-3 | S | Cross-check M — mutation operator (simplex / parent-correlation) |
| W21-4 | M | Cross-check N — SBX vs uniform crossover (intentional per W15-2) |
| **W21-5 KEYSTONE** | L | Full ablation matrix + 30-seed run → final replication verdict |
| W21-6 | S | Synthesis + publication-track decision menu |

**Parallel groups:** L0 = W21-1..W21-4 (file-disjoint); L1 = W21-5 (depends on W21-1); L2 = W21-6.

## W21-5 ablation matrix

Variants on 30-seed run:
1. default (Eq 7.16 + Python stability multiplier + Python sqrt + Python KF lifecycle)
2. v2 rate only (W20-1)
3. v2 stability disabled (W21-1)
4. v2 rate + v2 stability disabled
5. + sqrt removed (W18-CARRY-1)
6. + KF lifecycle aligned (Reading D)

**Final replication verdict:** PAPER-REPLICATES / PARTIAL / REFUTED.

## Publication-track framings (W21-6)

1. **Paper replicates** after closing documented divergence chain
2. **Even closing all documented divergences, paper's headline doesn't replicate** — full receipt + remaining-hypothesis story

Either way: 14-check cross-validation against the paper-companion v2 substrate is itself a meaningful methodological contribution.

## Mutual-skepticism caveat applies

Per operator's W18 directive, v2 may also be wrong. The v2 stability field is at best dead code / unfinished feature — declared, referenced in selection, but never updated. This may be intentional (planned-but-disabled) or a v2 bug. The thesis text needs re-read to determine intended behavior; if the thesis specifies a non-trivial stability formula, BOTH v2 (always 1.0) AND Python (different formula) diverge from the thesis.

## Dependencies

- **Blocked by** W20 wave close (#119 + #120)
- #120 contains the W20-5 correction document

## Test plan

- [x] `.dfg/plan.yaml` adds W21 wave with INVERTED Reading-F framing (118 + 7 lines)
- [x] `dfg validate` clean
- [x] W21-1 acceptance criteria updated per inversion
- [ ] W21-1 through W21-6 unit PRs (next, after #119 + #120 merge)
- [ ] W21 wave-close ceremony

🤖 Generated with [Claude Code](https://claude.com/claude-code)