### PR TITLE
W22: closed-form (point-estimate) OOS eHypV flag — methodology pivot

### DIFF
--- a/python_refactor/experiments/oos_evaluator.py
+++ b/python_refactor/experiments/oos_evaluator.py
@@ -128,7 +128,8 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
                       oos_returns: pd.DataFrame,
                       n_samples: int = 1000,
                       z_ref: tuple[float, float] = (0.2, 0.0),
-                      rng: np.random.Generator | None = None) -> dict:
+                      rng: np.random.Generator | None = None,
+                      use_closed_form: bool = False) -> dict:
     """Sample-average OOS Future Hypervolume per thesis Eqs 7.10+7.11.
 
     For each of n_samples MC scenarios e:
@@ -139,11 +140,25 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
          (u_i^T Σ̂_e u_i, μ̂_e^T u_i)
       4. Compute hypervolume of the N-point cloud against z_ref → S_e
 
+    W22 closed-form variant (use_closed_form=True): skips bootstrap MC;
+    instead uses single full-window MLE (μ̂, Σ̂) computed once. Returns
+    deterministic Ŝ given (oos_returns, pareto_weights, z_ref). This is
+    a POINT-ESTIMATE (S(E[μ,Σ])) NOT a true closed-form expectation
+    (E[S(μ,Σ)]) — by Jensen these differ for nonlinear HV. For Phase B
+    parallel validation: if closed-form Ŝ tracks the MC mean within
+    noise, the MC bootstrap was over-sampling for our use; otherwise
+    the uncertainty model is material and a true closed-form expected
+    Ŝ (Option B per W22 design doc, Black-Scholes-style truncated
+    means per portfolio + HV aggregation) is needed.
+
+    n_samples is IGNORED when use_closed_form=True (output is
+    deterministic; efhv_std=0.0; efhv_samples=[the single Ŝ value]).
+
     Returns:
         {
           'efhv_mean': float,   # Ŝ_{t+1} per Eq 7.11
-          'efhv_std':  float,   # MC standard deviation across scenarios
-          'efhv_samples': np.ndarray  # all E sample HVs (for downstream stats)
+          'efhv_std':  float,   # MC standard deviation across scenarios (0 if closed-form)
+          'efhv_samples': np.ndarray  # all E sample HVs (length 1 if closed-form)
         }
     """
     if rng is None:
@@ -165,6 +180,19 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
                 f"weights[{i}] shape {w.shape} mismatches oos_returns "
                 f"n_assets={n_assets}"
             )
+
+    if use_closed_form:
+        # W22 closed-form (point-estimate) variant: single full-window MLE
+        # → deterministic Ŝ. Skips bootstrap MC entirely.
+        mu = arr.mean(axis=0)
+        cov = np.cov(arr, rowvar=False, ddof=1)
+        points = [(float(w @ cov @ w), float(mu @ w)) for w in weights_arr]
+        hv = hypervolume_2d(points, z_ref)
+        return {
+            "efhv_mean": float(hv),
+            "efhv_std": 0.0,
+            "efhv_samples": np.array([hv], dtype=float),
+        }
 
     samples_hv = np.empty(n_samples, dtype=float)
     for e in range(n_samples):

--- a/python_refactor/experiments/walk_forward.py
+++ b/python_refactor/experiments/walk_forward.py
@@ -160,6 +160,7 @@ def run_walk_forward(scenario: str,
                       n_mc: int = 1000,
                       rng: np.random.Generator | None = None,
                       lambda_trace_csv_path: str | None = None,
+                      use_closed_form_efhv: bool = False,
                       ) -> list[dict[str, Any]]:
     """Walk-forward evaluate one (scenario, seed) across all rolling periods.
 
@@ -212,6 +213,7 @@ def run_walk_forward(scenario: str,
             oos_returns=oos,
             n_samples=n_mc,
             rng=rng,
+            use_closed_form=use_closed_form_efhv,
         )
         # W17-4 (closes W16-2-CARRY-1 + BACKLOG M5 partial): pick the
         # AMFC per thesis §6.4 Eq 6.42 as u*_{t-1} for the NEXT period

--- a/python_refactor/experiments/walk_forward_report.py
+++ b/python_refactor/experiments/walk_forward_report.py
@@ -59,7 +59,8 @@ def _run_one(scenario: str, seed: int,
               full_returns_pickle: bytes,
               train_window_days: int, step_days: int,
               n_mc: int,
-              lambda_trace_csv_path: str | None = None) -> dict[str, Any]:
+              lambda_trace_csv_path: str | None = None,
+              use_closed_form_efhv: bool = False) -> dict[str, Any]:
     """ProcessPoolExecutor entry: unpickle returns + run one
     (scenario, seed) walk-forward, return aggregate.
 
