### PR TITLE
W22-EQ1 fix: Theorem 6.3.1 / Eq 6.41 stochastic Δ_S closed-form

### DIFF
--- a/python_refactor/src/algorithms/sms_emoa.py
+++ b/python_refactor/src/algorithms/sms_emoa.py
@@ -603,67 +603,152 @@ class SMSEMOA:
             solution.hypervolume_contribution *= stability_factor
 
     def _compute_stochastic_hypervolume_contributions_class(self, solutions: List[Solution]):
-        """Compute stochastic hypervolume contributions considering uncertainty."""
+        """Compute E[Δ_S] per Theorem 6.3.1 / Eq 6.41 in the thesis (p.131).
+
+        W22-EQ1 FIX (NC equation-review agent finding 2026-05-18).
+        Pre-fix the function used a heuristic
+            ``(mean_dROI·var_drisk + mean_drisk·var_dROI) / (var_dROI + var_drisk)``
+        that is dimensionally wrong (variances don't multiply out to a
+        hypervolume rectangle) and traces to NO equation in the thesis.
+
+        Theorem 6.3.1 / Eq 6.41 expands ``E[Δ_S(ẑ_t^(i))] = E[(a−b)(c−d)]``
+        where (per Eq 6.36):
+
+            a = ẑ_{1,t}^(i)|m̂_{2,t}^(i)      (self ROI cond. on self risk-mean)
+            b = ẑ_{1,t}^(i−1)|m̂_{2,t}^(i−1)  (LEFT-neighbor ROI cond. on its risk-mean)
+            c = ẑ_{2,t}^(i+1)|m̂_{1,t}^(i+1)  (RIGHT-neighbor risk cond. on its ROI-mean)
+            d = ẑ_{2,t}^(i)|m̂_{1,t}^(i)      (self risk cond. on self ROI-mean)
+
+        Using ``E[xy] = E[x]E[y] + Cov(x,y)`` (Eq 6.39) and ``E[X|Y=m_Y] = m_X``
+        when conditioning on the mean of a bivariate Gaussian (Eq 6.38),
+        the expansion ``(a−b)(c−d) = ac − ad − bc + bd`` yields:
+
+            E[Δ_S] = (m̂_{1,t}^(i) − m̂_{1,t}^(i−1))(m̂_{2,t}^(i+1) − m̂_{2,t}^(i))
+                   + Cov(a, c)   ← (+)
+                   − Cov(a, d)   ← (−)
+                   − Cov(b, c)   ← (−)
+                   + Cov(b, d)   ← (+)
+
+        which is exactly Eq 6.41 (the four Cov terms with signs +,−,−,+).
+        SCAR (HONEST): the C++ legacy (legacy-cpp-v2/source/asms_emoa.cpp
+        ``mean_delta_product``) computes ``Cov(a,c), Cov(b,c), Cov(b,d)``
+        **empirically** from per-solution Monte-Carlo samples
+        (``w_k->P.S.samples[j].roi`` etc.) that the Python refactor does
+        NOT store — only Kalman state covariances are kept per solution.
+        We therefore assume ``Cov(a,c) = Cov(b,c) = Cov(b,d) = 0`` (no
+        cross-solution information available). The within-solution
+        ``Cov(a,d)`` term — both random variables come from the same
+        solution i's bivariate Gaussian — is set to that solution's KF
+        state ROI↔risk covariance ``P[0,1]`` (matching how the C++ uses
+        ``w_1->P.S.covar`` for the self-product term).
+
+        DETERMINISTIC-VS-STOCHASTIC RECTANGLE NOTE: the deterministic
+        ``_compute_hypervolume_contributions_class`` middle branch uses
+        rectangle ``(ROI_i − ROI_{i+1})(risk_{i−1} − risk_i)`` (legacy
+        Python convention, same as C++ deterministic). Eq 6.36/6.41
+        specify rectangle ``(ROI_i − ROI_{i−1})(risk_{i+1} − risk_i)``.
+        Both yield POSITIVE values on a sorted-by-ROI Pareto front (with
+        risk DESC), but they are different rectangles. We implement
+        Eq 6.41 LITERALLY (prev-on-ROI, next-on-risk) because that is
+        the equation the operator's audit cited. Operator may decide
+        whether the deterministic version should be re-aligned.
+
+        Edge cases (|C| ∈ {1, 2}) use deterministic-style fallbacks since
+        Eq 6.41 is undefined without both neighbors:
+          - |C|=1: same rectangle as the deterministic single-solution
+            branch ``(ROI − R1)(R2 − risk)``, with the within-solution
+            ``Cov(ROI, risk)`` correction subtracted (mirroring the C++
+            single-solution stochastic branch term1−term2−term3+term4).
+          - |C|=2: i=0 uses LEFT-boundary R1 in place of m̂^(i−1); i=1
+            uses RIGHT-boundary R2 in place of m̂^(i+1). Cross-pair Cov
+            terms involving the boundary are zero (R1, R2 are
+            deterministic constants → Cov(R1, ·) = Cov(R2, ·) = 0).
+
+        Citations:
+          - Thesis Theorem 6.3.1, Eq 6.41, p.131
+          - Thesis Eq 6.36 (rectangle definition), p.130
+          - Thesis Eq 6.38 (conditioning on mean), p.130
+          - Thesis Eq 6.39 (E[xy] = E[x]E[y] + Cov(x,y)), p.130
+          - legacy-cpp-v2/source/asms_emoa.cpp::mean_delta_product (reference impl)
+        """
+
+        def _self_cov(stoch: "StochasticParams") -> float:
+            """Within-solution Cov(ROI, risk) for the Cov(a, d) self-term.
+
+            Mirrors C++ ``w_1->P.S.covar`` usage in
+            ``mean_delta_product`` (asms_emoa.cpp:361). In Python the
+            within-solution covariance is the Kalman state P[0,1].
+            """
+            return stoch.cov
+
         if len(solutions) == 1:
