### PR TITLE
W22 fix (c): compute_per_portfolio_efhv honors closed-form flag

### DIFF
--- a/python_refactor/experiments/oos_evaluator.py
+++ b/python_refactor/experiments/oos_evaluator.py
@@ -384,7 +384,8 @@ def compute_per_portfolio_efhv(pareto_weights: list[np.ndarray],
                                 oos_returns: pd.DataFrame,
                                 n_samples: int = 1000,
                                 z_ref: tuple[float, float] = (0.2, 0.0),
-                                rng: np.random.Generator | None = None) -> np.ndarray:
+                                rng: np.random.Generator | None = None,
+                                use_closed_form: bool = False) -> np.ndarray:
     """W17-4: per-portfolio expected single-point HV against z_ref.
 
     Implements thesis §6.4 Eq 6.42 (AMFC selection) on the OOS side:
@@ -401,6 +402,15 @@ def compute_per_portfolio_efhv(pareto_weights: list[np.ndarray],
     walk_forward.run_walk_forward uses this argmax as u*_{t-1} for the
     next rolling period (W16-2-CARRY-1 closure: replaces "first
     Pareto-front portfolio" proxy).
+
+    W22 closed-form variant (use_closed_form=True): skips bootstrap MC;
+    uses single full-window MLE (μ̂, Σ̂) for a deterministic per-portfolio
+    single-point HV. Matches the Option A point-estimate methodology
+    used by compute_oos_efhv when its same flag is set. Fixes the
+    W17-4 "all per-portfolio EFHV are 0/NaN" fallback that surfaced
+    in W22 Options B/C calibration smokes (per_portfolio_efhv used to
+    always bootstrap-MC regardless of which Ŝ estimator was active).
+    n_samples is IGNORED when this flag is set.
 
     Returns:
         np.ndarray of length len(pareto_weights), each entry is the
@@ -428,7 +438,21 @@ def compute_per_portfolio_efhv(pareto_weights: list[np.ndarray],
             )
 
     risk_ref, return_ref = z_ref[0], z_ref[1]
-    # Accumulate per-portfolio HV samples across MC bootstrap.
+
+    if use_closed_form:
+        # Single full-window MLE → deterministic per-portfolio HV
+        mu = arr.mean(axis=0)
+        cov = np.cov(arr, rowvar=False, ddof=1)
+        if cov.ndim == 0:
+            cov = np.array([[float(cov)]])
+        per_portfolio_hv = np.zeros(n_portfolios, dtype=float)
+        for i, w in enumerate(weights_arr):
+            var = float(w @ cov @ w)
+            ret = float(mu @ w)
+            per_portfolio_hv[i] = max(0.0, ret - return_ref) * max(0.0, risk_ref - var)
+        return per_portfolio_hv
+
+    # Default: bootstrap MC (preserves W14-2 behavior)
     per_portfolio_hv = np.zeros(n_portfolios, dtype=float)
     for e in range(n_samples):
         idx = rng.integers(0, n_days, n_days)

--- a/python_refactor/experiments/walk_forward.py
+++ b/python_refactor/experiments/walk_forward.py
@@ -224,11 +224,23 @@ def run_walk_forward(scenario: str,
         # — argmax over per-portfolio expected single-point HV against
         # z_ref. Replaces W16-2's "first Pareto-front portfolio" proxy.
         from .oos_evaluator import compute_per_portfolio_efhv
+        # W22: per-portfolio EFHV should match the chosen Ŝ estimator
+        # methodology to keep the AMFC u*_{t-1} selection consistent
+        # with the OOS scoring. ANY closed-form Ŝ flag (A, B, or C)
+        # triggers the closed-form per-portfolio variant; otherwise
+        # bootstrap MC (W14-2 default). Fixes the W17-4 "all
+        # per-portfolio EFHV are 0/NaN" fallback that surfaced in
+        # Options B/C smokes (per_portfolio_efhv was always MC,
+        # producing degenerate values when paired with a closed-form
+        # Ŝ estimator).
         per_portfolio_efhv = compute_per_portfolio_efhv(
             pareto_weights=weights,
             oos_returns=oos,
             n_samples=n_mc,
             rng=rng,
+            use_closed_form=(use_closed_form_efhv
+                              or use_closed_form_expectation_efhv
+                              or use_v2_per_front_efhv),
         )
         u_star_idx = _select_amfc_index(per_portfolio_efhv)
         previous_weights = weights[u_star_idx]

--- a/python_refactor/tests/test_compute_per_portfolio_efhv_closed_form.py
+++ b/python_refactor/tests/test_compute_per_portfolio_efhv_closed_form.py
@@ -1,0 +1,116 @@
+"""W22: tests for compute_per_portfolio_efhv use_closed_form flag.
+
+Per W22 calibration smoke finding: per_portfolio_efhv was always using
+MC bootstrap regardless of which Ŝ estimator was active in
+compute_oos_efhv, producing degenerate "all EFHV are 0/NaN" fallback
+warnings when paired with a closed-form Ŝ estimator. Fix: thread the
+closed-form flag through compute_per_portfolio_efhv.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.oos_evaluator import compute_per_portfolio_efhv
+
+
+def _make_oos_returns(n_days: int = 50, n_assets: int = 5,
+                       seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    arr = rng.normal(0.001, 0.01, (n_days, n_assets))
+    return pd.DataFrame(arr, columns=[f"a{i}" for i in range(n_assets)])
+
+
+def _make_pareto_weights(n_portfolios: int = 5, n_assets: int = 5,
+                          seed: int = 42) -> list[np.ndarray]:
+    rng = np.random.default_rng(seed)
+    weights = []
+    for _ in range(n_portfolios):
+        w = rng.dirichlet(np.ones(n_assets))
+        weights.append(w)
+    return weights
+
+
+class TestDefaultFlagFalse:
+    """Default behavior preserved (bootstrap MC)."""
+
+    def test_default_uses_mc(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result = compute_per_portfolio_efhv(weights, oos, n_samples=10,
+                                              rng=np.random.default_rng(42))
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (5,)
+        assert np.all(result >= 0.0)
+
+
+class TestClosedFormFlag:
+    """use_closed_form=True → deterministic per-portfolio single-point HV."""
+
+    def test_closed_form_returns_correct_shape(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result = compute_per_portfolio_efhv(weights, oos,
+                                              use_closed_form=True)
+        assert result.shape == (5,)
+        assert np.all(result >= 0.0)
+
+    def test_closed_form_is_deterministic(self):
+        oos = _make_oos_returns()
+        weights = _make_pareto_weights()
+        result_a = compute_per_portfolio_efhv(weights, oos,
+                                                use_closed_form=True,
+                                                rng=np.random.default_rng(1))
+        result_b = compute_per_portfolio_efhv(weights, oos,
+                                                use_closed_form=True,
+                                                rng=np.random.default_rng(999))
+        assert np.allclose(result_a, result_b, atol=0)
+
+    def test_closed_form_matches_manual_single_point_hv(self):
+        oos = _make_oos_returns(n_days=30, n_assets=3, seed=7)
+        weights = [np.array([0.5, 0.3, 0.2]), np.array([0.2, 0.5, 0.3])]
+        z_ref = (0.001, 0.0001)  # tight enough to be in-the-money
+
+        result = compute_per_portfolio_efhv(weights, oos,
+                                              use_closed_form=True,
+                                              z_ref=z_ref)
+
+        # Hand-compute
+        arr = oos.values
+        mu = arr.mean(axis=0)
+        cov = np.cov(arr, rowvar=False, ddof=1)
+        expected = []
+        for w in weights:
+            var = float(w @ cov @ w)
+            ret = float(mu @ w)
+            hv = max(0.0, ret - z_ref[1]) * max(0.0, z_ref[0] - var)
+            expected.append(hv)
+        assert np.allclose(result, np.array(expected), atol=1e-15)
+
+    def test_closed_form_argmax_consistent_with_default_mc(self):
+        """For low-noise fixture, closed-form argmax should match MC argmax."""
+        oos = _make_oos_returns(n_days=200, seed=42)  # plenty of data
+        weights = _make_pareto_weights(n_portfolios=10, seed=42)
+        closed = compute_per_portfolio_efhv(weights, oos, use_closed_form=True)
+        mc = compute_per_portfolio_efhv(weights, oos, n_samples=500,
+                                          rng=np.random.default_rng(42))
+        # AMFC argmax should agree for sufficient MC samples
+        assert int(np.argmax(closed)) == int(np.argmax(mc)) or \
+                abs(closed[int(np.argmax(closed))] - mc[int(np.argmax(mc))]) < 0.1 * mc[int(np.argmax(mc))]
+
+
+class TestEmptyWeights:
+    """Empty weights returns empty array."""
+
+    def test_empty_returns_empty(self):
+        oos = _make_oos_returns()
+        result = compute_per_portfolio_efhv([], oos, use_closed_form=True)
+        assert result.shape == (0,)


### PR DESCRIPTION
## Summary

Fixes the `W17-4: all per-portfolio EFHV are 0/NaN — fallback to index 0` warnings that flooded the W22 Options B/C calibration smokes. `compute_per_portfolio_efhv` was always using MC bootstrap regardless of which Ŝ estimator was active in `compute_oos_efhv`.

Stacked on #130.

## Changes

- `compute_per_portfolio_efhv` gets new kwarg `use_closed_form=False` (default preserves W14-2 MC behavior)
- When True, skips bootstrap MC; uses single full-window MLE → deterministic per-portfolio HV
- `walk_forward.run_walk_forward` threads ANY closed-form Ŝ flag (Option A/B/C) into per_portfolio_efhv so the AMFC u*_{t-1} selection is methodologically consistent with the Ŝ scoring

## Tests (5/5 + 22 regression pass)

- `test_default_uses_mc` — backward compat
- `test_closed_form_returns_correct_shape` — shape sanity
- `test_closed_form_is_deterministic` — zero RNG influence
- `test_closed_form_matches_manual_single_point_hv` — hand-computed match to 1e-15
- `test_closed_form_argmax_consistent_with_default_mc` — AMFC argmax consistency
- `test_empty_returns_empty` — edge case

## Impact

Future W22 calibration smokes + Phase C with closed-form Ŝ estimator no longer produce "all per-portfolio EFHV are 0/NaN" fallback warnings. The AMFC selection becomes a methodologically consistent companion to the closed-form Ŝ scoring.

## Dependencies

- Stacked on #130 (retro revision + Phase C protocol + kitchen-sink scenario)

🔖 Generated with [Claude Code](https://claude.com/claude-code)