@@ -82,6 +83,7 @@ def _run_one(scenario: str, seed: int,
         n_mc=n_mc,
         rng=rng,
         lambda_trace_csv_path=lambda_trace_csv_path,
+        use_closed_form_efhv=use_closed_form_efhv,
     )
     agg = aggregate_per_seed(per_period)
     return {
@@ -227,6 +229,16 @@ def main(argv: list[str] | None = None) -> int:
                           help="Restrict asset universe to the 87 thesis-faithful "
                                "assets per docs/H4-ASSET-UNIVERSE-EDA.md. "
                                "Default is the full 98-asset legacy archive.")
+    # W22 closed-form OOS eHypV variant (operator directive 2026-05-17):
+    # skip bootstrap MC; use single full-window MLE per period →
+    # deterministic Ŝ. n_mc is IGNORED when this flag is set.
+    parser.add_argument("--use-closed-form-efhv",
+                          action="store_true",
+                          help="W22 methodology pivot: skip bootstrap MC in "
+                               "compute_oos_efhv; use single full-window MLE "
+                               "(μ̂, Σ̂) per period for a deterministic Ŝ "
+                               "point-estimate. Faster + zero MC noise; not "
+                               "directly comparable to the W14-2 MC chain.")
     args = parser.parse_args(argv)
 
     scenarios = [s.strip() for s in args.scenarios.split(",") if s.strip()]
@@ -263,7 +275,8 @@ def main(argv: list[str] | None = None) -> int:
         futures = {
             pool.submit(_run_one, s, sd, full_returns_pickle,
                           args.train_window_days, args.step_days, args.n_mc,
-                          lambda_trace_csv_path_str): (s, sd)
+                          lambda_trace_csv_path_str,
+                          args.use_closed_form_efhv): (s, sd)
             for (s, sd) in pairs
         }
         done = 0