-            # Single solution with uncertainty
+            # |C|=1: deterministic rectangle (ROI − R1)(R2 − risk) with
+            # the within-solution Cov(ROI, risk) correction subtracted.
+            # Matches C++ compute_stochastic_Delta_S_front_id single-
+            # solution branch (asms_emoa.cpp:383-399):
+            #   term1 = ROI·R2,   term2 = ROI·risk + P.S.covar,
+            #   term3 = R1·R2,    term4 = R1·risk
+            #   Δ_S = term1 − term2 − term3 + term4
+            #       = (ROI − R1)(R2 − risk) − P.S.covar
             solution = solutions[0]
-            stoch_params = StochasticParams(solution)
-            
-            mean_delta_ROI = stoch_params.conditional_mean_ROI - self.R1
-            mean_delta_risk = self.R2 - stoch_params.conditional_mean_risk
-            var_delta_ROI = stoch_params.conditional_var_ROI
-            var_delta_risk = stoch_params.conditional_var_risk
-            
-            # Expected hypervolume contribution
-            solution.hypervolume_contribution = (mean_delta_ROI * var_delta_risk + mean_delta_risk * var_delta_ROI) / (var_delta_ROI + var_delta_risk)
+            stoch = StochasticParams(solution)
+            mean_roi = stoch.conditional_mean_ROI
+            mean_risk = stoch.conditional_mean_risk
+            delta_s = (mean_roi - self.R1) * (self.R2 - mean_risk) - _self_cov(stoch)
             stability_factor = 1.0 if self.use_v2_stability_weighting else solution.stability
-            solution.hypervolume_contribution *= stability_factor
+            solution.hypervolume_contribution = delta_s * stability_factor
             return
-        
-        # Sort by ROI
+
+        # Sort by ROI ascending — matches C++ sort_per_objective(_,0)
         solutions.sort(key=lambda s: s.P.ROI)
-        
-        # Compute stochastic contributions
+        n = len(solutions)
+
         for i, solution in enumerate(solutions):
-            stoch_params = StochasticParams(solution)
-            
+            stoch = StochasticParams(solution)
+            mean_roi_i = stoch.conditional_mean_ROI
+            mean_risk_i = stoch.conditional_mean_risk
+
+            # Resolve left ROI-mean (m̂_{1,t}^(i−1)) and right risk-mean
+            # (m̂_{2,t}^(i+1)) with boundary fallbacks: leftmost uses
+            # R1 (return floor) as the ROI lower bound; rightmost uses
+            # R2 (risk ceiling) as the risk upper bound — same boundary
+            # conventions as the C++ first/last branches.
             if i == 0:
-                # First solution
-                next_solution = solutions[i + 1]
-                next_stoch_params = StochasticParams(next_solution)
-                
-                mean_delta_ROI = stoch_params.conditional_mean_ROI - next_stoch_params.conditional_mean_ROI
-                mean_delta_risk = self.R2 - stoch_params.conditional_mean_risk
-                var_delta_ROI = stoch_params.conditional_var_ROI + next_stoch_params.conditional_var_ROI
-                var_delta_risk = stoch_params.conditional_var_risk
-                
-            elif i == len(solutions) - 1:
-                # Last solution
-                prev_solution = solutions[i - 1]
-                prev_stoch_params = StochasticParams(prev_solution)
-                
-                mean_delta_ROI = stoch_params.conditional_mean_ROI - self.R1
-                mean_delta_risk = prev_stoch_params.conditional_mean_risk - stoch_params.conditional_mean_risk
-                var_delta_ROI = stoch_params.conditional_var_ROI
-                var_delta_risk = prev_stoch_params.conditional_var_risk + stoch_params.conditional_var_risk
-                
+                # No left neighbor → use R1 as left ROI floor.
+                left_mean_roi = self.R1
+                left_stoch = None  # → Cov(b, ·) terms are 0 (R1 is deterministic)
             else:
-                # Middle solution
                 prev_solution = solutions[i - 1]
+                left_stoch = StochasticParams(prev_solution)
+                left_mean_roi = left_stoch.conditional_mean_ROI
+
+            if i == n - 1:
+                # No right neighbor → use R2 as right risk ceiling.
+                right_mean_risk = self.R2
+                right_stoch = None  # → Cov(·, c) terms are 0 (R2 is deterministic)
+            else:
                 next_solution = solutions[i + 1]
-                prev_stoch_params = StochasticParams(prev_solution)
-                next_stoch_params = StochasticParams(next_solution)
-                
-                # Compute mean delta product
-                mean_delta_ROI = stoch_params.conditional_mean_ROI - next_stoch_params.conditional_mean_ROI
-                mean_delta_risk = prev_stoch_params.conditional_mean_risk - stoch_params.conditional_mean_risk
-                var_delta_ROI = stoch_params.conditional_var_ROI + next_stoch_params.conditional_var_ROI
-                var_delta_risk = prev_stoch_params.conditional_var_risk + stoch_params.conditional_var_risk
-            
-            # Expected hypervolume contribution
-            solution.hypervolume_contribution = (mean_delta_ROI * var_delta_risk + mean_delta_risk * var_delta_ROI) / (var_delta_ROI + var_delta_risk)
+                right_stoch = StochasticParams(next_solution)
+                right_mean_risk = right_stoch.conditional_mean_risk
+
+            # Mean-product term from Eq 6.41 line 1:
+            #   (m̂_{1,t}^(i) − m̂_{1,t}^(i−1)) · (m̂_{2,t}^(i+1) − m̂_{2,t}^(i))
+            mean_product = (mean_roi_i - left_mean_roi) * (right_mean_risk - mean_risk_i)
+
+            # Four Cov terms from Eq 6.41 lines 2–5 with signs (+,−,−,+).
+            # In Python without per-solution MC samples, the only
+            # nonzero Cov is Cov(a, d) (within-solution self term).
+            # All cross-pair Cov terms are 0; boundary R1/R2 are
+            # deterministic so all Cov terms involving them are 0.
+            cov_a_c = 0.0  # cross-pair: Cov(self_ROI|self_risk_mean, right_risk|right_ROI_mean)
+            cov_a_d = _self_cov(stoch)  # self: within-solution Cov(ROI, risk)
+            cov_b_c = 0.0  # cross-pair: Cov(left_ROI|left_risk_mean, right_risk|right_ROI_mean)
+            cov_b_d = 0.0  # cross-pair: Cov(left_ROI|left_risk_mean, self_risk|self_ROI_mean)
+
+            delta_s = mean_product + cov_a_c - cov_a_d - cov_b_c + cov_b_d
+
             stability_factor = 1.0 if self.use_v2_stability_weighting else solution.stability
-            solution.hypervolume_contribution *= stability_factor
+            solution.hypervolume_contribution = delta_s * stability_factor
 
     def _tournament_selection(self) -> int:
         """Perform tournament selection based on hypervolume contribution."""

