### PR TITLE
W22 Option B: true closed-form expected Ŝ via Black-Scholes-style truncated means

### DIFF
--- a/python_refactor/experiments/oos_evaluator.py
+++ b/python_refactor/experiments/oos_evaluator.py
@@ -34,6 +34,7 @@ from typing import Iterable
 
 import numpy as np
 import pandas as pd
+from scipy import stats as _stats  # W22 Option B: standard normal CDF/PDF
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +130,8 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
                       n_samples: int = 1000,
                       z_ref: tuple[float, float] = (0.2, 0.0),
                       rng: np.random.Generator | None = None,
-                      use_closed_form: bool = False) -> dict:
+                      use_closed_form: bool = False,
+                      use_closed_form_expectation: bool = False) -> dict:
     """Sample-average OOS Future Hypervolume per thesis Eqs 7.10+7.11.
 
     For each of n_samples MC scenarios e:
@@ -182,8 +184,8 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
             )
 
     if use_closed_form:
-        # W22 closed-form (point-estimate) variant: single full-window MLE
-        # → deterministic Ŝ. Skips bootstrap MC entirely.
+        # W22 Option A: closed-form (point-estimate) variant. Single
+        # full-window MLE → deterministic Ŝ. Skips bootstrap MC entirely.
         mu = arr.mean(axis=0)
         cov = np.cov(arr, rowvar=False, ddof=1)
         points = [(float(w @ cov @ w), float(mu @ w)) for w in weights_arr]
@@ -192,6 +194,67 @@ def compute_oos_efhv(pareto_weights: list[np.ndarray],
             "efhv_mean": float(hv),
             "efhv_std": 0.0,
             "efhv_samples": np.array([hv], dtype=float),
+        }
+
+    if use_closed_form_expectation:
+        # W22 Option B: TRUE closed-form expected Ŝ via per-portfolio
+        # Black-Scholes-style truncated-mean call/put pricing on
+        # (ROI, risk) modeled as independent Gaussians.
+        #
+        # Setup: full-window MLE (μ̂, Σ̂).
+        # Per portfolio i:
+        #   mu_i = μ̂^T u_i (mean of E[ROI_i])
+        #   sigma2_i = u_i^T Σ̂ u_i (point estimate of variance)
+        #   Var(ROI_i) ≈ sigma2_i / n_days (asymptotic MLE mean variance)
+        #   Var(risk_i) ≈ 2 * sigma2_i^2 / (n_days - 1) (Wishart approx)
+        #
+        # E[max(0, ROI_i - return_min)] using BS-like formula:
+        #   E[max(0, X - K)] = (μ - K) * Φ((μ - K) / σ) + σ * φ((μ - K) / σ)
+        # E[max(0, risk_max - risk_i)] using put-like formula:
+        #   E[max(0, K - X)] = (K - μ) * Φ((K - μ) / σ) + σ * φ((K - μ) / σ)
+        #
+        # E[HV_i] (independence) = product of the two truncated means.
+        # Aggregate Ŝ = SUM of per-portfolio E[HV_i] (no Pareto overlap
+        # correction → over-estimate; see HONEST SCAR in docstring).
+        risk_max, return_min = z_ref[0], z_ref[1]
+        mu_hat = arr.mean(axis=0)
+        Sigma_hat = np.cov(arr, rowvar=False, ddof=1)
+        # n_assets=1 → np.cov returns a 0-d array; coerce to 2D for matmul.
+        if Sigma_hat.ndim == 0:
+            Sigma_hat = np.array([[float(Sigma_hat)]])
+
+        total = 0.0
+        for w in weights_arr:
+            mu_i = float(mu_hat @ w)
+            sigma2_i = float(w @ Sigma_hat @ w)
+            sigma2_i = max(sigma2_i, 0.0)
+            var_roi = sigma2_i / max(n_days, 1)
+            var_risk = 2.0 * sigma2_i * sigma2_i / max(n_days - 1, 1)
+            sd_roi = float(np.sqrt(var_roi))
+            sd_risk = float(np.sqrt(var_risk))
+
+            # E[max(0, ROI - return_min)]: BS call
+            if sd_roi <= 0.0:
+                call_term = max(0.0, mu_i - return_min)
+            else:
+                d_roi = (mu_i - return_min) / sd_roi
+                call_term = (mu_i - return_min) * _stats.norm.cdf(d_roi) \
+                            + sd_roi * _stats.norm.pdf(d_roi)
+
+            # E[max(0, risk_max - risk)]: BS put on risk
+            if sd_risk <= 0.0:
+                put_term = max(0.0, risk_max - sigma2_i)
+            else:
+                d_risk = (risk_max - sigma2_i) / sd_risk
+                put_term = (risk_max - sigma2_i) * _stats.norm.cdf(d_risk) \
+                           + sd_risk * _stats.norm.pdf(d_risk)
+
+            total += call_term * put_term
+
+        return {
+            "efhv_mean": float(total),
+            "efhv_std": 0.0,
+            "efhv_samples": np.array([total], dtype=float),
         }
 
     samples_hv = np.empty(n_samples, dtype=float)

--- a/python_refactor/tests/test_w22_option_b_closed_form_expectation.py
+++ b/python_refactor/tests/test_w22_option_b_closed_form_expectation.py
@@ -1,0 +1,153 @@
+"""W22 Option B: tests for use_closed_form_expectation flag in
+compute_oos_efhv.
+
+True closed-form expected Ŝ via per-portfolio Black-Scholes-style
+truncated-mean call (E[max(0, ROI-K)]) and put (E[max(0, K-risk)])
+pricing on (ROI, risk) modeled as independent Gaussians, aggregated
+by SUMMING per-portfolio E[HV_i] (no Pareto overlap correction →
+acknowledged over-estimate).
+
+Formulas (X ~ N(μ, σ²)):
+  E[max(0, X - K)] = (μ - K) Φ((μ-K)/σ) + σ φ((μ-K)/σ)   [BS call]
+  E[max(0, K - X)] = (K - μ) Φ((K-μ)/σ) + σ φ((K-μ)/σ)   [BS put]
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import stats as _stats
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.oos_evaluator import compute_oos_efhv
+
+
+def _make_oos_returns(n_days: int = 100, n_assets: int = 5,
+                       seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    arr = rng.normal(0.001, 0.01, (n_days, n_assets))
+    return pd.DataFrame(arr, columns=[f"a{i}" for i in range(n_assets)])
+
+
+def _make_pareto_weights(n_portfolios: int = 5, n_assets: int = 5,
+                          seed: int = 42) -> list[np.ndarray]:
+    rng = np.random.default_rng(seed)
+    weights = []
+    for _ in range(n_portfolios):
+        w = rng.dirichlet(np.ones(n_assets))
+        weights.append(w)
+    return weights
+
+
+class TestFlagDefaultsFalse:
+    """Default behavior: use_closed_form_expectation=False → MC bootstrap."""
+
+    def test_default_uses_mc(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result = compute_oos_efhv(weights, oos, n_samples=10,
+                                    rng=np.random.default_rng(42))
+        assert len(result["efhv_samples"]) == 10  # MC produced 10 samples
+
+
+class TestFlagOnDeterministic:
+    """Closed-form expectation is deterministic given inputs."""
+
+    def test_deterministic_across_rng_seeds(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result_a = compute_oos_efhv(weights, oos,
+                                      use_closed_form_expectation=True,
+                                      rng=np.random.default_rng(1))
+        result_b = compute_oos_efhv(weights, oos,
+                                      use_closed_form_expectation=True,
+                                      rng=np.random.default_rng(999))
+        # Identical Ŝ across different RNG seeds (deterministic)
+        assert result_a["efhv_mean"] == pytest.approx(result_b["efhv_mean"], abs=0)
+        # std=0 because deterministic
+        assert result_a["efhv_std"] == 0.0
+        assert len(result_a["efhv_samples"]) == 1
+
+
+class TestManualBlackScholesMatch:
+    """Sanity check: single-portfolio closed-form Ŝ equals manual BS calc."""
+
+    def test_single_portfolio_matches_manual_formula(self):
+        """One portfolio, hand-compute the BS truncated means, verify."""
+        # 2-day OOS with controlled mean and variance.
+        # Single asset, single portfolio with weight=1 on that asset.
+        oos = pd.DataFrame(np.array([[0.01], [0.02], [0.015], [0.005]]),
+                             columns=["a0"])
+        weights = [np.array([1.0])]
+        z_ref = (0.5, 0.0)  # risk_max=0.5, return_min=0.0
+
+        result = compute_oos_efhv(weights, oos,
+                                    use_closed_form_expectation=True,
+                                    z_ref=z_ref)
+
+        # Manual: μ̂ = mean of [0.01, 0.02, 0.015, 0.005] = 0.0125
+        # Σ̂ = sample variance (ddof=1) = var([...]) ≈ 4.166e-5
+        # n_days = 4
+        # mu_i (portfolio mean) = 0.0125
+        # sigma2_i = 4.166e-5 (variance is u^T Σ u with u=[1])
+        # var_roi = sigma2_i / 4 = 1.0417e-5 → sd_roi ≈ 0.003227
+        # var_risk = 2 * sigma2_i^2 / 3 ≈ 1.157e-9 → sd_risk ≈ 3.401e-5
+        # call: d = (0.0125 - 0) / 0.003227 ≈ 3.873 → call ≈ 0.0125 * 1.0 + 0 ≈ 0.0125
+        # put: d = (0.5 - 4.166e-5) / 3.401e-5 ≈ huge → put ≈ 0.4999 * 1.0 + 0 ≈ 0.5
+        # E[HV] ≈ 0.0125 * 0.5 = 0.00625
+
+        # Compute exact reference using numpy
+        mu_hat = oos.values.mean(axis=0)
+        Sigma_hat = np.cov(oos.values, rowvar=False, ddof=1)
+        # For 1D, np.cov returns a 0-d scalar; coerce
+        if Sigma_hat.ndim == 0:
+            Sigma_hat = np.array([[float(Sigma_hat)]])
+        w = weights[0]
+        mu_i = float(mu_hat @ w)
+        sigma2_i = float(w @ Sigma_hat @ w)
+        var_roi = sigma2_i / 4
+        var_risk = 2 * sigma2_i * sigma2_i / 3
+        sd_roi = np.sqrt(var_roi)
+        sd_risk = np.sqrt(var_risk)
+        d_call = (mu_i - 0.0) / sd_roi
+        d_put = (0.5 - sigma2_i) / sd_risk
+        call = (mu_i - 0.0) * _stats.norm.cdf(d_call) + sd_roi * _stats.norm.pdf(d_call)
+        put = (0.5 - sigma2_i) * _stats.norm.cdf(d_put) + sd_risk * _stats.norm.pdf(d_put)
+        expected = call * put
+
+        assert result["efhv_mean"] == pytest.approx(expected, rel=1e-12)
+
+
+class TestInTheMoneyNonzero:
+    """When portfolio has positive ROI and low risk, E[HV] > 0."""
+
+    def test_inthemoney_returns_positive(self):
+        oos = _make_oos_returns(n_days=50, seed=1)
+        weights = _make_pareto_weights(n_portfolios=3, seed=1)
+        result = compute_oos_efhv(weights, oos,
+                                    use_closed_form_expectation=True,
+                                    z_ref=(0.5, -0.5))  # generous z_ref
+        assert result["efhv_mean"] > 0.0
+
+
+class TestOutOfMoneyDegenerate:
+    """When z_ref dominates all portfolios, E[HV] approaches 0."""
+
+    def test_extreme_zref_makes_ehv_tiny(self):
+        # Use a very TIGHT z_ref so no portfolio dominates it
+        oos = _make_oos_returns(n_days=50, seed=1)
+        weights = _make_pareto_weights(n_portfolios=3, seed=1)
+        # z_ref = (0.0001, 1.0) means risk_max is very small AND
+        # return_min is huge — portfolios with normal returns (~0.001)
+        # can't dominate.
+        result = compute_oos_efhv(weights, oos,
+                                    use_closed_form_expectation=True,
+                                    z_ref=(0.0001, 1.0))
+        # Should be tiny (call term collapses near 0)
+        assert result["efhv_mean"] < 1e-3


### PR DESCRIPTION
## Summary

True closed-form expected Ŝ via per-portfolio Black-Scholes-style call/put truncated means on (ROI, risk) modeled as independent Gaussians.

Stacked on #125 (V6 KF lifecycle).

## Formulas

Per portfolio i with full-window MLE (μ̂, Σ̂):
- mu_i = μ̂^T u_i; sigma2_i = u_i^T Σ̂ u_i
- Var(ROI_i) ≈ sigma2_i / n_days (asymptotic MLE mean variance)
- Var(risk_i) ≈ 2 × sigma2_i^2 / (n_days - 1) (Wishart approx)

For X ~ N(μ, σ²):
- E[max(0, X - K)] = (μ - K) Φ((μ-K)/σ) + σ φ((μ-K)/σ)  (BS call)
- E[max(0, K - X)] = (K - μ) Φ((K-μ)/σ) + σ φ((K-μ)/σ)  (BS put)

E[HV_i] = (independence) call_term × put_term. Aggregate Ŝ = sum of per-portfolio E[HV_i].

## Honest scars

1. **No Pareto overlap correction.** Per-portfolio E[HV_i] counted independently regardless of dominance → OVER-ESTIMATE vs true cloud HV. For ablation purposes, acceptable IF the over-estimate factor is consistent across scenarios (verify in calibration).
2. **Independence assumption** (ROI ⊥ risk) is standard asymptotic but breaks for non-trivially-weighted portfolios (ROI-risk correlation is non-zero in finite samples).
3. **Mean estimator variance** (sigma2/n) and **variance estimator variance** (Wishart approx 2σ⁴/(n-1)) are asymptotic but finite-sample-noisy at n_days=50 (our typical step window).

## Tests (5/5 pass)

- test_default_uses_mc — backward compat
- test_deterministic_across_rng_seeds — zero RNG influence on Ŝ
- test_single_portfolio_matches_manual_formula — hand-computed BS values match to 1e-12
- test_inthemoney_returns_positive — sanity for normal case
- test_extreme_zref_makes_ehv_tiny — degenerate case (z_ref dominates all portfolios)

**11 tests pass** when combined with Option A regression (test_use_closed_form_efhv.py).

## Edge case fix

n_assets=1 → np.cov returns 0-d scalar. Coerce to 2D for matmul.

## CLI usage

Currently exposed as Python kwarg only. CLI flag wiring (`--use-closed-form-expectation-efhv`) is a 2-line addition to walk_forward_report.py + walk_forward.py if/when operator wants Phase C ablation to include Option B.

## Test plan

- [x] 5 Option B tests pass
- [x] 6 Option A tests still pass (no regression)
- [ ] CLI wiring + parallel calibration smoke vs MC + Option A (after merge + operator GO)

🔖 Generated with [Claude Code](https://claude.com/claude-code)