--- a/python_refactor/tests/test_use_closed_form_efhv.py
+++ b/python_refactor/tests/test_use_closed_form_efhv.py
@@ -1,0 +1,121 @@
+"""W22: tests for use_closed_form_efhv flag in compute_oos_efhv.
+
+Methodology pivot per operator directive 2026-05-17: when flag is True,
+compute_oos_efhv skips bootstrap MC and uses a single full-window MLE
+(μ̂, Σ̂) → deterministic Ŝ point-estimate. This is S(E[μ,Σ]) rather
+than the true closed-form expectation E[S(μ,Σ)] — by Jensen these
+differ for nonlinear HV.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.oos_evaluator import compute_oos_efhv, fit_future_state, hypervolume_2d
+
+
+def _make_oos_returns(n_days: int = 50, n_assets: int = 5,
+                       seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    arr = rng.normal(0.001, 0.01, (n_days, n_assets))
+    return pd.DataFrame(arr, columns=[f"a{i}" for i in range(n_assets)])
+
+
+def _make_pareto_weights(n_portfolios: int = 5, n_assets: int = 5,
+                          seed: int = 42) -> list[np.ndarray]:
+    rng = np.random.default_rng(seed)
+    weights = []
+    for _ in range(n_portfolios):
+        w = rng.dirichlet(np.ones(n_assets))
+        weights.append(w)
+    return weights
+
+
+class TestClosedFormFlagDefaultsFalse:
+    """Default behavior (use_closed_form=False) preserves MC bootstrap."""
+
+    def test_default_uses_mc(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result = compute_oos_efhv(weights, oos, n_samples=10,
+                                    rng=np.random.default_rng(42))
+        # MC with n_samples=10 should have non-zero std (probabilistic)
+        assert "efhv_mean" in result
+        assert "efhv_std" in result
+        assert len(result["efhv_samples"]) == 10  # MC produced 10 samples
+
+
+class TestClosedFormFlagTrue:
+    """When flag=True: single MLE → deterministic Ŝ; n_samples ignored."""
+
+    def test_closed_form_returns_single_sample(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result = compute_oos_efhv(weights, oos, n_samples=1000,
+                                    use_closed_form=True)
+        # Single sample in output (n_samples ignored)
+        assert len(result["efhv_samples"]) == 1
+        # std = 0 since single point
+        assert result["efhv_std"] == 0.0
+
+    def test_closed_form_is_deterministic(self):
+        """Same (weights, returns) → same Ŝ regardless of rng seed."""
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result1 = compute_oos_efhv(weights, oos, use_closed_form=True,
+                                     rng=np.random.default_rng(1))
+        result2 = compute_oos_efhv(weights, oos, use_closed_form=True,
+                                     rng=np.random.default_rng(99999))
+        result3 = compute_oos_efhv(weights, oos, use_closed_form=True,
+                                     rng=None)
+        # Identical Ŝ across different RNGs (deterministic per fixture)
+        assert result1["efhv_mean"] == pytest.approx(result2["efhv_mean"], abs=0)
+        assert result2["efhv_mean"] == pytest.approx(result3["efhv_mean"], abs=0)
+
+    def test_closed_form_matches_manual_full_mle_hv(self):
+        """Closed-form Ŝ equals HV of (var, mean) cloud under full-window MLE."""
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        # Compute the expected closed-form result manually.
+        mu, cov = fit_future_state(oos)
+        points = [(float(w @ cov @ w), float(mu @ w)) for w in weights]
+        expected_hv = hypervolume_2d(points, z_ref=(0.2, 0.0))
+        result = compute_oos_efhv(weights, oos, use_closed_form=True)
+        assert result["efhv_mean"] == pytest.approx(expected_hv, abs=1e-15)
+
+
+class TestClosedFormVsMC:
+    """Closed-form Ŝ vs MC mean Ŝ: should be in the same ballpark for
+    reasonable n_samples, but they differ structurally (Jensen)."""
+
+    def test_closed_form_within_mc_distribution(self):
+        """Closed-form Ŝ should be within a few stds of the MC mean."""
+        oos = _make_oos_returns(n_days=100, seed=42)
+        weights = _make_pareto_weights(n_portfolios=10, seed=42)
+        closed = compute_oos_efhv(weights, oos, use_closed_form=True)
+        mc = compute_oos_efhv(weights, oos, n_samples=500,
+                                rng=np.random.default_rng(42))
+        # The closed-form point estimate should not be ridiculously far
+        # from the MC mean (within 5 stds is loose but safe)
+        if mc["efhv_std"] > 0:
+            z = abs(closed["efhv_mean"] - mc["efhv_mean"]) / mc["efhv_std"]
+            assert z < 5.0, f"closed-form Ŝ={closed['efhv_mean']} is {z:.2f} stds away from MC mean"
+
+
+class TestEmptyWeights:
+    """Edge case: empty pareto_weights returns zero Ŝ + empty samples."""
+
+    def test_empty_returns_zero_closed_form(self):
+        oos = _make_oos_returns()
+        result = compute_oos_efhv([], oos, use_closed_form=True)
+        assert result["efhv_mean"] == 0.0
+        assert result["efhv_std"] == 0.0
+        assert len(result["efhv_samples"]) == 0


### PR DESCRIPTION
## Summary

Per your directive 2026-05-17 ("What if we drop the monte carlo sampling and instead go with the closed-form expectation of oo eHypV?"), this PR adds a `use_closed_form` flag to `compute_oos_efhv` that skips bootstrap MC and uses a single full-window MLE (μ̂, Σ̂) → **deterministic Ŝ point-estimate** per period.

Stacked on #123 (W21-5 V5+V7 + V6 stub + H=3 variants).

## Implementation

| Surface | Change |
|---|---|
| `oos_evaluator.py::compute_oos_efhv` | New `use_closed_form` kwarg; bypasses MC loop |
| `walk_forward.py::run_walk_forward` | New `use_closed_form_efhv` kwarg, forwarded |
| `walk_forward_report.py` | New `--use-closed-form-efhv` CLI flag |
| `tests/test_use_closed_form_efhv.py` | 6 unit tests (all pass) |

## ⚠️ Honesty note (Jensen's inequality)

This is a **POINT-ESTIMATE** `S(E[μ,Σ])`, NOT a **true closed-form expectation** `E[S(μ,Σ)]`. By Jensen these differ for nonlinear HV. The flag is intended as a methodology pivot that:
- Eliminates MC noise → sharper deltas, fewer seeds needed
- Is more faithful to v2's paper-headline methodology (`asms_emoa.cpp:380+` per-solution closed-form Δ_S)
- Is **NOT directly comparable** to the W14-2 → W21-1 MC-based baseline chain — needs calibration run

The wall-clock speedup is **minor** (SMS-EMOA training dominates, not OOS evaluation). The main value is variance reduction.

## Test results

6/6 new tests pass:
- `test_default_uses_mc` — backward compat preserved
- `test_closed_form_returns_single_sample` — n_samples ignored when flag is True
- `test_closed_form_is_deterministic` — same Ŝ across RNG seeds
- `test_closed_form_matches_manual_full_mle_hv` — formula correctness
- `test_closed_form_within_mc_distribution` — closed-form within 5σ of MC mean (sanity)
- `test_empty_returns_zero_closed_form` — edge case

## Three implementation tiers (this PR ships only A)

| Tier | Description | Trade-off |
|---|---|---|
| **A (this PR)** | Single full-window MLE point estimate | Trivial impl; not true expectation |
| **B (future)** | True closed-form expected single-point HV per portfolio via Black-Scholes-style truncated means | Faithful expectation; requires per-portfolio variance derivation |
| **C (future)** | Lift v2's per-solution `compute_stochastic_Delta_S_front_id` directly | Uses existing v2 formula; per-front, not per-portfolio aggregation |

## Composability

`use_closed_form_efhv` is orthogonal to W21-1's `use_v2_anticipative_rate` + W21-5's V5/V6/V7. The Phase B smoke (currently running) uses MC; a parallel closed-form Phase B could be launched whenever:

```bash
cd python_refactor && uv run python -m experiments.walk_forward_report \
    --scenarios SMS_RDM_K0,ASMS_mHDM_K3,ASMS_mHDM_K3_v2rate,ASMS_mHDM_K3_v2both,ASMS_mHDM_K3_v2stab,ASMS_mHDM_K3_v2rate_noSqrt,ASMS_mHDM_K3_v2rate_v2entropy,ASMS_mHDM_K3_H3,ASMS_mHDM_K3_H3_v2rate \
    --seeds 1-10 \
    --train-window-days 378 --step-days 50 --n-mc 1 \
    --jobs 5 \
    --use-closed-form-efhv \
    --enforce-thesis-continuous-trades \
    --output ../docs/W22-CLOSED-FORM-CALIBRATION.md \
    --per-seed-json experiments/results/w22-closed-form-calibration/per_seed.json
```

(`--n-mc 1` because closed-form ignores it; can stay default too.)

## Dependencies

- **Stacked on** #123 (W21-5 V5+V7 + V6 stub + H=3 variants)
- No calibration smoke run yet — pending your GO to launch in parallel with Phase B

## Test plan

- [x] 6 new W22 unit tests pass
- [x] No regression on prior tests (oos_evaluator default behavior preserved)
- [ ] Parallel closed-form calibration smoke (pending GO)
- [ ] Compare closed-form Ŝ trajectory vs Phase B MC Ŝ trajectory per scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)