--- a/python_refactor/tests/test_eq1_stochastic_hv_theorem_6_3_1.py
+++ b/python_refactor/tests/test_eq1_stochastic_hv_theorem_6_3_1.py
@@ -1,0 +1,359 @@
+"""W22-EQ1 — Theorem 6.3.1 / Eq 6.41 stochastic Δ_S unit tests.
+
+Pins ``SMSEMOA._compute_stochastic_hypervolume_contributions_class`` to
+the EXACT closed-form expansion of Theorem 6.3.1 (thesis p.131).
+
+Pre-fix the function used a heuristic
+``(mean_dROI·var_drisk + mean_drisk·var_dROI) / (var_dROI + var_drisk)``
+which is dimensionally wrong (a hypervolume rectangle cannot be a
+weighted average of variances) and traces to NO equation in the thesis.
+
+These tests construct hand-computed Δ_S using Eq 6.41 verbatim and
+assert the implementation matches to 1e-12.
+
+Thesis Eq 6.41 (verbatim, sign convention preserved):
+    E[Δ_S(ẑ_t^(i))] = (m̂_{1,t}^(i) − m̂_{1,t}^(i−1))(m̂_{2,t}^(i+1) − m̂_{2,t}^(i))
+                    + Cov(ẑ_{1,t}^(i)|m̂_{2,t}^(i),   ẑ_{2,t}^(i+1)|m̂_{1,t}^(i+1))
+                    − Cov(ẑ_{1,t}^(i)|m̂_{2,t}^(i),   ẑ_{2,t}^(i)|m̂_{1,t}^(i))
+                    − Cov(ẑ_{1,t}^(i−1)|m̂_{2,t}^(i−1), ẑ_{2,t}^(i+1)|m̂_{1,t}^(i+1))
+                    + Cov(ẑ_{1,t}^(i−1)|m̂_{2,t}^(i−1), ẑ_{2,t}^(i)|m̂_{1,t}^(i))
+
+In the Python refactor (no per-solution MC samples), the three
+cross-pair covariances are 0; only ``Cov(a, d)`` (within-solution
+self-term) is non-zero and equals the KF state ``P[0,1]`` of solution i.
+
+The within-solution covariance is intentionally chosen ≠ 0 in the
+fixtures so the Cov-term contribution to Δ_S is exercised and observable.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.algorithms.kalman_filter import KalmanParams
+from src.algorithms.sms_emoa import SMSEMOA, StochasticParams
+from src.algorithms.solution import Solution
+from src.portfolio.portfolio import Portfolio
+
+
+# ─── Test fixture infrastructure ────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_portfolio_class_state():
+    """Each test gets a clean Portfolio class state."""
+    prev = (
+        Portfolio.mean_ROI,
+        Portfolio.median_ROI,
+        Portfolio.covariance,
+        Portfolio.robust_covariance,
+        Portfolio.use_thesis_eq74_risk,
+    )
+    Portfolio.mean_ROI = np.array([0.01, 0.02, 0.015])
+    Portfolio.median_ROI = np.array([0.01, 0.02, 0.015])
+    Portfolio.covariance = np.diag([0.04, 0.09, 0.0625])
+    Portfolio.robust_covariance = np.diag([0.04, 0.09, 0.0625])
+    Portfolio.use_thesis_eq74_risk = False
+    try:
+        yield
+    finally:
+        (
+            Portfolio.mean_ROI,
+            Portfolio.median_ROI,
+            Portfolio.covariance,
+            Portfolio.robust_covariance,
+            Portfolio.use_thesis_eq74_risk,
+        ) = prev
+
+
+def _make_sol(roi: float, risk: float, var_roi: float, var_risk: float, cov_roi_risk: float) -> Solution:
+    """Construct a Solution with a 4D Kalman state (ROI, risk, vROI, vRisk).
+
+    The 2×2 top-left of the KF state covariance encodes the within-solution
+    (ROI, risk) joint Gaussian per StochasticParams.
+    """
+    sol = Solution(num_assets=3)
+    sol.P.investment = np.array([0.5, 0.3, 0.2])
+    sol.P.ROI = roi
+    sol.P.risk = risk
+    # Disable stability multiplier (so Δ_S equals raw Eq 6.41 value).
+    sol.stability = 1.0
+    state = KalmanParams()
+    state.F = np.eye(4)
+    state.H = np.eye(2, 4)
+    state.R = np.eye(2) * 0.01
+    state.x = np.array([roi, risk, 0.0, 0.0])
+    state.x_next = np.array([roi, risk, 0.0, 0.0])
+    state.u = np.zeros(4)
+    # 4×4 cov with non-trivial (ROI, risk) sub-block; velocity sub-block
+    # is irrelevant for Δ_S (StochasticParams reads only P[0:2, 0:2]).
+    P = np.zeros((4, 4))
+    P[0, 0] = var_roi
+    P[1, 1] = var_risk
+    P[0, 1] = cov_roi_risk
+    P[1, 0] = cov_roi_risk
+    P[2, 2] = 0.001
+    P[3, 3] = 0.001
+    state.P = P
+    state.P_next = P.copy()
+    sol.P.kalman_state = state
+    return sol
+
+
+def _eq641_expected(
+    *,
+    roi_i: float,
+    risk_i: float,
+    left_roi_mean: float,
+    right_risk_mean: float,
+    self_cov_roi_risk: float,
+) -> float:
+    """Hand-compute Eq 6.41 with cross-pair Cov terms = 0.
+
+    Returns:
+        E[Δ_S] = (m_{1,i} − m_{1,i−1})(m_{2,i+1} − m_{2,i}) − Cov(a, d)
+
+        where Cov(a, d) is the within-solution KF P[0,1] of solution i,
+        and the three cross-pair covariances Cov(a,c), Cov(b,c), Cov(b,d)
+        are all 0 (Python refactor lacks per-solution MC samples).
+    """
+    mean_product = (roi_i - left_roi_mean) * (right_risk_mean - risk_i)
+    cov_a_d = self_cov_roi_risk
+    return mean_product - cov_a_d
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────
+
+
+class TestEq641SingleSolution:
+    """|C| = 1 edge case: Δ_S = (ROI − R1)(R2 − risk) − Cov(ROI, risk).
+
+    Matches C++ compute_stochastic_Delta_S_front_id single-solution
+    branch (legacy-cpp-v2/source/asms_emoa.cpp:383-399).
+    """
+
+    def test_single_solution_eq641_matches_hand_computed(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol = _make_sol(roi=0.05, risk=0.10, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.012)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol])
+
+        # Hand-compute: (0.05 − 0.0)(0.2 − 0.10) − 0.012 = 0.005 − 0.012 = −0.007
+        expected = (0.05 - 0.0) * (0.2 - 0.10) - 0.012
+        assert sol.hypervolume_contribution == pytest.approx(expected, abs=1e-12), (
+            f"Eq 6.41 single-solution: expected {expected}, got "
+            f"{sol.hypervolume_contribution}"
+        )
+
+    def test_single_solution_zero_self_cov_reduces_to_deterministic_rectangle(self):
+        """With Cov(ROI, risk) = 0, Δ_S = deterministic (ROI − R1)(R2 − risk)."""
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol = _make_sol(roi=0.04, risk=0.05, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.0)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol])
+
+        expected = (0.04 - 0.0) * (0.2 - 0.05)  # = 0.04 * 0.15 = 0.006
+        assert sol.hypervolume_contribution == pytest.approx(expected, abs=1e-12)
+
+
+class TestEq641TwoSolutionClass:
+    """|C| = 2 edge case: each solution uses one boundary, one neighbor.
+
+    - i=0: left ROI mean = R1, right risk mean = m̂_risk^(1)
+    - i=1: left ROI mean = m̂_ROI^(0), right risk mean = R2
+    """
+
+    def test_two_solution_i0_eq641_matches_hand_computed(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol0 = _make_sol(roi=0.03, risk=0.04, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.008)
+        sol1 = _make_sol(roi=0.07, risk=0.02, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.015)
+
+        # Pre-sort: ROI ascending → [sol0, sol1] already in order.
+        algo._compute_stochastic_hypervolume_contributions_class([sol0, sol1])
+
+        # i=0: ROI=0.03, risk=0.04, left=R1=0.0, right_risk=risk(sol1)=0.02, self_cov=0.008
+        expected_0 = _eq641_expected(
+            roi_i=0.03,
+            risk_i=0.04,
+            left_roi_mean=0.0,
+            right_risk_mean=0.02,
+            self_cov_roi_risk=0.008,
+        )
+        # Hand-trace: (0.03 − 0.0)(0.02 − 0.04) − 0.008
+        #          = 0.03 · (−0.02) − 0.008
+        #          = −0.0006 − 0.008 = −0.0086
+        assert expected_0 == pytest.approx(-0.0086, abs=1e-12)
+        assert sol0.hypervolume_contribution == pytest.approx(expected_0, abs=1e-12)
+
+    def test_two_solution_i1_eq641_matches_hand_computed(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol0 = _make_sol(roi=0.03, risk=0.04, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.008)
+        sol1 = _make_sol(roi=0.07, risk=0.02, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.015)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol0, sol1])
+
+        # i=1: ROI=0.07, risk=0.02, left_ROI=ROI(sol0)=0.03, right=R2=0.2, self_cov=0.015
+        expected_1 = _eq641_expected(
+            roi_i=0.07,
+            risk_i=0.02,
+            left_roi_mean=0.03,
+            right_risk_mean=0.2,
+            self_cov_roi_risk=0.015,
+        )
+        # Hand-trace: (0.07 − 0.03)(0.20 − 0.02) − 0.015
+        #          = 0.04 · 0.18 − 0.015
+        #          = 0.0072 − 0.015 = −0.0078
+        assert expected_1 == pytest.approx(-0.0078, abs=1e-12)
+        assert sol1.hypervolume_contribution == pytest.approx(expected_1, abs=1e-12)
+
+
+class TestEq641ThreeSolutionMiddle:
+    """|C| ≥ 3: middle position exercises the FULL Eq 6.41 with both
+    neighbors (no boundary fallback). This is the canonical Theorem
+    6.3.1 case.
+    """
+
+    def test_three_solution_middle_eq641_matches_hand_computed(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol_left = _make_sol(roi=0.02, risk=0.08, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.010)
+        sol_mid = _make_sol(roi=0.05, risk=0.05, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.020)
+        sol_right = _make_sol(roi=0.09, risk=0.03, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.005)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol_left, sol_mid, sol_right])
+
+        # i=1 (middle): ROI=0.05, risk=0.05, left_ROI=0.02, right_risk=0.03, self_cov=0.020
+        expected_mid = _eq641_expected(
+            roi_i=0.05,
+            risk_i=0.05,
+            left_roi_mean=0.02,
+            right_risk_mean=0.03,
+            self_cov_roi_risk=0.020,
+        )
+        # Hand-trace: (0.05 − 0.02)(0.03 − 0.05) − 0.020
+        #          = 0.03 · (−0.02) − 0.020
+        #          = −0.0006 − 0.020 = −0.0206
+        assert expected_mid == pytest.approx(-0.0206, abs=1e-12)
+        assert sol_mid.hypervolume_contribution == pytest.approx(expected_mid, abs=1e-12)
+
+    def test_three_solution_first_uses_R1_as_left_boundary(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol_left = _make_sol(roi=0.02, risk=0.08, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.010)
+        sol_mid = _make_sol(roi=0.05, risk=0.05, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.020)
+        sol_right = _make_sol(roi=0.09, risk=0.03, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.005)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol_left, sol_mid, sol_right])
+
+        # i=0: ROI=0.02, risk=0.08, left=R1=0.0, right_risk=risk(sol_mid)=0.05, self_cov=0.010
+        expected_first = _eq641_expected(
+            roi_i=0.02,
+            risk_i=0.08,
+            left_roi_mean=0.0,
+            right_risk_mean=0.05,
+            self_cov_roi_risk=0.010,
+        )
+        # Hand-trace: (0.02 − 0.0)(0.05 − 0.08) − 0.010
+        #          = 0.02 · (−0.03) − 0.010
+        #          = −0.0006 − 0.010 = −0.0106
+        assert expected_first == pytest.approx(-0.0106, abs=1e-12)
+        assert sol_left.hypervolume_contribution == pytest.approx(expected_first, abs=1e-12)
+
+    def test_three_solution_last_uses_R2_as_right_boundary(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol_left = _make_sol(roi=0.02, risk=0.08, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.010)
+        sol_mid = _make_sol(roi=0.05, risk=0.05, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.020)
+        sol_right = _make_sol(roi=0.09, risk=0.03, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.005)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol_left, sol_mid, sol_right])
+
+        # i=2: ROI=0.09, risk=0.03, left_ROI=0.05, right=R2=0.2, self_cov=0.005
+        expected_last = _eq641_expected(
+            roi_i=0.09,
+            risk_i=0.03,
+            left_roi_mean=0.05,
+            right_risk_mean=0.2,
+            self_cov_roi_risk=0.005,
+        )
+        # Hand-trace: (0.09 − 0.05)(0.20 − 0.03) − 0.005
+        #          = 0.04 · 0.17 − 0.005
+        #          = 0.0068 − 0.005 = 0.0018
+        assert expected_last == pytest.approx(0.0018, abs=1e-12)
+        assert sol_right.hypervolume_contribution == pytest.approx(expected_last, abs=1e-12)
+
+
+class TestEq641HeuristicRegression:
+    """Pin: post-fix Δ_S MUST NOT equal the pre-fix heuristic
+    ``(mean_dROI·var_drisk + mean_drisk·var_dROI) / (var_dROI + var_drisk)``.
+
+    This guards against accidental reversion to the dimensionally-wrong
+    formula. Use a 3-solution middle fixture where the two formulas
+    differ by O(1) — there is no risk of a numerical coincidence.
+    """
+
+    def test_middle_solution_post_fix_does_not_match_pre_fix_heuristic(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2))
+        sol_left = _make_sol(roi=0.02, risk=0.08, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.010)
+        sol_mid = _make_sol(roi=0.05, risk=0.05, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.020)
+        sol_right = _make_sol(roi=0.09, risk=0.03, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.005)
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol_left, sol_mid, sol_right])
+
+        # Pre-fix heuristic for middle (per pre-fix code):
+        #   mean_dROI = mean_ROI_self - mean_ROI_next = 0.05 - 0.09 = -0.04
+        #   mean_drisk = mean_risk_prev - mean_risk_self = 0.08 - 0.05 = 0.03
+        #   var_dROI = (var_ROI_self_cond) + (var_ROI_next_cond)
+        #   var_drisk = (var_risk_prev_cond) + (var_risk_self_cond)
+        #   pre_fix_dS = (mean_dROI·var_drisk + mean_drisk·var_dROI) / (var_dROI + var_drisk)
+        stoch_self = StochasticParams(sol_mid)
+        stoch_prev = StochasticParams(sol_left)
+        stoch_next = StochasticParams(sol_right)
+        mean_dROI = stoch_self.conditional_mean_ROI - stoch_next.conditional_mean_ROI
+        mean_drisk = stoch_prev.conditional_mean_risk - stoch_self.conditional_mean_risk
+        var_dROI = stoch_self.conditional_var_ROI + stoch_next.conditional_var_ROI
+        var_drisk = stoch_prev.conditional_var_risk + stoch_self.conditional_var_risk
+        pre_fix = (mean_dROI * var_drisk + mean_drisk * var_dROI) / (var_dROI + var_drisk)
+
+        # Post-fix value (Eq 6.41) was hand-computed as -0.0206 in the
+        # canonical test above. Assert the implementation is the post-fix
+        # value AND is significantly different from the pre-fix heuristic.
+        post_fix_expected = -0.0206
+        assert sol_mid.hypervolume_contribution == pytest.approx(post_fix_expected, abs=1e-12)
+        assert abs(sol_mid.hypervolume_contribution - pre_fix) > 1e-6, (
+            f"Post-fix Δ_S ({sol_mid.hypervolume_contribution}) collapsed to "
+            f"pre-fix heuristic ({pre_fix}) — Eq 6.41 fix was reverted."
+        )
+
+
+class TestEq641StabilityWeighting:
+    """Δ_S × stability_factor wiring is preserved post-fix (existing
+    behavior must remain — fix is only to the per-position formula).
+    """
+
+    def test_stability_multiplier_applied_post_fix(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2), use_v2_stability_weighting=False)
+        sol = _make_sol(roi=0.05, risk=0.10, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.012)
+        sol.stability = 0.5  # depressing multiplier
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol])
+
+        # Bare Δ_S = (0.05 − 0.0)(0.2 − 0.10) − 0.012 = 0.005 − 0.012 = −0.007
+        # With stability 0.5: Δ_S × 0.5 = −0.0035
+        expected = (-0.007) * 0.5
+        assert sol.hypervolume_contribution == pytest.approx(expected, abs=1e-12)
+
+    def test_v2_stability_weighting_overrides_to_1_post_fix(self):
+        algo = SMSEMOA(z_ref=(0.0, 0.2), use_v2_stability_weighting=True)
+        sol = _make_sol(roi=0.05, risk=0.10, var_roi=0.04, var_risk=0.09, cov_roi_risk=0.012)
+        sol.stability = 0.5
+
+        algo._compute_stochastic_hypervolume_contributions_class([sol])
+
+        # v2 flag should force stability factor → 1.0, ignoring sol.stability
+        expected = -0.007
+        assert sol.hypervolume_contribution == pytest.approx(expected, abs=1e-12)


### PR DESCRIPTION
## Summary

- Replace ``_compute_stochastic_hypervolume_contributions_class``'s pre-fix heuristic ``(mean_dROI·var_drisk + mean_drisk·var_dROI) / (var_dROI + var_drisk)`` (dimensionally wrong; not in thesis) with the faithful Theorem 6.3.1 / Eq 6.41 closed-form (thesis p.131).
- Add 10 hand-computed unit tests (``test_eq1_stochastic_hv_theorem_6_3_1.py``) pinning Δ_S to abs=1e-12 for |C|=1, |C|=2, |C|=3 (first/mid/last), plus a heuristic-regression pin and stability-wiring preservation.
- No regressions on the operator's regression sweep (40 passed).

## What Eq 6.41 says

```
E[Δ_S(ẑ_t^(i))] = (m̂_{1,t}^(i) − m̂_{1,t}^(i−1))(m̂_{2,t}^(i+1) − m̂_{2,t}^(i))
                + Cov(a, c)   ← (+)
                − Cov(a, d)   ← (−)
                − Cov(b, c)   ← (−)
                + Cov(b, d)   ← (+)
```

where ``a = ẑ_{1,t}^(i)|m̂_{2,t}^(i)`` (self ROI cond. on self risk-mean), ``b = ẑ_{1,t}^(i−1)|m̂_{2,t}^(i−1)`` (left-neighbor), ``c = ẑ_{2,t}^(i+1)|m̂_{1,t}^(i+1)`` (right-neighbor), ``d = ẑ_{2,t}^(i)|m̂_{1,t}^(i)`` (self risk cond.). Derivation: ``(a−b)(c−d) = ac−ad−bc+bd`` with Eq 6.39 ``E[xy]=E[x]E[y]+Cov`` and Eq 6.38 ``E[X|Y=m_Y]=m_X``.

## Honest scars

1. **Cross-pair covariances assumed 0.** The C++ legacy (``legacy-cpp-v2/source/asms_emoa.cpp::mean_delta_product``) computes ``Cov(a,c), Cov(b,c), Cov(b,d)`` *empirically* from per-solution Monte-Carlo samples (``w_k->P.S.samples[j].roi/risk``). The Python refactor stores only the 2×2 Kalman state covariance per solution — there are no MC samples. We therefore assume the three cross-pair Cov terms = 0; only the within-solution self ``Cov(a,d) = KF P[0,1]`` is retained (matching the C++ ``w_1->P.S.covar`` term2). To recover full Eq 6.41 fidelity the operator must plumb MC samples through Solution.
2. **Deterministic-vs-stochastic rectangle mismatch.** The deterministic ``_compute_hypervolume_contributions_class`` middle branch uses rectangle ``(ROI_i − ROI_{i+1})(risk_{i−1} − risk_i)`` (legacy Python, same as C++ deterministic). Eq 6.36/6.41 specify rectangle ``(ROI_i − ROI_{i−1})(risk_{i+1} − risk_i)``. Both yield positive values on a sorted-by-ROI Pareto front (risk DESC) but they are *different* rectangles. This PR implements Eq 6.41 LITERALLY (prev-on-ROI, next-on-risk) per the audit's directive. **Operator decision needed**: re-align the deterministic branch for full consistency, or accept the inconsistency.

## Test plan

- [x] New file ``python_refactor/tests/test_eq1_stochastic_hv_theorem_6_3_1.py`` (10 tests)
- [x] Operator regression sweep: ``test_use_v2_anticipative_rate + test_use_v2_stability_weighting + test_w21_5_ablation_flags + test_use_v2_kf_lifecycle + test_eq1_stochastic_hv_theorem_6_3_1`` → 40 passed
- [x] Hand-computed Δ_S values asserted to abs=1e-12 (single-solution, 2-solution i=0/i=1, 3-solution mid/first/last)
- [x] Heuristic-regression pin: explicitly asserts post-fix value ≠ pre-fix heuristic by >1e-6 (guards against reversion)
- [x] Stability-weighting wiring preserved (sol.stability multiplier still applied; use_v2_stability_weighting flag still overrides to 1.0)

## Citations

- Thesis Theorem 6.3.1 / Eq 6.41, p.131
- Thesis Eq 6.36 (rectangle definition), p.130
- Thesis Eq 6.38 (E[X|Y=m_Y] = m_X), p.130
- Thesis Eq 6.39 (E[xy] = E[x]E[y] + Cov(x,y)), p.130
- ``legacy-cpp-v2/source/asms_emoa.cpp::mean_delta_product`` (reference impl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)