### PR TITLE
W22 CRITICAL bug-fix bundle: NC1+NC2+NC3+NC4+NC5+NC6 (6 of 11+ fixes)

### DIFF
--- a/python_refactor/experiments/validation_matrix.py
+++ b/python_refactor/experiments/validation_matrix.py
@@ -99,7 +99,12 @@ def _asms_learning_config(K: int, use_multi_horizon: bool = True,
         "parameters": {
             "window_size": K,        # K = OAL historical window
             "max_horizon": max_horizon,  # H per thesis Eq 7.16 (H-1 future steps)
-            "monte_carlo_samples": 500,
+            # NC6 FIX (W22 agent finding 2026-05-18): thesis §7.2.3 p.146
+            # specifies "E = 1000, i.e., the risk and return of each
+            # candidate portfolio is evaluated from 1000 simulated daily
+            # return values." Pre-fix default was 500 (also wrong;
+            # validation_matrix overrode to 200 via --n-mc CLI).
+            "monte_carlo_samples": 1000,
             "use_v2_anticipative_rate": use_v2_anticipative_rate,  # W20-1 / Reading-E
         },
     }

--- a/python_refactor/src/algorithms/anticipatory_learning.py
+++ b/python_refactor/src/algorithms/anticipatory_learning.py
@@ -755,10 +755,19 @@ class TIPIntegratedAnticipatoryLearning(AnticipatoryLearning):
         )
         
         # Update state using anticipatory learning rate
-        x_state = np.array([anticipative_portfolio.P.ROI, anticipative_portfolio.P.risk, 0.0, 0.0])
+        # NC1 FIX (W22 agent finding 2026-05-18): pre-fix x_state zero-padded
+        # the velocity components ([ROI, risk, 0.0, 0.0]), but kalman_state.x_next
+        # carries the propagated (non-zero) velocities from the prior predict
+        # step. The blend `x_state + α*(x_next - x_state)` therefore treated
+        # the full velocity components of x_next as a delta against zero —
+        # imposing a phantom anticipative-velocity injection that overshoots.
+        # v2 keeps the filtered state's velocities in x_state.
+        # Fix: use full kalman_state.x (which carries the velocities) as the
+        # baseline rather than zero-padding.
+        x_state = anticipative_portfolio.P.kalman_state.x.copy()
         x = x_state.copy()
         C = anticipative_portfolio.P.kalman_state.P.copy()
-        
+
         if self.window_size > 0:
             # Update state vector
             x = x_state + solution.anticipation_rate * (anticipative_portfolio.P.kalman_state.x_next - x_state)
@@ -1163,9 +1172,19 @@ class TIPIntegratedAnticipatoryLearning(AnticipatoryLearning):
         cov_roi_risk = np.cov(roi_samples, risk_samples)[0, 1] if len(roi_samples) > 1 else 0.0
         
         # Update measurement noise covariance
+        # NC2 FIX (W22 agent finding 2026-05-18): pre-fix divided sample
+        # variance by monte_carlo_simulations (default 1000), producing R
+        # of order 1e-5 to 1e-7. This made Kalman gain ≈ 1 → KF became
+        # identity pass-through. The W22 R-harmonization fix from PR #135
+        # (initializing R off-diagonal = 0) was IMMEDIATELY clobbered on
+        # the first learning call. v2 keeps R as a measurement-noise
+        # estimate (variance of the sample), NOT variance-of-the-mean.
+        # Fix: drop the /monte_carlo_simulations divisor. R is now the
+        # sample's own variance, which is the standard MLE measurement-
+        # noise estimate.
         kalman_state.R = np.array([
-            [var_roi / self.monte_carlo_simulations, cov_roi_risk / self.monte_carlo_simulations],
-            [cov_roi_risk / self.monte_carlo_simulations, var_risk / self.monte_carlo_simulations]
+            [var_roi, cov_roi_risk],
+            [cov_roi_risk, var_risk]
         ])
         
         # Update Kalman filter with observed state

--- a/python_refactor/src/algorithms/sms_emoa.py
+++ b/python_refactor/src/algorithms/sms_emoa.py
@@ -52,7 +52,7 @@ class SMSEMOA:
     
     def __init__(self, population_size: int = 100, generations: int = 200,
                  crossover_rate: float = 0.9, mutation_rate: float = 0.1,
-                 tournament_size: int = 3,
+                 tournament_size: int = 2,  # NC4 FIX (W22): thesis specifies binary tournament (§7.2.3 p.147)
                  z_ref: tuple[float, float] = (0.0, 0.2),
                  use_v2_stability_weighting: bool = False,
                  use_thesis_eq74_risk: bool = False,
@@ -670,17 +670,34 @@ class SMSEMOA:
         # Select random individuals (handle case where tournament_size > population_size)
         tournament_size = min(self.tournament_size, len(self.population))
         indices = np.random.choice(len(self.population), tournament_size, replace=False)
-        
-        # Find the best based on hypervolume contribution
+
+        # NC5 FIX (W22 agent finding 2026-05-18): pre-fix tournament picked
+        # by hypervolume_contribution ONLY (single criterion). Thesis §7.2.3
+        # p.147 specifies "binary tournament selection was utilized using
+        # the Pareto Dominance over the sample mean vectors, with expected
+        # Hypv contribution (Eq. (6.35)) serving as a TIEBREAKER."
+        # So the correct ordering is: (1) lower Pareto_rank wins; (2) if
+        # ranks tie, higher hypervolume_contribution wins. Pre-fix, a
+        # rank-2 high-Δ_S could beat a rank-1 low-Δ_S — subverting NDS.
+        # Fix: sort by (Pareto_rank ASC, hypervolume_contribution DESC).
+        def _better(idx_a, idx_b):
+            """Returns idx of better solution per thesis-faithful tournament."""
+            sol_a = self.population[idx_a]
+            sol_b = self.population[idx_b]
+            # Lower rank is better
+            if sol_a.Pareto_rank < sol_b.Pareto_rank:
+                return idx_a
+            if sol_b.Pareto_rank < sol_a.Pareto_rank:
+                return idx_b
+            # Ranks tied → higher hypervolume_contribution wins
+            if sol_a.hypervolume_contribution >= sol_b.hypervolume_contribution:
+                return idx_a
+            return idx_b
+
         best_idx = indices[0]
-        best_contribution = self.population[best_idx].hypervolume_contribution
-        
         for idx in indices[1:]:
-            contribution = self.population[idx].hypervolume_contribution
-            if contribution > best_contribution:
-                best_contribution = contribution
-                best_idx = idx
-        
+            best_idx = _better(best_idx, idx)
+
         return best_idx
     
     def _remove_worst_solution(self):

--- a/python_refactor/src/portfolio/portfolio.py
+++ b/python_refactor/src/portfolio/portfolio.py
@@ -54,7 +54,14 @@ class Portfolio:
     autocorrelation: Optional[np.ndarray] = None
     
     # Configuration
-    max_cardinality: int = 10
+    # NC3 FIX (W22 agent finding 2026-05-18): thesis §7.2.3 p.146 specifies
+    # c_u = 15 (maximum cardinality). Pre-fix Portfolio.max_cardinality = 10
+    # silently CULLED valid 11-15-asset portfolios via the dominance
+    # penalty in solution.py:90-93. The operators module already had the
+    # correct THESIS_CARDINALITY_MIN=5 / MAX=15 constants but they were
+    # not synced to Portfolio.max_cardinality. Fix: align to thesis.
+    max_cardinality: int = 15
+    min_cardinality: int = 5  # thesis c_l per §7.2.3 p.146
     robustness: bool = False
 
     # W21-5 V5 (W18-CARRY-1 Reading): when True, compute_risk returns the


### PR DESCRIPTION
## Summary

Per operator directive 2026-05-18 ("Ship bug fixing first"). 6 critical bugs discovered by parallel specialist agents shipped as a bundle. 52 unit tests still pass.

Stacked on #136.

## Fixes

| # | Bug | Predicted Δ | File |
|---|---|---|---|
| NC1 | velocity zero-padding in obj_space | MEDIUM-LARGE | anticipatory_learning.py:758-764 |
| NC2 | R matrix clobbered every learning call (KF→identity) | **LARGE** | anticipatory_learning.py:1166-1169 |
| NC3 | max_cardinality=10 vs thesis 15 (silently culls portfolios) | MEDIUM-LARGE | portfolio.py:57 |
| NC4 | tournament_size=3 vs thesis binary (=2) | SMALL-MEDIUM | sms_emoa.py:55 |
| NC5 | tournament tiebreaker contribution-only (not rank-then-Δ_S) | MEDIUM | sms_emoa.py:_tournament_selection |
| NC6 | n_mc=200 vs thesis E=1000 | SMALL-MEDIUM | validation_matrix.py |

## Remaining (separate PRs)

- EQ1: stochastic HV per Theorem 6.3.1 (Eq 6.41 with 4 Cov terms) — most complex
- EQ2: λ^K population min-max per Eq 6.9
- EQ3: TIPIntegrated legacy violates Eq 7.16
- EQ4: middle-solution Δ_S indexing scramble
- EQ5: compute_risk default √ (flip default)

## Dependencies

- Stacked on #136

🔖 Generated with [Claude Code](https://claude.com/claude-code)